### PR TITLE
feat: add mobile recent home

### DIFF
--- a/.github/workflows/web-quality.yml
+++ b/.github/workflows/web-quality.yml
@@ -43,3 +43,19 @@ jobs:
 
       - name: Build web shell
         run: pnpm build
+
+  e2e:
+    name: Mobile recent home E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Playwright E2E
+        run: pnpm test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ dist-ssr
 
 # Playwright MCP output
 .playwright-mcp/
+playwright-report/
+test-results/
 
 # Capacitor generated web assets
 android/app/src/main/assets/public/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "vitest run",
+    "test": "vitest run src",
+    "test:e2e": "playwright test",
     "typecheck": "vue-tsc -b",
     "lint": "eslint . --max-warnings 0",
     "build": "pnpm typecheck && vite build",
@@ -24,6 +25,7 @@
   "devDependencies": {
     "@capacitor/cli": "^8.4.1",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^24.13.2",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vue/tsconfig": "^0.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL: 'http://127.0.0.1:5174',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'pnpm dev --host 127.0.0.1 --port 5174 --strictPort',
+    url: 'http://127.0.0.1:5174',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+  projects: [
+    {
+      name: 'mobile-chromium',
+      use: {
+        ...devices['Pixel 5'],
+      },
+    },
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0)
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -245,6 +248,11 @@ packages:
 
   '@oxc-project/types@0.137.0':
     resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.1.3':
     resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
@@ -1117,6 +1125,11 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1503,6 +1516,16 @@ packages:
 
   plantuml-encoder@1.4.0:
     resolution: {integrity: sha512-sxMwpDw/ySY1WB2CE3+IdMuEcWibJ72DDOsXLkSmEaSzwEUaYBT6DWgOfBiHGCux4q433X6+OEFWjlVqp7gL6g==}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
@@ -2291,6 +2314,10 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.137.0': {}
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@rolldown/binding-android-arm64@1.1.3':
     optional: true
@@ -3205,6 +3232,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3528,6 +3558,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   plantuml-encoder@1.4.0: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.1:
     dependencies:

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import {
   CodeBlockLanguageSelector,
   EmojiSelector,
   InlineFormatToolbar,
   Muya,
-  ParagraphQuickInsertMenu,
   PreviewToolBar,
   en,
 } from '@muyajs/core'
+import DocumentHome from './components/DocumentHome.vue'
 import {
   createUntitledDocument,
   markDocumentSaved,
@@ -16,31 +16,23 @@ import {
   markDocumentSaving,
   updateDocumentMarkdown,
 } from './lib/documentState'
+import {
+  getLocalDraftListItems,
+  parseLocalDrafts,
+  removeLocalDraft,
+  serializeLocalDrafts,
+  upsertLocalDraft,
+  type LocalDraftListItem,
+  type LocalDraftRecord,
+} from './lib/localDrafts'
 import { createLogger, getNativeLogInfo } from './lib/logger'
 
-const STORAGE_KEY = 'marktext-for-android:draft'
+const LEGACY_DRAFT_STORAGE_KEY = 'marktext-for-android:draft'
+const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
 const DRAFT_SAVE_DELAY_MS = 800
-
-const SAMPLE_MARKDOWN = `# MarkText for Android
-
-This editor shell runs Muya inside a Capacitor Android app.
-
-## Checklist
-
-- Reuse MarkText's Markdown editing core.
-- Keep the mobile shell small.
-- Add native file access after the editor baseline is stable.
-
-## Markdown
-
-1. Write
-2. Preview
-3. Export
-`
 
 const editorPlugins = [
   InlineFormatToolbar,
-  ParagraphQuickInsertMenu,
   PreviewToolBar,
   CodeBlockLanguageSelector,
   EmojiSelector,
@@ -48,7 +40,9 @@ const editorPlugins = [
 
 const editorElement = ref<HTMLElement | null>(null)
 const documentState = ref(createUntitledDocument())
+const localDrafts = ref<LocalDraftRecord[]>([])
 const status = ref('Ready')
+const currentScreen = ref<'home' | 'editor'>('home')
 
 let editor: Muya | null = null
 let lastContentLogAt = 0
@@ -63,6 +57,40 @@ const lineCount = computed(() => documentState.value.stats.lines)
 const characterCount = computed(() => documentState.value.stats.characters)
 const wordCount = computed(() => documentState.value.stats.words)
 const documentTitle = computed(() => documentState.value.title)
+const draftItems = computed(() => getLocalDraftListItems(localDrafts.value))
+const continueDraftItem = computed(() => draftItems.value[0] ?? null)
+const earlierDraftItems = computed(() => draftItems.value.slice(1))
+const continueDraft = computed(() =>
+  continueDraftItem.value ? toHomeDraftItem(continueDraftItem.value) : null,
+)
+const earlierDrafts = computed(() => earlierDraftItems.value.map(toHomeDraftItem))
+
+function toHomeDraftItem(item: LocalDraftListItem) {
+  const savedAt = formatSavedTime(item.lastSavedAt ?? item.updatedAt)
+  const count = `${item.stats.words} ${item.stats.words === 1 ? 'word' : 'words'}`
+
+  return {
+    id: item.id,
+    title: item.title,
+    details: savedAt ? `Autosaved locally - ${savedAt} - ${count}` : `Local draft - ${count}`,
+  }
+}
+
+function formatSavedTime(value: string | null) {
+  if (!value) {
+    return ''
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
 
 function registerMuyaPlugins() {
   editorLog.debug('register Muya plugins start', { count: editorPlugins.length })
@@ -74,13 +102,30 @@ function registerMuyaPlugins() {
   editorLog.debug('register Muya plugins complete', { registered: Muya.plugins.length })
 }
 
+function createDocumentFromDraft(draft: LocalDraftRecord) {
+  return {
+    ...createUntitledDocument({
+      markdown: draft.markdown,
+      autosaveTarget: 'local-draft',
+      now: draft.updatedAt,
+    }),
+    id: draft.id,
+    lastSavedAt: draft.lastSavedAt,
+    updatedAt: draft.updatedAt,
+  }
+}
+
+function normalizeEditorMarkdown(markdown: string) {
+  return markdown === '\n' ? '' : markdown
+}
+
 function syncMarkdown(nextStatus: unknown = 'Edited') {
   if (!editor) {
     return
   }
 
   const resolvedStatus = typeof nextStatus === 'string' ? nextStatus : 'Edited'
-  const nextMarkdown = editor.getMarkdown()
+  const nextMarkdown = normalizeEditorMarkdown(editor.getMarkdown())
   const markDirty = resolvedStatus === 'Edited'
   documentState.value = updateDocumentMarkdown(documentState.value, nextMarkdown, { markDirty })
   status.value = markDirty ? 'Autosaving locally' : resolvedStatus
@@ -114,23 +159,50 @@ function scheduleDraftSave() {
   draftSaveTimer = window.setTimeout(saveDraft, DRAFT_SAVE_DELAY_MS)
 }
 
+function persistLocalDrafts(nextDrafts: LocalDraftRecord[]) {
+  localDrafts.value = nextDrafts
+
+  if (nextDrafts.length > 0) {
+    localStorage.setItem(DRAFTS_STORAGE_KEY, serializeLocalDrafts(nextDrafts))
+  } else {
+    localStorage.removeItem(DRAFTS_STORAGE_KEY)
+  }
+
+  localStorage.removeItem(LEGACY_DRAFT_STORAGE_KEY)
+}
+
 function saveDraft() {
   if (!editor) {
     return
   }
 
-  const value = editor.getMarkdown()
+  const value = normalizeEditorMarkdown(editor.getMarkdown())
+  const hasContent = value.trim().length > 0
   documentState.value = markDocumentSaving(
     updateDocumentMarkdown(documentState.value, value, { markDirty: documentState.value.isDirty }),
   )
 
   try {
-    localStorage.setItem(STORAGE_KEY, value)
-    documentState.value = markDocumentSaved(
+    const savedDocument = markDocumentSaved(
       updateDocumentMarkdown(documentState.value, value, { markDirty: false }),
       { autosaveTarget: 'local-draft' },
     )
-    status.value = 'Autosaved locally'
+
+    if (hasContent) {
+      persistLocalDrafts(
+        upsertLocalDraft(localDrafts.value, {
+          id: savedDocument.id,
+          markdown: savedDocument.markdown,
+          updatedAt: savedDocument.updatedAt,
+          lastSavedAt: savedDocument.lastSavedAt,
+        }),
+      )
+    } else {
+      persistLocalDrafts(removeLocalDraft(localDrafts.value, savedDocument.id))
+    }
+
+    documentState.value = savedDocument
+    status.value = hasContent ? 'Autosaved locally' : 'Ready'
     draftLog.debug('local draft saved', {
       characters: characterCount.value,
       words: wordCount.value,
@@ -143,24 +215,16 @@ function saveDraft() {
   }
 }
 
-onMounted(() => {
+function initEditor(initialMarkdown: string) {
   if (!editorElement.value) {
     return
   }
 
-  appLog.info('app mounted')
   registerMuyaPlugins()
 
   try {
-    const restoredDraft = localStorage.getItem(STORAGE_KEY)
-    const initialMarkdown = restoredDraft ?? SAMPLE_MARKDOWN
-    documentState.value = createUntitledDocument({
-      markdown: initialMarkdown,
-      autosaveTarget: 'local-draft',
-    })
     editorLog.info('Muya init start', {
       initialCharacters: initialMarkdown.length,
-      restoredDraft: restoredDraft !== null,
     })
 
     editor = new Muya(editorElement.value, {
@@ -196,6 +260,77 @@ onMounted(() => {
     status.value = 'Editor failed'
     editorLog.error('Muya init failed', error)
   }
+}
+
+async function openEditor(markdown: string) {
+  currentScreen.value = 'editor'
+  await nextTick()
+  initEditor(markdown)
+}
+
+function openDraft(id: string) {
+  const draft = localDrafts.value.find(record => record.id === id)
+  if (!draft) {
+    draftLog.warn('local draft not found', { id })
+    return
+  }
+
+  documentState.value = createDocumentFromDraft(draft)
+  appLog.info('open local draft', { id })
+  void openEditor(draft.markdown)
+}
+
+function newDocument() {
+  appLog.info('create new local document')
+  documentState.value = createUntitledDocument({ autosaveTarget: 'local-draft' })
+  void openEditor('')
+}
+
+function destroyEditor() {
+  if (draftSaveTimer !== null) {
+    window.clearTimeout(draftSaveTimer)
+    draftSaveTimer = null
+  }
+  editor?.destroy()
+  editor = null
+}
+
+function showHome() {
+  appLog.info('show recent home')
+  saveDraft()
+  destroyEditor()
+  currentScreen.value = 'home'
+}
+
+onMounted(() => {
+  appLog.info('app mounted')
+  const restoredDrafts = parseLocalDrafts(localStorage.getItem(DRAFTS_STORAGE_KEY))
+  const legacyDraft = localStorage.getItem(LEGACY_DRAFT_STORAGE_KEY)
+
+  if (restoredDrafts.length > 0) {
+    localDrafts.value = restoredDrafts
+    documentState.value = createDocumentFromDraft(restoredDrafts[0])
+  } else if (legacyDraft?.trim()) {
+    const migratedDocument = createUntitledDocument({
+      markdown: legacyDraft,
+      autosaveTarget: 'local-draft',
+    })
+    const migratedDraft = {
+      id: migratedDocument.id,
+      markdown: migratedDocument.markdown,
+      updatedAt: migratedDocument.updatedAt,
+      lastSavedAt: migratedDocument.lastSavedAt,
+    }
+    persistLocalDrafts([migratedDraft])
+    documentState.value = migratedDocument
+  } else {
+    documentState.value = createUntitledDocument({ autosaveTarget: 'local-draft' })
+  }
+
+  draftLog.info('local draft checked', {
+    restoredDrafts: localDrafts.value.length,
+    characters: characterCount.value,
+  })
 
   getNativeLogInfo().then(info => {
     if (info) {
@@ -208,19 +343,24 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   appLog.info('app before unmount')
-  if (draftSaveTimer !== null) {
-    window.clearTimeout(draftSaveTimer)
-    draftSaveTimer = null
-  }
   saveDraft()
-  editor?.destroy()
-  editor = null
+  destroyEditor()
 })
 </script>
 
 <template>
-  <main class="app-shell">
+  <main v-if="currentScreen === 'home'" class="app-shell is-home">
+    <DocumentHome
+      :continue-draft="continueDraft"
+      :earlier-drafts="earlierDrafts"
+      @new-document="newDocument"
+      @open-draft="openDraft"
+    />
+  </main>
+
+  <main v-else class="app-shell">
     <header class="top-bar">
+      <button class="nav-button" type="button" data-testid="back-button" @click="showHome">Back</button>
       <div class="document-heading">
         <span>MarkText Android</span>
         <h1>{{ documentTitle }}</h1>
@@ -229,7 +369,7 @@ onBeforeUnmount(() => {
     </header>
 
     <section class="editor-pane" aria-label="Markdown editor">
-      <div ref="editorElement" class="muya-host" />
+      <div ref="editorElement" class="muya-host" data-testid="editor-host" />
     </section>
 
     <footer class="status-bar">

--- a/src/components/DocumentHome.vue
+++ b/src/components/DocumentHome.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+interface DraftListItem {
+  id: string
+  title: string
+  details: string
+}
+
+interface Props {
+  continueDraft: DraftListItem | null
+  earlierDrafts: DraftListItem[]
+}
+
+defineProps<Props>()
+
+defineEmits<{
+  openDraft: [id: string]
+  newDocument: []
+}>()
+</script>
+
+<template>
+  <section class="home-screen" aria-label="Recent documents">
+    <header class="home-top">
+      <div>
+        <h1>MarkText</h1>
+      </div>
+      <button
+        class="home-new-button"
+        type="button"
+        aria-label="New document"
+        data-testid="new-document-button"
+        title="New document"
+        @click="$emit('newDocument')"
+      >
+        +
+      </button>
+    </header>
+
+    <nav class="home-tabs" aria-label="Document sections">
+      <button class="home-tab is-active" type="button">Recent</button>
+    </nav>
+
+    <div class="home-content">
+      <section v-if="continueDraft" class="document-group" aria-labelledby="continue-title">
+        <h2 id="continue-title">Continue writing</h2>
+        <button class="document-row" type="button" @click="$emit('openDraft', continueDraft.id)">
+          <span class="document-icon" aria-hidden="true">M</span>
+          <span class="document-text">
+            <strong>{{ continueDraft.title }}</strong>
+            <span>{{ continueDraft.details }}</span>
+          </span>
+        </button>
+      </section>
+
+      <section v-if="earlierDrafts.length > 0" class="document-group" aria-labelledby="earlier-title">
+        <h2 id="earlier-title">Earlier</h2>
+        <button
+          v-for="draft in earlierDrafts"
+          :key="draft.id"
+          class="document-row"
+          type="button"
+          @click="$emit('openDraft', draft.id)"
+        >
+          <span class="document-icon" aria-hidden="true">M</span>
+          <span class="document-text">
+            <strong>{{ draft.title }}</strong>
+            <span>{{ draft.details }}</span>
+          </span>
+        </button>
+      </section>
+
+      <section
+        v-if="!continueDraft && earlierDrafts.length === 0"
+        class="document-group"
+        aria-labelledby="recent-title"
+      >
+        <div class="empty-recent">
+          <h2 id="recent-title">No recent Markdown files</h2>
+          <p>Use the plus button to start a local draft.</p>
+        </div>
+      </section>
+    </div>
+  </section>
+</template>

--- a/src/lib/localDrafts.test.ts
+++ b/src/lib/localDrafts.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getLocalDraftListItems,
+  normalizeLocalDrafts,
+  parseLocalDrafts,
+  removeLocalDraft,
+  serializeLocalDrafts,
+  upsertLocalDraft,
+  type LocalDraftRecord,
+} from './localDrafts'
+
+const olderDraft: LocalDraftRecord = {
+  id: 'older',
+  markdown: '# Older draft\n\nhello',
+  updatedAt: '2026-06-29T00:00:00.000Z',
+  lastSavedAt: '2026-06-29T00:00:00.000Z',
+}
+
+const newerDraft: LocalDraftRecord = {
+  id: 'newer',
+  markdown: '# Newer draft\n\n你好',
+  updatedAt: '2026-06-29T00:02:00.000Z',
+  lastSavedAt: '2026-06-29T00:02:00.000Z',
+}
+
+describe('localDrafts', () => {
+  it('parses invalid storage values as an empty draft list', () => {
+    expect(parseLocalDrafts('not-json')).toEqual([])
+    expect(parseLocalDrafts(JSON.stringify({ id: 'not-array' }))).toEqual([])
+  })
+
+  it('sorts drafts newest first and removes empty drafts', () => {
+    const drafts = normalizeLocalDrafts([
+      olderDraft,
+      { ...newerDraft, markdown: '   ' },
+      newerDraft,
+    ])
+
+    expect(drafts.map(draft => draft.id)).toEqual(['newer', 'older'])
+  })
+
+  it('upserts drafts by id and keeps the latest markdown', () => {
+    const drafts = upsertLocalDraft([olderDraft], {
+      ...olderDraft,
+      markdown: '# Updated draft',
+      updatedAt: '2026-06-29T00:03:00.000Z',
+    })
+
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0].markdown).toBe('# Updated draft')
+  })
+
+  it('removes drafts by id', () => {
+    expect(removeLocalDraft([olderDraft, newerDraft], 'older').map(draft => draft.id)).toEqual([
+      'newer',
+    ])
+  })
+
+  it('serializes normalized drafts for local storage', () => {
+    const serialized = serializeLocalDrafts([olderDraft, newerDraft])
+
+    expect(parseLocalDrafts(serialized).map(draft => draft.id)).toEqual(['newer', 'older'])
+  })
+
+  it('creates list items with titles and stats for the mobile home screen', () => {
+    const items = getLocalDraftListItems([newerDraft])
+
+    expect(items[0].title).toBe('Newer draft')
+    expect(items[0].stats.words).toBe(4)
+  })
+})

--- a/src/lib/localDrafts.ts
+++ b/src/lib/localDrafts.ts
@@ -1,0 +1,97 @@
+import { getDocumentStats, getDocumentTitle, type DocumentStats } from './documentState'
+
+export interface LocalDraftRecord {
+  id: string
+  markdown: string
+  updatedAt: string
+  lastSavedAt: string | null
+}
+
+export interface LocalDraftListItem {
+  id: string
+  title: string
+  markdown: string
+  updatedAt: string
+  lastSavedAt: string | null
+  stats: DocumentStats
+}
+
+const DEFAULT_DRAFT_LIMIT = 20
+
+function isLocalDraftRecord(value: unknown): value is LocalDraftRecord {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const record = value as Partial<LocalDraftRecord>
+  return (
+    typeof record.id === 'string' &&
+    typeof record.markdown === 'string' &&
+    typeof record.updatedAt === 'string' &&
+    (typeof record.lastSavedAt === 'string' || record.lastSavedAt === null)
+  )
+}
+
+function compareDraftsByUpdateTime(left: LocalDraftRecord, right: LocalDraftRecord) {
+  return Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
+}
+
+export function normalizeLocalDrafts(records: LocalDraftRecord[], limit = DEFAULT_DRAFT_LIMIT) {
+  const seen = new Set<string>()
+  const normalized: LocalDraftRecord[] = []
+
+  for (const record of [...records].sort(compareDraftsByUpdateTime)) {
+    if (seen.has(record.id) || !record.markdown.trim()) {
+      continue
+    }
+
+    seen.add(record.id)
+    normalized.push(record)
+  }
+
+  return normalized.slice(0, limit)
+}
+
+export function parseLocalDrafts(value: string | null) {
+  if (!value) {
+    return []
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value)
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+
+    return normalizeLocalDrafts(parsed.filter(isLocalDraftRecord))
+  } catch {
+    return []
+  }
+}
+
+export function serializeLocalDrafts(records: LocalDraftRecord[]) {
+  return JSON.stringify(normalizeLocalDrafts(records))
+}
+
+export function upsertLocalDraft(
+  records: LocalDraftRecord[],
+  draft: LocalDraftRecord,
+  limit = DEFAULT_DRAFT_LIMIT,
+) {
+  return normalizeLocalDrafts(
+    [draft, ...records.filter(record => record.id !== draft.id)],
+    limit,
+  )
+}
+
+export function removeLocalDraft(records: LocalDraftRecord[], id: string) {
+  return records.filter(record => record.id !== id)
+}
+
+export function getLocalDraftListItems(records: LocalDraftRecord[]): LocalDraftListItem[] {
+  return normalizeLocalDrafts(records).map(record => ({
+    ...record,
+    title: getDocumentTitle(record.markdown),
+    stats: getDocumentStats(record.markdown),
+  }))
+}

--- a/src/style.css
+++ b/src/style.css
@@ -42,13 +42,202 @@ body {
   background: var(--app-bg);
 }
 
-.top-bar {
+.app-shell.is-home {
   display: block;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.home-screen {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: calc(env(safe-area-inset-top, 0px) + 18px) 18px
+    calc(env(safe-area-inset-bottom, 0px) + 28px);
+  background: var(--surface);
+}
+
+.home-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.home-top h1 {
+  margin: 0;
+  color: var(--text);
+  font-size: 30px;
+  line-height: 1.08;
+  font-weight: 760;
+}
+
+.home-new-button,
+.nav-button {
+  min-height: 44px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.home-new-button {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 46px;
+  min-width: 46px;
+  height: 46px;
+  padding: 0;
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--surface);
+  font-size: 30px;
+  font-weight: 420;
+  line-height: 1;
+}
+
+.home-new-button:active,
+.nav-button:active,
+.document-row:active {
+  transform: translateY(1px);
+}
+
+.home-tabs {
+  display: flex;
+  max-width: 760px;
+  margin: 22px auto 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.home-tab {
+  position: relative;
+  min-height: 46px;
+  padding: 0 2px;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 16px;
+  font-weight: 760;
+}
+
+.home-tab.is-active::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 3px;
+  border-radius: 999px 999px 0 0;
+  background: var(--accent);
+  content: '';
+}
+
+.home-content {
+  max-width: 760px;
+  margin: 24px auto 0;
+}
+
+.document-group + .document-group {
+  margin-top: 30px;
+}
+
+.document-group h2 {
+  margin: 0 0 12px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.2;
+  font-weight: 760;
+}
+
+.document-row {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  align-items: center;
+  width: 100%;
+  min-height: 76px;
+  padding: 10px 0;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  font: inherit;
+}
+
+.document-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 36px;
+  height: 42px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface-muted);
+  color: var(--accent-strong);
+  font-size: 18px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.document-text {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.document-text strong,
+.document-text span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.document-text strong {
+  color: var(--text);
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: 760;
+}
+
+.document-text span {
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.25;
+  font-weight: 560;
+}
+
+.empty-recent {
+  display: grid;
+  gap: 16px;
+  justify-items: start;
+  padding: 8px 0;
+}
+
+.empty-recent p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1.4;
+}
+
+.top-bar {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
   min-height: 68px;
   padding: calc(env(safe-area-inset-top, 0px) + 10px) 18px 10px;
   border-bottom: 1px solid var(--border);
   background: rgba(255, 255, 255, 0.92);
   backdrop-filter: blur(16px);
+}
+
+.nav-button {
+  padding: 0 12px;
 }
 
 .document-heading {
@@ -120,6 +309,15 @@ body {
 }
 
 @media (max-width: 720px) {
+  .home-screen {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .home-top h1 {
+    font-size: 28px;
+  }
+
   .top-bar {
     padding-right: 12px;
     padding-left: 12px;

--- a/tests/e2e/mobile-recent-home.spec.ts
+++ b/tests/e2e/mobile-recent-home.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test'
+
+test('creates a local draft from real editor input and returns it to the recent home', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  await expect(page.getByText('No recent Markdown files')).toBeVisible()
+  await expect(page.getByTestId('new-document-button')).toBeVisible()
+
+  await page.getByTestId('new-document-button').click()
+  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expect(page.getByTestId('back-button')).toHaveText('Back')
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('# Fresh mobile note')
+  await page.keyboard.press('Enter')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('hello from playwright')
+
+  await expect
+    .poll(async () => {
+      return page.evaluate(() => localStorage.getItem('marktext-for-android:drafts') ?? '')
+    })
+    .toContain('Fresh mobile note')
+
+  await page.getByTestId('back-button').click()
+
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  await expect(page.getByText('Continue writing')).toBeVisible()
+  await expect(page.getByText('Fresh mobile note')).toBeVisible()
+  await expect(page.getByText('No recent Markdown files')).toBeHidden()
+  await expect(page.getByTestId('new-document-button')).toBeVisible()
+})


### PR DESCRIPTION
Closes #

## Summary

- Adds a mobile-first Recent home screen with a persistent top-right new-document action.
- Stores local drafts as a small local draft list so creating a new draft does not overwrite the previous one.
- Removes the desktop quick insert plugin that exposed keyboard shortcuts in the mobile editor.
- Adds focused local draft helper tests and a Playwright mobile E2E path for real Muya input, autosave, and returning to Recent.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] UI/UX change
- [ ] Android native integration
- [x] CI/build/documentation

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test:e2e`
- [ ] `pnpm android:sync`
- [ ] Android debug build
- [ ] MuMu/emulator install and launch, if UI or native Android behavior changed
- [ ] Screenshot or screen recording attached, if UI changed

Additional UI verification: checked the Recent home in a Playwright mobile viewport, including empty state, multiple local drafts, the persistent plus button, and the real-input E2E path.

## Android notes

- No native Android file access, intent, or content URI changes in this PR.
- Local drafts remain in WebView localStorage for now; SAF document persistence is follow-up work.

## Reviewer notes

- This PR intentionally keeps the first mobile home scope small: local drafts, Recent UI, and E2E coverage.
- Real Android file opening and content URI autosave should land in separate PRs.