### PR TITLE
Add recent document state model

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,15 +17,18 @@ import {
   updateDocumentMarkdown,
 } from './lib/documentState'
 import {
-  getLocalDraftListItems,
   parseLocalDrafts,
   removeLocalDraft,
   serializeLocalDrafts,
   upsertLocalDraft,
-  type LocalDraftListItem,
   type LocalDraftRecord,
 } from './lib/localDrafts'
 import { createLogger, getNativeLogInfo } from './lib/logger'
+import {
+  createRecentDocumentFromLocalDraft,
+  getRecentDocumentListItems,
+  type RecentDocumentListItem,
+} from './lib/recentDocuments'
 
 const LEGACY_DRAFT_STORAGE_KEY = 'marktext-for-android:draft'
 const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
@@ -57,22 +60,26 @@ const lineCount = computed(() => documentState.value.stats.lines)
 const characterCount = computed(() => documentState.value.stats.characters)
 const wordCount = computed(() => documentState.value.stats.words)
 const documentTitle = computed(() => documentState.value.title)
-const draftItems = computed(() => getLocalDraftListItems(localDrafts.value))
-const continueDraftItem = computed(() => draftItems.value[0] ?? null)
-const earlierDraftItems = computed(() => draftItems.value.slice(1))
-const continueDraft = computed(() =>
-  continueDraftItem.value ? toHomeDraftItem(continueDraftItem.value) : null,
+const recentDocumentRecords = computed(() =>
+  localDrafts.value.map(createRecentDocumentFromLocalDraft),
 )
-const earlierDrafts = computed(() => earlierDraftItems.value.map(toHomeDraftItem))
+const documentItems = computed(() => getRecentDocumentListItems(recentDocumentRecords.value))
+const continueDocumentItem = computed(() => documentItems.value[0] ?? null)
+const earlierDocumentItems = computed(() => documentItems.value.slice(1))
+const continueDocument = computed(() =>
+  continueDocumentItem.value ? toHomeDocumentItem(continueDocumentItem.value) : null,
+)
+const earlierDocuments = computed(() => earlierDocumentItems.value.map(toHomeDocumentItem))
 
-function toHomeDraftItem(item: LocalDraftListItem) {
+function toHomeDocumentItem(item: RecentDocumentListItem) {
   const savedAt = formatSavedTime(item.lastSavedAt ?? item.updatedAt)
-  const count = `${item.stats.words} ${item.stats.words === 1 ? 'word' : 'words'}`
+  const count = item.stats ? `${item.stats.words} ${item.stats.words === 1 ? 'word' : 'words'}` : ''
+  const source = item.providerName ?? 'Markdown document'
 
   return {
     id: item.id,
     title: item.title,
-    details: savedAt ? `Autosaved locally - ${savedAt} - ${count}` : `Local draft - ${count}`,
+    details: [source, savedAt, count].filter(Boolean).join(' - '),
   }
 }
 
@@ -268,15 +275,24 @@ async function openEditor(markdown: string) {
   initEditor(markdown)
 }
 
-function openDraft(id: string) {
+function openDocument(id: string) {
+  const recentDocument = documentItems.value.find(record => record.id === id)
+  if (recentDocument && recentDocument.kind !== 'local-draft') {
+    appLog.warn('recent document type is not openable yet', {
+      id,
+      kind: recentDocument.kind,
+    })
+    return
+  }
+
   const draft = localDrafts.value.find(record => record.id === id)
   if (!draft) {
-    draftLog.warn('local draft not found', { id })
+    draftLog.warn('recent local draft not found', { id })
     return
   }
 
   documentState.value = createDocumentFromDraft(draft)
-  appLog.info('open local draft', { id })
+  appLog.info('open recent local document', { id })
   void openEditor(draft.markdown)
 }
 
@@ -351,10 +367,10 @@ onBeforeUnmount(() => {
 <template>
   <main v-if="currentScreen === 'home'" class="app-shell is-home">
     <DocumentHome
-      :continue-draft="continueDraft"
-      :earlier-drafts="earlierDrafts"
+      :continue-document="continueDocument"
+      :earlier-documents="earlierDocuments"
       @new-document="newDocument"
-      @open-draft="openDraft"
+      @open-document="openDocument"
     />
   </main>
 

--- a/src/components/DocumentHome.vue
+++ b/src/components/DocumentHome.vue
@@ -1,19 +1,19 @@
 <script setup lang="ts">
-interface DraftListItem {
+interface DocumentListItem {
   id: string
   title: string
   details: string
 }
 
 interface Props {
-  continueDraft: DraftListItem | null
-  earlierDrafts: DraftListItem[]
+  continueDocument: DocumentListItem | null
+  earlierDocuments: DocumentListItem[]
 }
 
 defineProps<Props>()
 
 defineEmits<{
-  openDraft: [id: string]
+  openDocument: [id: string]
   newDocument: []
 }>()
 </script>
@@ -41,36 +41,36 @@ defineEmits<{
     </nav>
 
     <div class="home-content">
-      <section v-if="continueDraft" class="document-group" aria-labelledby="continue-title">
+      <section v-if="continueDocument" class="document-group" aria-labelledby="continue-title">
         <h2 id="continue-title">Continue writing</h2>
-        <button class="document-row" type="button" @click="$emit('openDraft', continueDraft.id)">
+        <button class="document-row" type="button" @click="$emit('openDocument', continueDocument.id)">
           <span class="document-icon" aria-hidden="true">M</span>
           <span class="document-text">
-            <strong>{{ continueDraft.title }}</strong>
-            <span>{{ continueDraft.details }}</span>
+            <strong>{{ continueDocument.title }}</strong>
+            <span>{{ continueDocument.details }}</span>
           </span>
         </button>
       </section>
 
-      <section v-if="earlierDrafts.length > 0" class="document-group" aria-labelledby="earlier-title">
+      <section v-if="earlierDocuments.length > 0" class="document-group" aria-labelledby="earlier-title">
         <h2 id="earlier-title">Earlier</h2>
         <button
-          v-for="draft in earlierDrafts"
-          :key="draft.id"
+          v-for="document in earlierDocuments"
+          :key="document.id"
           class="document-row"
           type="button"
-          @click="$emit('openDraft', draft.id)"
+          @click="$emit('openDocument', document.id)"
         >
           <span class="document-icon" aria-hidden="true">M</span>
           <span class="document-text">
-            <strong>{{ draft.title }}</strong>
-            <span>{{ draft.details }}</span>
+            <strong>{{ document.title }}</strong>
+            <span>{{ document.details }}</span>
           </span>
         </button>
       </section>
 
       <section
-        v-if="!continueDraft && earlierDrafts.length === 0"
+        v-if="!continueDocument && earlierDocuments.length === 0"
         class="document-group"
         aria-labelledby="recent-title"
       >

--- a/src/lib/recentDocuments.test.ts
+++ b/src/lib/recentDocuments.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createRecentDocumentFromLocalDraft,
+  getRecentDocumentListItems,
+  normalizeRecentDocuments,
+  parseRecentDocuments,
+  serializeRecentDocuments,
+  upsertRecentDocument,
+  type RecentDocumentRecord,
+} from './recentDocuments'
+
+const olderDraft = {
+  id: 'older',
+  markdown: '# Older draft\n\nhello',
+  updatedAt: '2026-06-29T00:00:00.000Z',
+  lastSavedAt: '2026-06-29T00:00:00.000Z',
+}
+
+const newerDraft = {
+  id: 'newer',
+  markdown: '# Newer draft\n\n你好',
+  updatedAt: '2026-06-29T00:02:00.000Z',
+  lastSavedAt: '2026-06-29T00:02:00.000Z',
+}
+
+const androidDocument: RecentDocumentRecord = {
+  id: 'android-1',
+  kind: 'android-document',
+  displayName: 'notes.md',
+  title: 'notes',
+  sourceUri: 'content://provider/notes.md',
+  providerName: 'Documents',
+  pathHint: 'Documents/notes.md',
+  markdownPreview: null,
+  updatedAt: '2026-06-29T00:01:00.000Z',
+  lastOpenedAt: '2026-06-29T00:01:00.000Z',
+  lastSavedAt: null,
+  autosaveState: 'clean',
+  canWrite: true,
+}
+
+describe('recentDocuments', () => {
+  it('parses invalid storage values as an empty recent document list', () => {
+    expect(parseRecentDocuments('not-json')).toEqual([])
+    expect(parseRecentDocuments(JSON.stringify({ id: 'not-array' }))).toEqual([])
+    expect(parseRecentDocuments(JSON.stringify([{ ...androidDocument, kind: 'bad-kind' }]))).toEqual(
+      [],
+    )
+  })
+
+  it('creates recent document records from local drafts', () => {
+    const record = createRecentDocumentFromLocalDraft(newerDraft)
+
+    expect(record.kind).toBe('local-draft')
+    expect(record.title).toBe('Newer draft')
+    expect(record.providerName).toBe('Local draft')
+    expect(record.markdownPreview).toBe(newerDraft.markdown)
+    expect(record.canWrite).toBe(true)
+  })
+
+  it('sorts recent documents newest first by update or open time', () => {
+    const openedLater = {
+      ...androidDocument,
+      id: 'opened-later',
+      sourceUri: 'content://provider/opened-later.md',
+      updatedAt: '2026-06-29T00:00:00.000Z',
+      lastOpenedAt: '2026-06-29T00:05:00.000Z',
+    }
+    const updatedEarlier = createRecentDocumentFromLocalDraft(newerDraft)
+
+    expect(normalizeRecentDocuments([updatedEarlier, openedLater]).map(record => record.id)).toEqual(
+      ['opened-later', 'newer'],
+    )
+  })
+
+  it('deduplicates Android documents by content URI', () => {
+    const newerRecord = {
+      ...androidDocument,
+      id: 'android-2',
+      updatedAt: '2026-06-29T00:03:00.000Z',
+      lastOpenedAt: '2026-06-29T00:03:00.000Z',
+    }
+
+    const records = normalizeRecentDocuments([androidDocument, newerRecord])
+
+    expect(records).toHaveLength(1)
+    expect(records[0].id).toBe('android-2')
+  })
+
+  it('deduplicates local drafts by id', () => {
+    const olderRecord = createRecentDocumentFromLocalDraft(olderDraft)
+    const newerRecord = createRecentDocumentFromLocalDraft({
+      ...olderDraft,
+      markdown: '# Updated draft',
+      updatedAt: '2026-06-29T00:04:00.000Z',
+    })
+
+    const records = upsertRecentDocument([olderRecord], newerRecord)
+
+    expect(records).toHaveLength(1)
+    expect(records[0].title).toBe('Updated draft')
+  })
+
+  it('filters empty local draft previews', () => {
+    const emptyDraft = {
+      ...createRecentDocumentFromLocalDraft(olderDraft),
+      markdownPreview: '   ',
+      updatedAt: '2026-06-29T00:05:00.000Z',
+    }
+
+    expect(normalizeRecentDocuments([emptyDraft])).toEqual([])
+  })
+
+  it('serializes normalized recent documents for storage', () => {
+    const serialized = serializeRecentDocuments([
+      createRecentDocumentFromLocalDraft(olderDraft),
+      createRecentDocumentFromLocalDraft(newerDraft),
+    ])
+
+    expect(parseRecentDocuments(serialized).map(record => record.id)).toEqual(['newer', 'older'])
+  })
+
+  it('creates list items with stats when a markdown preview exists', () => {
+    const items = getRecentDocumentListItems([createRecentDocumentFromLocalDraft(newerDraft)])
+
+    expect(items[0].stats?.words).toBe(4)
+  })
+
+  it('keeps stats empty for Android documents without a markdown preview', () => {
+    const items = getRecentDocumentListItems([androidDocument])
+
+    expect(items[0].stats).toBeNull()
+  })
+})

--- a/src/lib/recentDocuments.ts
+++ b/src/lib/recentDocuments.ts
@@ -1,0 +1,169 @@
+import {
+  getDocumentStats,
+  getDocumentTitle,
+  type AutosaveState,
+  type DocumentStats,
+} from './documentState'
+
+export type RecentDocumentKind = 'local-draft' | 'android-document' | 'incoming-document'
+
+export interface RecentDocumentRecord {
+  id: string
+  kind: RecentDocumentKind
+  displayName: string
+  title: string
+  sourceUri: string | null
+  providerName: string | null
+  pathHint: string | null
+  markdownPreview: string | null
+  updatedAt: string
+  lastOpenedAt: string
+  lastSavedAt: string | null
+  autosaveState: AutosaveState
+  canWrite: boolean | null
+}
+
+export interface RecentDocumentListItem extends RecentDocumentRecord {
+  stats: DocumentStats | null
+}
+
+interface LocalDraftSource {
+  id: string
+  markdown: string
+  updatedAt: string
+  lastSavedAt: string | null
+}
+
+const DEFAULT_RECENT_LIMIT = 50
+
+function isRecentDocumentKind(value: unknown): value is RecentDocumentKind {
+  return value === 'local-draft' || value === 'android-document' || value === 'incoming-document'
+}
+
+function isAutosaveState(value: unknown): value is AutosaveState {
+  return value === 'clean' || value === 'dirty' || value === 'saving' || value === 'save-failed'
+}
+
+function isRecentDocumentRecord(value: unknown): value is RecentDocumentRecord {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const record = value as Partial<RecentDocumentRecord>
+  return (
+    typeof record.id === 'string' &&
+    isRecentDocumentKind(record.kind) &&
+    typeof record.displayName === 'string' &&
+    typeof record.title === 'string' &&
+    (typeof record.sourceUri === 'string' || record.sourceUri === null) &&
+    (typeof record.providerName === 'string' || record.providerName === null) &&
+    (typeof record.pathHint === 'string' || record.pathHint === null) &&
+    (typeof record.markdownPreview === 'string' || record.markdownPreview === null) &&
+    typeof record.updatedAt === 'string' &&
+    typeof record.lastOpenedAt === 'string' &&
+    (typeof record.lastSavedAt === 'string' || record.lastSavedAt === null) &&
+    isAutosaveState(record.autosaveState) &&
+    (typeof record.canWrite === 'boolean' || record.canWrite === null)
+  )
+}
+
+function getRecentDocumentKey(record: RecentDocumentRecord) {
+  return record.sourceUri ? `${record.kind}:${record.sourceUri}` : `${record.kind}:${record.id}`
+}
+
+function getRecentDocumentSortTime(record: RecentDocumentRecord) {
+  return Math.max(Date.parse(record.updatedAt), Date.parse(record.lastOpenedAt))
+}
+
+function compareRecentDocuments(left: RecentDocumentRecord, right: RecentDocumentRecord) {
+  return getRecentDocumentSortTime(right) - getRecentDocumentSortTime(left)
+}
+
+export function createRecentDocumentFromLocalDraft(
+  draft: LocalDraftSource,
+): RecentDocumentRecord {
+  const title = getDocumentTitle(draft.markdown)
+
+  return {
+    id: draft.id,
+    kind: 'local-draft',
+    displayName: title,
+    title,
+    sourceUri: null,
+    providerName: 'Local draft',
+    pathHint: null,
+    markdownPreview: draft.markdown,
+    updatedAt: draft.updatedAt,
+    lastOpenedAt: draft.updatedAt,
+    lastSavedAt: draft.lastSavedAt,
+    autosaveState: 'clean',
+    canWrite: true,
+  }
+}
+
+export function normalizeRecentDocuments(
+  records: RecentDocumentRecord[],
+  limit = DEFAULT_RECENT_LIMIT,
+) {
+  const seen = new Set<string>()
+  const normalized: RecentDocumentRecord[] = []
+
+  for (const record of [...records].sort(compareRecentDocuments)) {
+    const key = getRecentDocumentKey(record)
+    if (seen.has(key)) {
+      continue
+    }
+
+    if (record.kind === 'local-draft' && !record.markdownPreview?.trim()) {
+      continue
+    }
+
+    seen.add(key)
+    normalized.push(record)
+  }
+
+  return normalized.slice(0, limit)
+}
+
+export function parseRecentDocuments(value: string | null) {
+  if (!value) {
+    return []
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value)
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+
+    return normalizeRecentDocuments(parsed.filter(isRecentDocumentRecord))
+  } catch {
+    return []
+  }
+}
+
+export function serializeRecentDocuments(records: RecentDocumentRecord[]) {
+  return JSON.stringify(normalizeRecentDocuments(records))
+}
+
+export function upsertRecentDocument(
+  records: RecentDocumentRecord[],
+  nextRecord: RecentDocumentRecord,
+  limit = DEFAULT_RECENT_LIMIT,
+) {
+  const nextKey = getRecentDocumentKey(nextRecord)
+
+  return normalizeRecentDocuments(
+    [nextRecord, ...records.filter(record => getRecentDocumentKey(record) !== nextKey)],
+    limit,
+  )
+}
+
+export function getRecentDocumentListItems(
+  records: RecentDocumentRecord[],
+): RecentDocumentListItem[] {
+  return normalizeRecentDocuments(records).map(record => ({
+    ...record,
+    stats: record.markdownPreview ? getDocumentStats(record.markdownPreview) : null,
+  }))
+}


### PR DESCRIPTION
Closes #

## Summary

Adds a recent document state model that can represent local drafts, future Android SAF documents, and future incoming/shared documents. The current home screen still shows local drafts, but it now builds those rows through the recent document layer instead of being tied directly to local draft list items.

This keeps the branch focused on state shape and UI wiring before adding Android file picker, content URI persistence, or save-as behavior.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] UI/UX change
- [ ] Android native integration
- [ ] CI/build/documentation

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm android:sync`
- [ ] Android debug build
- [ ] MuMu/emulator install and launch, if UI or native Android behavior changed
- [ ] Screenshot or screen recording attached, if UI changed

## Android notes

No Android native storage APIs are introduced in this PR. There are no new permissions, intent filters, content URI reads/writes, or persisted URI grants yet. The new model is intended to make the next SAF/open-document PR smaller and easier to review.

## Reviewer notes

The recent document helper currently converts local drafts into recent document records and preserves the existing mobile home behavior. Android document records can exist in the model with `markdownPreview: null`, but opening those records is intentionally not implemented yet.