### PR TITLE
Add mobile document logic foundation

### DIFF
--- a/.github/workflows/web-quality.yml
+++ b/.github/workflows/web-quality.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run TypeScript typecheck
         run: pnpm typecheck
 
+      - name: Run unit tests
+        run: pnpm test
+
   build:
     name: Vite production build
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "vitest run",
     "typecheck": "vue-tsc -b",
     "lint": "eslint . --max-warnings 0",
     "build": "pnpm typecheck && vite build",
@@ -32,6 +33,7 @@
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.62.0",
     "vite": "^8.1.0",
+    "vitest": "^4.1.9",
     "vue-tsc": "^3.3.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       vite:
         specifier: ^8.1.0
         version: 8.1.0(@types/node@24.13.2)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@24.13.2)(vite@8.1.0(@types/node@24.13.2))
       vue-tsc:
         specifier: ^3.3.5
         version: 3.3.5(typescript@6.0.3)
@@ -341,8 +344,14 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -437,6 +446,9 @@ packages:
   '@types/d3@7.4.3':
     resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -530,6 +542,35 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
@@ -618,6 +659,10 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -662,6 +707,10 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -695,6 +744,9 @@ packages:
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -922,6 +974,9 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-toolkit@1.49.0:
     resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
@@ -988,6 +1043,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -995,6 +1053,10 @@ packages:
   execall@3.0.0:
     resolution: {integrity: sha512-FaJeg2uWc8ADWnAnoDbxhAAr4U/j86ujlojnEpnBHQ4FM2viZKNjjyO2O6AKG6+9usZAnqsI4+1+w6vzx0x4uw==}
     engines: {node: '>=12'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1369,6 +1431,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
@@ -1417,6 +1483,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -1521,6 +1590,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -1545,6 +1617,12 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1575,6 +1653,9 @@ packages:
   through2@4.0.2:
     resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -1582,6 +1663,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1813,6 +1898,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -1839,6 +1965,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2212,10 +2343,17 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -2333,6 +2471,8 @@ snapshots:
       '@types/d3-timer': 3.0.2
       '@types/d3-transition': 3.0.9
       '@types/d3-zoom': 3.0.8
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -2457,6 +2597,47 @@ snapshots:
       vite: 8.1.0(@types/node@24.13.2)
       vue: 3.5.39(typescript@6.0.3)
 
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@24.13.2))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.0(@types/node@24.13.2)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@volar/language-core@2.4.28':
     dependencies:
       '@volar/source-map': 2.4.28
@@ -2565,6 +2746,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  assertion-error@2.0.1: {}
+
   astral-regex@2.0.0: {}
 
   at-least-node@1.0.0: {}
@@ -2597,6 +2780,8 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  chai@6.2.2: {}
+
   chownr@3.0.0: {}
 
   cliui@9.0.1:
@@ -2622,6 +2807,8 @@ snapshots:
   commander@7.2.0: {}
 
   commander@8.3.0: {}
+
+  convert-source-map@2.0.0: {}
 
   cose-base@1.0.3:
     dependencies:
@@ -2863,6 +3050,8 @@ snapshots:
 
   env-paths@2.2.1: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-toolkit@1.49.0: {}
 
   escalade@3.2.0: {}
@@ -2946,11 +3135,17 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   execall@3.0.0:
     dependencies:
       clone-regexp: 3.0.0
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3268,6 +3463,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  obug@2.1.3: {}
+
   open@8.4.2:
     dependencies:
       define-lazy-prop: 2.0.0
@@ -3319,6 +3516,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
       minipass: 7.1.3
+
+  pathe@2.0.3: {}
 
   pend@1.2.0: {}
 
@@ -3428,6 +3627,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   sisteransi@1.0.5: {}
@@ -3453,6 +3654,10 @@ snapshots:
   source-map-js@1.2.1: {}
 
   split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -3492,12 +3697,16 @@ snapshots:
     dependencies:
       readable-stream: 3.6.2
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3829,6 +4038,33 @@ snapshots:
       '@types/node': 24.13.2
       fsevents: 2.3.3
 
+  vitest@4.1.9(@types/node@24.13.2)(vite@8.1.0(@types/node@24.13.2)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@24.13.2))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.0(@types/node@24.13.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.2
+    transitivePeerDependencies:
+      - msw
+
   vscode-uri@3.1.0: {}
 
   vue-eslint-parser@10.4.1(eslint@10.6.0):
@@ -3862,6 +4098,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,13 @@ import {
   PreviewToolBar,
   en,
 } from '@muyajs/core'
+import {
+  createUntitledDocument,
+  markDocumentSaved,
+  markDocumentSaveFailed,
+  markDocumentSaving,
+  updateDocumentMarkdown,
+} from './lib/documentState'
 import { createLogger, getNativeLogInfo } from './lib/logger'
 
 const STORAGE_KEY = 'marktext-for-android:draft'
@@ -40,7 +47,7 @@ const editorPlugins = [
 ] as const
 
 const editorElement = ref<HTMLElement | null>(null)
-const markdown = ref('')
+const documentState = ref(createUntitledDocument())
 const status = ref('Ready')
 
 let editor: Muya | null = null
@@ -52,10 +59,10 @@ const editorLog = createLogger('editor')
 const draftLog = createLogger('draft')
 const loggingLog = createLogger('logging')
 
-const lineCount = computed(() => (markdown.value ? markdown.value.split(/\r\n|\r|\n/).length : 0))
-const characterCount = computed(() => markdown.value.length)
-const wordCount = computed(() => countWords(markdown.value))
-const documentTitle = computed(() => getDocumentTitle(markdown.value))
+const lineCount = computed(() => documentState.value.stats.lines)
+const characterCount = computed(() => documentState.value.stats.characters)
+const wordCount = computed(() => documentState.value.stats.words)
+const documentTitle = computed(() => documentState.value.title)
 
 function registerMuyaPlugins() {
   editorLog.debug('register Muya plugins start', { count: editorPlugins.length })
@@ -67,32 +74,19 @@ function registerMuyaPlugins() {
   editorLog.debug('register Muya plugins complete', { registered: Muya.plugins.length })
 }
 
-function countWords(value: string) {
-  const latinWords = value.match(/[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*/g)?.length ?? 0
-  const cjkCharacters = value.match(/[\u3400-\u9fff\u3040-\u30ff\uac00-\ud7af]/g)?.length ?? 0
-  return latinWords + cjkCharacters
-}
-
-function getDocumentTitle(value: string) {
-  const heading = value
-    .split(/\r\n|\r|\n/)
-    .map(line => line.match(/^#{1,6}\s+(.+)$/)?.[1]?.trim())
-    .find(Boolean)
-
-  return heading || 'Untitled'
-}
-
 function syncMarkdown(nextStatus: unknown = 'Edited') {
   if (!editor) {
     return
   }
 
   const resolvedStatus = typeof nextStatus === 'string' ? nextStatus : 'Edited'
-  markdown.value = editor.getMarkdown()
-  status.value = resolvedStatus
+  const nextMarkdown = editor.getMarkdown()
+  const markDirty = resolvedStatus === 'Edited'
+  documentState.value = updateDocumentMarkdown(documentState.value, nextMarkdown, { markDirty })
+  status.value = markDirty ? 'Autosaving locally' : resolvedStatus
   logContentSnapshot(resolvedStatus)
 
-  if (resolvedStatus === 'Edited') {
+  if (markDirty) {
     scheduleDraftSave()
   }
 }
@@ -106,7 +100,7 @@ function logContentSnapshot(reason: string) {
   lastContentLogAt = now
   editorLog.debug('content snapshot', {
     reason,
-    characters: markdown.value.length,
+    characters: characterCount.value,
     words: wordCount.value,
     lines: lineCount.value,
   })
@@ -126,17 +120,25 @@ function saveDraft() {
   }
 
   const value = editor.getMarkdown()
+  documentState.value = markDocumentSaving(
+    updateDocumentMarkdown(documentState.value, value, { markDirty: documentState.value.isDirty }),
+  )
+
   try {
     localStorage.setItem(STORAGE_KEY, value)
-    markdown.value = value
-    status.value = 'Saved locally'
+    documentState.value = markDocumentSaved(
+      updateDocumentMarkdown(documentState.value, value, { markDirty: false }),
+      { autosaveTarget: 'local-draft' },
+    )
+    status.value = 'Autosaved locally'
     draftLog.debug('local draft saved', {
-      characters: markdown.value.length,
+      characters: characterCount.value,
       words: wordCount.value,
       lines: lineCount.value,
     })
   } catch (error) {
-    status.value = 'Draft save failed'
+    documentState.value = markDocumentSaveFailed(documentState.value, error)
+    status.value = 'Autosave failed'
     draftLog.error('local draft save failed', error)
   }
 }
@@ -150,10 +152,15 @@ onMounted(() => {
   registerMuyaPlugins()
 
   try {
-    const initialMarkdown = localStorage.getItem(STORAGE_KEY) ?? SAMPLE_MARKDOWN
+    const restoredDraft = localStorage.getItem(STORAGE_KEY)
+    const initialMarkdown = restoredDraft ?? SAMPLE_MARKDOWN
+    documentState.value = createUntitledDocument({
+      markdown: initialMarkdown,
+      autosaveTarget: 'local-draft',
+    })
     editorLog.info('Muya init start', {
       initialCharacters: initialMarkdown.length,
-      restoredDraft: initialMarkdown !== SAMPLE_MARKDOWN,
+      restoredDraft: restoredDraft !== null,
     })
 
     editor = new Muya(editorElement.value, {
@@ -181,7 +188,7 @@ onMounted(() => {
     })
     syncMarkdown('Ready')
     editorLog.info('Muya init complete', {
-      characters: markdown.value.length,
+      characters: characterCount.value,
       words: wordCount.value,
       lines: lineCount.value,
     })

--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createUntitledDocument,
+  getDocumentStats,
+  getDocumentTitle,
+  normalizeMarkdownForEditor,
+  prepareMarkdownForSave,
+  updateDocumentMarkdown,
+  markDocumentSaved,
+  markDocumentSaveFailed,
+} from './documentState'
+
+describe('documentState', () => {
+  it('derives a title from the first markdown heading', () => {
+    expect(getDocumentTitle('intro\n\n## Mobile Notes\nbody', 'draft.md')).toBe('Mobile Notes')
+  })
+
+  it('falls back to the display name without markdown extension', () => {
+    expect(getDocumentTitle('plain text', 'notes.md')).toBe('notes')
+  })
+
+  it('counts latin words and CJK characters for mobile status text', () => {
+    expect(getDocumentStats('Hello MarkText\n你好').words).toBe(4)
+  })
+
+  it('normalizes CRLF documents to LF internally while preserving save intent', () => {
+    const normalized = normalizeMarkdownForEditor('one\r\ntwo\r\n')
+
+    expect(normalized.markdown).toBe('one\ntwo\n')
+    expect(normalized.lineEnding).toBe('crlf')
+    expect(normalized.adjustLineEndingOnSave).toBe(true)
+  })
+
+  it('detects mixed line endings', () => {
+    const normalized = normalizeMarkdownForEditor('one\r\ntwo\nthree\r')
+
+    expect(normalized.markdown).toBe('one\ntwo\nthree\n')
+    expect(normalized.isMixedLineEndings).toBe(true)
+  })
+
+  it('prepares markdown for CRLF save targets', () => {
+    const saved = prepareMarkdownForSave('one\ntwo\n', {
+      adjustLineEndingOnSave: true,
+      lineEnding: 'crlf',
+      trimTrailingNewline: 1,
+    })
+
+    expect(saved).toBe('one\r\ntwo\r\n')
+  })
+
+  it('marks edited local drafts dirty until autosave succeeds', () => {
+    const documentState = createUntitledDocument({
+      markdown: 'initial',
+      now: '2026-06-29T00:00:00.000Z',
+    })
+    const dirty = updateDocumentMarkdown(documentState, 'changed', {
+      now: '2026-06-29T00:00:01.000Z',
+    })
+
+    expect(dirty.isDirty).toBe(true)
+    expect(dirty.autosaveState).toBe('dirty')
+
+    const saved = markDocumentSaved(dirty, { now: '2026-06-29T00:00:02.000Z' })
+    expect(saved.isDirty).toBe(false)
+    expect(saved.autosaveState).toBe('clean')
+    expect(saved.lastSavedAt).toBe('2026-06-29T00:00:02.000Z')
+  })
+
+  it('keeps content dirty when autosave fails', () => {
+    const documentState = createUntitledDocument({ markdown: 'initial' })
+    const failed = markDocumentSaveFailed(documentState, new Error('write denied'))
+
+    expect(failed.isDirty).toBe(true)
+    expect(failed.autosaveState).toBe('save-failed')
+    expect(failed.lastSaveError).toBe('write denied')
+  })
+})

--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -48,6 +48,24 @@ describe('documentState', () => {
     expect(saved).toBe('one\r\ntwo\r\n')
   })
 
+  it('preserves a final newline added after opening a document without one', () => {
+    const documentState = createUntitledDocument({ markdown: 'one' })
+    const dirty = updateDocumentMarkdown(documentState, 'one\n')
+    const saved = prepareMarkdownForSave(dirty.markdown, dirty)
+
+    expect(dirty.trimTrailingNewline).toBe(1)
+    expect(saved).toBe('one\n')
+  })
+
+  it('preserves final newline removal after opening a document with one', () => {
+    const documentState = createUntitledDocument({ markdown: 'one\n' })
+    const dirty = updateDocumentMarkdown(documentState, 'one')
+    const saved = prepareMarkdownForSave(dirty.markdown, dirty)
+
+    expect(dirty.trimTrailingNewline).toBe(0)
+    expect(saved).toBe('one')
+  })
+
   it('marks edited local drafts dirty until autosave succeeds', () => {
     const documentState = createUntitledDocument({
       markdown: 'initial',

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -221,6 +221,7 @@ export function updateDocumentMarkdown(
     markdown,
     title: getDocumentTitle(markdown, documentState.displayName),
     isDirty,
+    trimTrailingNewline: detectTrailingNewline(markdown),
     autosaveState,
     lastSaveError: markDirty ? null : documentState.lastSaveError,
     updatedAt: now,

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -1,0 +1,263 @@
+export type LineEnding = 'lf' | 'crlf'
+export type AutosaveTarget = 'local-draft' | 'android-document'
+export type AutosaveState = 'clean' | 'dirty' | 'saving' | 'save-failed'
+
+export interface DocumentStats {
+  words: number
+  characters: number
+  lines: number
+}
+
+export interface NormalizedMarkdown {
+  markdown: string
+  lineEnding: LineEnding
+  isMixedLineEndings: boolean
+  adjustLineEndingOnSave: boolean
+  trimTrailingNewline: number
+}
+
+export interface MarkdownDocumentState {
+  id: string
+  markdown: string
+  displayName: string
+  title: string
+  sourceUri: string | null
+  isDirty: boolean
+  lineEnding: LineEnding
+  isMixedLineEndings: boolean
+  adjustLineEndingOnSave: boolean
+  trimTrailingNewline: number
+  autosaveTarget: AutosaveTarget
+  autosaveState: AutosaveState
+  lastSavedAt: string | null
+  lastSaveError: string | null
+  updatedAt: string
+  stats: DocumentStats
+}
+
+interface CreateDocumentOptions {
+  markdown?: string
+  displayName?: string
+  sourceUri?: string | null
+  autosaveTarget?: AutosaveTarget
+  preferredLineEnding?: LineEnding
+  now?: string
+}
+
+interface UpdateDocumentOptions {
+  markDirty?: boolean
+  now?: string
+}
+
+interface SaveDocumentOptions {
+  autosaveTarget?: AutosaveTarget
+  now?: string
+}
+
+const DEFAULT_UNTITLED_NAME = 'Untitled-1'
+const MARKDOWN_EXTENSION_REGEXP = /\.(markdown|mdown|mkdn|mkd|md)$/i
+const LINE_ENDING_REGEXP = /\r\n|\r|\n/g
+
+function createDocumentId() {
+  const random = Math.random().toString(36).slice(2, 8)
+  return `doc-${Date.now().toString(36)}-${random}`
+}
+
+function currentTimestamp() {
+  return new Date().toISOString()
+}
+
+function countLineEndingKinds(markdown: string) {
+  const crlf = markdown.match(/\r\n/g)?.length ?? 0
+  const withoutCrlf = markdown.replace(/\r\n/g, '')
+  const lf = withoutCrlf.match(/\n/g)?.length ?? 0
+  const cr = withoutCrlf.match(/\r/g)?.length ?? 0
+
+  return { crlf, lf, cr }
+}
+
+function detectTrailingNewline(markdown: string) {
+  if (!markdown) {
+    return 3
+  }
+
+  if (/\n\n$/.test(markdown)) {
+    return 2
+  }
+
+  if (/\n$/.test(markdown)) {
+    return 1
+  }
+
+  return 0
+}
+
+function trimTrailingNewlines(markdown: string) {
+  return markdown.replace(/\n+$/, '')
+}
+
+function adjustTrailingNewlines(markdown: string, mode: number) {
+  if (!markdown) {
+    return ''
+  }
+
+  if (mode === 0) {
+    return trimTrailingNewlines(markdown)
+  }
+
+  if (mode === 1) {
+    const trimmed = trimTrailingNewlines(markdown)
+    return trimmed ? `${trimmed}\n` : ''
+  }
+
+  return markdown
+}
+
+function stripMarkdownExtension(displayName: string) {
+  return displayName.replace(MARKDOWN_EXTENSION_REGEXP, '')
+}
+
+export function normalizeMarkdownForEditor(
+  rawMarkdown: string,
+  preferredLineEnding: LineEnding = 'lf',
+): NormalizedMarkdown {
+  const { crlf, lf, cr } = countLineEndingKinds(rawMarkdown)
+  const kinds = [crlf > 0, lf > 0, cr > 0].filter(Boolean).length
+  let lineEnding = preferredLineEnding
+
+  if (crlf > 0 && lf === 0 && cr === 0) {
+    lineEnding = 'crlf'
+  } else if (lf > 0 && crlf === 0 && cr === 0) {
+    lineEnding = 'lf'
+  }
+
+  const markdown = rawMarkdown.replace(/\r\n|\r/g, '\n')
+
+  return {
+    markdown,
+    lineEnding,
+    isMixedLineEndings: kinds > 1,
+    adjustLineEndingOnSave: lineEnding !== 'lf',
+    trimTrailingNewline: detectTrailingNewline(markdown),
+  }
+}
+
+export function prepareMarkdownForSave(
+  markdown: string,
+  options: Pick<MarkdownDocumentState, 'adjustLineEndingOnSave' | 'lineEnding' | 'trimTrailingNewline'>,
+) {
+  let nextMarkdown = adjustTrailingNewlines(markdown, options.trimTrailingNewline)
+
+  if (options.adjustLineEndingOnSave && options.lineEnding === 'crlf') {
+    nextMarkdown = nextMarkdown.replace(LINE_ENDING_REGEXP, '\r\n')
+  }
+
+  return nextMarkdown
+}
+
+export function countWords(markdown: string) {
+  const latinWords = markdown.match(/[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*/g)?.length ?? 0
+  const cjkCharacters = markdown.match(/[\u3400-\u9fff\u3040-\u30ff\uac00-\ud7af]/g)?.length ?? 0
+  return latinWords + cjkCharacters
+}
+
+export function getDocumentStats(markdown: string): DocumentStats {
+  return {
+    words: countWords(markdown),
+    characters: markdown.length,
+    lines: markdown ? markdown.split(/\r\n|\r|\n/).length : 0,
+  }
+}
+
+export function getDocumentTitle(markdown: string, displayName = DEFAULT_UNTITLED_NAME) {
+  const heading = markdown
+    .split(/\r\n|\r|\n/)
+    .map(line => line.match(/^#{1,6}\s+(.+)$/)?.[1]?.trim())
+    .find(Boolean)
+
+  return heading || stripMarkdownExtension(displayName) || 'Untitled'
+}
+
+export function createUntitledDocument(options: CreateDocumentOptions = {}): MarkdownDocumentState {
+  const now = options.now ?? currentTimestamp()
+  const normalized = normalizeMarkdownForEditor(
+    options.markdown ?? '',
+    options.preferredLineEnding ?? 'lf',
+  )
+  const displayName = options.displayName ?? DEFAULT_UNTITLED_NAME
+
+  return {
+    id: createDocumentId(),
+    markdown: normalized.markdown,
+    displayName,
+    title: getDocumentTitle(normalized.markdown, displayName),
+    sourceUri: options.sourceUri ?? null,
+    isDirty: false,
+    lineEnding: normalized.lineEnding,
+    isMixedLineEndings: normalized.isMixedLineEndings,
+    adjustLineEndingOnSave: normalized.adjustLineEndingOnSave,
+    trimTrailingNewline: normalized.trimTrailingNewline,
+    autosaveTarget: options.autosaveTarget ?? 'local-draft',
+    autosaveState: 'clean',
+    lastSavedAt: now,
+    lastSaveError: null,
+    updatedAt: now,
+    stats: getDocumentStats(normalized.markdown),
+  }
+}
+
+export function updateDocumentMarkdown(
+  documentState: MarkdownDocumentState,
+  markdown: string,
+  options: UpdateDocumentOptions = {},
+): MarkdownDocumentState {
+  const now = options.now ?? currentTimestamp()
+  const markDirty = options.markDirty ?? true
+  const isDirty = markDirty ? true : documentState.isDirty
+  const autosaveState: AutosaveState = markDirty ? 'dirty' : documentState.autosaveState
+
+  return {
+    ...documentState,
+    markdown,
+    title: getDocumentTitle(markdown, documentState.displayName),
+    isDirty,
+    autosaveState,
+    lastSaveError: markDirty ? null : documentState.lastSaveError,
+    updatedAt: now,
+    stats: getDocumentStats(markdown),
+  }
+}
+
+export function markDocumentSaving(documentState: MarkdownDocumentState): MarkdownDocumentState {
+  return {
+    ...documentState,
+    autosaveState: 'saving',
+    lastSaveError: null,
+  }
+}
+
+export function markDocumentSaved(
+  documentState: MarkdownDocumentState,
+  options: SaveDocumentOptions = {},
+): MarkdownDocumentState {
+  return {
+    ...documentState,
+    isDirty: false,
+    autosaveTarget: options.autosaveTarget ?? documentState.autosaveTarget,
+    autosaveState: 'clean',
+    lastSavedAt: options.now ?? currentTimestamp(),
+    lastSaveError: null,
+  }
+}
+
+export function markDocumentSaveFailed(
+  documentState: MarkdownDocumentState,
+  error: unknown,
+): MarkdownDocumentState {
+  return {
+    ...documentState,
+    isDirty: true,
+    autosaveState: 'save-failed',
+    lastSaveError: error instanceof Error ? error.message : String(error),
+  }
+}

--- a/src/lib/mobileCommands.test.ts
+++ b/src/lib/mobileCommands.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MOBILE_COMMANDS,
+  getMobileCommandDefinition,
+  runMobileEditorCommand,
+  type MobileEditorCommandTarget,
+} from './mobileCommands'
+
+function createEditorTarget() {
+  const calls: string[] = []
+  const editor: MobileEditorCommandTarget = {
+    undo: () => calls.push('undo'),
+    redo: () => calls.push('redo'),
+    format: type => calls.push(`format:${type}`),
+    updateParagraph: type => calls.push(`paragraph:${type}`),
+  }
+
+  return { editor, calls }
+}
+
+describe('mobileCommands', () => {
+  it('keeps document file commands out of the editor command runner', () => {
+    const result = runMobileEditorCommand(null, MOBILE_COMMANDS.FILE_OPEN)
+
+    expect(result).toEqual({
+      handled: false,
+      commandId: MOBILE_COMMANDS.FILE_OPEN,
+      reason: 'document-command',
+    })
+  })
+
+  it('maps upstream format command ids to Muya format actions', () => {
+    const { editor, calls } = createEditorTarget()
+    const result = runMobileEditorCommand(editor, MOBILE_COMMANDS.FORMAT_STRONG)
+
+    expect(result.handled).toBe(true)
+    expect(calls).toEqual(['format:strong'])
+  })
+
+  it('maps upstream paragraph command ids to Muya paragraph actions', () => {
+    const { editor, calls } = createEditorTarget()
+    const result = runMobileEditorCommand(editor, MOBILE_COMMANDS.PARAGRAPH_TASK_LIST)
+
+    expect(result.handled).toBe(true)
+    expect(calls).toEqual(['paragraph:ul-task'])
+  })
+
+  it('classifies frequent touch actions for a selection toolbar', () => {
+    expect(getMobileCommandDefinition(MOBILE_COMMANDS.FORMAT_EMPHASIS)?.surface).toBe(
+      'selection-toolbar',
+    )
+    expect(getMobileCommandDefinition(MOBILE_COMMANDS.PARAGRAPH_HEADING_1)?.surface).toBe(
+      'bottom-sheet',
+    )
+  })
+})

--- a/src/lib/mobileCommands.ts
+++ b/src/lib/mobileCommands.ts
@@ -1,0 +1,245 @@
+export const MOBILE_COMMANDS = Object.freeze({
+  FILE_NEW: 'file.new',
+  FILE_OPEN: 'file.open-file',
+  FILE_SAVE: 'file.save',
+  FILE_SAVE_AS: 'file.save-as',
+  EDIT_UNDO: 'edit.undo',
+  EDIT_REDO: 'edit.redo',
+  FORMAT_STRONG: 'format.strong',
+  FORMAT_EMPHASIS: 'format.emphasis',
+  FORMAT_INLINE_CODE: 'format.inline-code',
+  FORMAT_HYPERLINK: 'format.hyperlink',
+  FORMAT_IMAGE: 'format.image',
+  FORMAT_CLEAR: 'format.clear-format',
+  PARAGRAPH_PARAGRAPH: 'paragraph.paragraph',
+  PARAGRAPH_HEADING_1: 'paragraph.heading-1',
+  PARAGRAPH_HEADING_2: 'paragraph.heading-2',
+  PARAGRAPH_HEADING_3: 'paragraph.heading-3',
+  PARAGRAPH_BULLET_LIST: 'paragraph.bullet-list',
+  PARAGRAPH_ORDERED_LIST: 'paragraph.order-list',
+  PARAGRAPH_TASK_LIST: 'paragraph.task-list',
+  PARAGRAPH_QUOTE_BLOCK: 'paragraph.quote-block',
+  PARAGRAPH_CODE_FENCE: 'paragraph.code-fence',
+} as const)
+
+export type MobileCommandId = (typeof MOBILE_COMMANDS)[keyof typeof MOBILE_COMMANDS]
+export type MobileCommandGroup = 'document' | 'edit' | 'format' | 'paragraph'
+export type MobileCommandSurface = 'android-file-entry' | 'selection-toolbar' | 'bottom-sheet'
+
+export interface MobileCommandDefinition {
+  id: MobileCommandId
+  group: MobileCommandGroup
+  surface: MobileCommandSurface
+  label: string
+}
+
+export interface MobileEditorCommandTarget {
+  undo(): void
+  redo(): void
+  format(type: string): void
+  updateParagraph(type: string): void
+}
+
+export interface MobileCommandResult {
+  handled: boolean
+  commandId: MobileCommandId
+  reason?: 'editor-unavailable' | 'document-command'
+}
+
+const DOCUMENT_COMMANDS = new Set<MobileCommandId>([
+  MOBILE_COMMANDS.FILE_NEW,
+  MOBILE_COMMANDS.FILE_OPEN,
+  MOBILE_COMMANDS.FILE_SAVE,
+  MOBILE_COMMANDS.FILE_SAVE_AS,
+])
+
+const FORMAT_ACTIONS: Partial<Record<MobileCommandId, string>> = {
+  [MOBILE_COMMANDS.FORMAT_STRONG]: 'strong',
+  [MOBILE_COMMANDS.FORMAT_EMPHASIS]: 'em',
+  [MOBILE_COMMANDS.FORMAT_INLINE_CODE]: 'inline_code',
+  [MOBILE_COMMANDS.FORMAT_HYPERLINK]: 'link',
+  [MOBILE_COMMANDS.FORMAT_IMAGE]: 'image',
+  [MOBILE_COMMANDS.FORMAT_CLEAR]: 'clear',
+}
+
+const PARAGRAPH_ACTIONS: Partial<Record<MobileCommandId, string>> = {
+  [MOBILE_COMMANDS.PARAGRAPH_PARAGRAPH]: 'paragraph',
+  [MOBILE_COMMANDS.PARAGRAPH_HEADING_1]: 'heading 1',
+  [MOBILE_COMMANDS.PARAGRAPH_HEADING_2]: 'heading 2',
+  [MOBILE_COMMANDS.PARAGRAPH_HEADING_3]: 'heading 3',
+  [MOBILE_COMMANDS.PARAGRAPH_BULLET_LIST]: 'ul-bullet',
+  [MOBILE_COMMANDS.PARAGRAPH_ORDERED_LIST]: 'ol-order',
+  [MOBILE_COMMANDS.PARAGRAPH_TASK_LIST]: 'ul-task',
+  [MOBILE_COMMANDS.PARAGRAPH_QUOTE_BLOCK]: 'blockquote',
+  [MOBILE_COMMANDS.PARAGRAPH_CODE_FENCE]: 'pre',
+}
+
+export const MOBILE_COMMAND_DEFINITIONS: readonly MobileCommandDefinition[] = [
+  {
+    id: MOBILE_COMMANDS.FILE_NEW,
+    group: 'document',
+    surface: 'android-file-entry',
+    label: 'New document',
+  },
+  {
+    id: MOBILE_COMMANDS.FILE_OPEN,
+    group: 'document',
+    surface: 'android-file-entry',
+    label: 'Open document',
+  },
+  {
+    id: MOBILE_COMMANDS.FILE_SAVE,
+    group: 'document',
+    surface: 'android-file-entry',
+    label: 'Autosave current document',
+  },
+  {
+    id: MOBILE_COMMANDS.FILE_SAVE_AS,
+    group: 'document',
+    surface: 'android-file-entry',
+    label: 'Save a copy',
+  },
+  {
+    id: MOBILE_COMMANDS.EDIT_UNDO,
+    group: 'edit',
+    surface: 'selection-toolbar',
+    label: 'Undo',
+  },
+  {
+    id: MOBILE_COMMANDS.EDIT_REDO,
+    group: 'edit',
+    surface: 'selection-toolbar',
+    label: 'Redo',
+  },
+  {
+    id: MOBILE_COMMANDS.FORMAT_STRONG,
+    group: 'format',
+    surface: 'selection-toolbar',
+    label: 'Bold',
+  },
+  {
+    id: MOBILE_COMMANDS.FORMAT_EMPHASIS,
+    group: 'format',
+    surface: 'selection-toolbar',
+    label: 'Italic',
+  },
+  {
+    id: MOBILE_COMMANDS.FORMAT_INLINE_CODE,
+    group: 'format',
+    surface: 'selection-toolbar',
+    label: 'Inline code',
+  },
+  {
+    id: MOBILE_COMMANDS.FORMAT_HYPERLINK,
+    group: 'format',
+    surface: 'selection-toolbar',
+    label: 'Link',
+  },
+  {
+    id: MOBILE_COMMANDS.FORMAT_IMAGE,
+    group: 'format',
+    surface: 'bottom-sheet',
+    label: 'Image',
+  },
+  {
+    id: MOBILE_COMMANDS.FORMAT_CLEAR,
+    group: 'format',
+    surface: 'bottom-sheet',
+    label: 'Clear format',
+  },
+  {
+    id: MOBILE_COMMANDS.PARAGRAPH_PARAGRAPH,
+    group: 'paragraph',
+    surface: 'bottom-sheet',
+    label: 'Paragraph',
+  },
+  {
+    id: MOBILE_COMMANDS.PARAGRAPH_HEADING_1,
+    group: 'paragraph',
+    surface: 'bottom-sheet',
+    label: 'Heading 1',
+  },
+  {
+    id: MOBILE_COMMANDS.PARAGRAPH_HEADING_2,
+    group: 'paragraph',
+    surface: 'bottom-sheet',
+    label: 'Heading 2',
+  },
+  {
+    id: MOBILE_COMMANDS.PARAGRAPH_HEADING_3,
+    group: 'paragraph',
+    surface: 'bottom-sheet',
+    label: 'Heading 3',
+  },
+  {
+    id: MOBILE_COMMANDS.PARAGRAPH_BULLET_LIST,
+    group: 'paragraph',
+    surface: 'selection-toolbar',
+    label: 'Bullet list',
+  },
+  {
+    id: MOBILE_COMMANDS.PARAGRAPH_ORDERED_LIST,
+    group: 'paragraph',
+    surface: 'selection-toolbar',
+    label: 'Ordered list',
+  },
+  {
+    id: MOBILE_COMMANDS.PARAGRAPH_TASK_LIST,
+    group: 'paragraph',
+    surface: 'selection-toolbar',
+    label: 'Task list',
+  },
+  {
+    id: MOBILE_COMMANDS.PARAGRAPH_QUOTE_BLOCK,
+    group: 'paragraph',
+    surface: 'bottom-sheet',
+    label: 'Quote block',
+  },
+  {
+    id: MOBILE_COMMANDS.PARAGRAPH_CODE_FENCE,
+    group: 'paragraph',
+    surface: 'bottom-sheet',
+    label: 'Code block',
+  },
+]
+
+export function getMobileCommandDefinition(commandId: MobileCommandId) {
+  return MOBILE_COMMAND_DEFINITIONS.find(command => command.id === commandId) ?? null
+}
+
+export function runMobileEditorCommand(
+  editor: MobileEditorCommandTarget | null,
+  commandId: MobileCommandId,
+): MobileCommandResult {
+  if (DOCUMENT_COMMANDS.has(commandId)) {
+    return { handled: false, commandId, reason: 'document-command' }
+  }
+
+  if (!editor) {
+    return { handled: false, commandId, reason: 'editor-unavailable' }
+  }
+
+  if (commandId === MOBILE_COMMANDS.EDIT_UNDO) {
+    editor.undo()
+    return { handled: true, commandId }
+  }
+
+  if (commandId === MOBILE_COMMANDS.EDIT_REDO) {
+    editor.redo()
+    return { handled: true, commandId }
+  }
+
+  const formatAction = FORMAT_ACTIONS[commandId]
+  if (formatAction) {
+    editor.format(formatAction)
+    return { handled: true, commandId }
+  }
+
+  const paragraphAction = PARAGRAPH_ACTIONS[commandId]
+  if (paragraphAction) {
+    editor.updateParagraph(paragraphAction)
+    return { handled: true, commandId }
+  }
+
+  return { handled: false, commandId, reason: 'editor-unavailable' }
+}


### PR DESCRIPTION
This PR adds the first mobile-oriented document logic layer for the Android app.

What changed:
- Added a document state helper for markdown content, title derivation, word/line/character stats, dirty state, autosave state, and line-ending handling.
- Updated App.vue to use the new document state instead of keeping title/count/autosave logic directly in the component.
- Added a mobile command foundation that keeps MarkText-style command ids, but only maps Android-appropriate editor actions to Muya.
- Kept file commands separate from editor commands so open/save/save-as can later be wired to Android document picker / content URI flows.
- Added Vitest unit tests for document state and mobile command mapping.
- Added pnpm test to the web quality GitHub Actions workflow.

Notes:
- This does not add new user-facing toolbar buttons.
- Current autosave still writes to the local draft; real Android document persistence will be added in a later file-access step.
- The upstream MarkText logic was used as a reference, but Electron/desktop menu/window/file-watcher behavior was not copied.

Validation run locally:
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm build
- pnpm android:sync
- Gradle assembleDebug with JDK 22