### PR TITLE
feat: open Android Markdown documents

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -102,8 +102,9 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
 
         try {
-            persistUriPermission(uri, data);
             JSObject document = buildDocumentResult(uri, data);
+            persistUriPermission(uri, data);
+            document.put("persisted", hasPersistedReadPermission(uri));
             Log.i(TAG, "Opened Android document: " + safeForLog(document.getString("displayName")));
             call.resolve(document);
         } catch (DocumentReadException ex) {

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -1,0 +1,303 @@
+package io.github.renakoni.marktextandroid;
+
+import android.app.Activity;
+import android.content.ActivityNotFoundException;
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.content.UriPermission;
+import android.content.pm.PackageManager;
+import android.content.pm.ProviderInfo;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.OpenableColumns;
+import android.util.Log;
+import androidx.activity.result.ActivityResult;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.ActivityCallback;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+@CapacitorPlugin(name = "AndroidDocuments")
+public class AndroidDocumentsPlugin extends Plugin {
+
+    private static final String TAG = "MarkTextAndroid";
+    private static final int MAX_MARKDOWN_BYTES = 5 * 1024 * 1024;
+    private static final String CALLBACK_OPEN_MARKDOWN_DOCUMENT = "openMarkdownDocumentResult";
+
+    @PluginMethod
+    public void openMarkdownDocument(PluginCall call) {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*");
+        intent.putExtra(
+            Intent.EXTRA_MIME_TYPES,
+            new String[] {
+                "text/markdown",
+                "text/x-markdown",
+                "text/plain",
+                "application/octet-stream"
+            }
+        );
+        intent.addFlags(
+            Intent.FLAG_GRANT_READ_URI_PERMISSION |
+            Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+        );
+
+        try {
+            startActivityForResult(call, intent, CALLBACK_OPEN_MARKDOWN_DOCUMENT);
+        } catch (ActivityNotFoundException ex) {
+            Log.e(TAG, "No Android document picker is available", ex);
+            call.reject("No Android document picker is available", "DOCUMENT_PICKER_UNAVAILABLE", ex);
+        }
+    }
+
+    @PluginMethod
+    public void readMarkdownDocument(PluginCall call) {
+        String sourceUri = call.getString("sourceUri", "");
+        Uri uri = parseContentUri(sourceUri);
+        if (uri == null) {
+            call.reject("A valid content URI is required", "INVALID_SOURCE_URI");
+            return;
+        }
+
+        try {
+            JSObject result = buildDocumentResult(uri, null);
+            Log.i(TAG, "Read Android document: " + safeForLog(result.getString("displayName")));
+            call.resolve(result);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android document read rejected: " + ex.getMessage());
+            call.reject(ex.getMessage(), ex.code, ex);
+        } catch (IOException | SecurityException ex) {
+            Log.e(TAG, "Failed to read Android document", ex);
+            call.reject("Failed to read Android document", "DOCUMENT_READ_FAILED", ex);
+        }
+    }
+
+    @ActivityCallback
+    private void openMarkdownDocumentResult(PluginCall call, ActivityResult result) {
+        if (call == null) {
+            Log.w(TAG, "Missing plugin call for Android document picker result");
+            return;
+        }
+
+        if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
+            JSObject canceled = new JSObject();
+            canceled.put("canceled", true);
+            call.resolve(canceled);
+            return;
+        }
+
+        Intent data = result.getData();
+        Uri uri = data.getData();
+        if (uri == null) {
+            call.reject("Android document picker returned no URI", "DOCUMENT_URI_MISSING");
+            return;
+        }
+
+        try {
+            persistUriPermission(uri, data);
+            JSObject document = buildDocumentResult(uri, data);
+            Log.i(TAG, "Opened Android document: " + safeForLog(document.getString("displayName")));
+            call.resolve(document);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android document open rejected: " + ex.getMessage());
+            call.reject(ex.getMessage(), ex.code, ex);
+        } catch (IOException | SecurityException ex) {
+            Log.e(TAG, "Failed to open Android document", ex);
+            call.reject("Failed to open Android document", "DOCUMENT_READ_FAILED", ex);
+        }
+    }
+
+    private JSObject buildDocumentResult(Uri uri, Intent grantIntent) throws IOException, DocumentReadException {
+        String displayName = getDisplayName(uri);
+        String mimeType = getMimeType(uri);
+        if (!isMarkdownCandidate(displayName, mimeType)) {
+            throw new DocumentReadException(
+                "UNSUPPORTED_DOCUMENT",
+                "Choose a Markdown or plain text document"
+            );
+        }
+
+        String markdown = readText(uri);
+        JSObject result = new JSObject();
+        result.put("canceled", false);
+        result.put("sourceUri", uri.toString());
+        result.put("displayName", displayName);
+        result.put("providerName", getProviderName(uri));
+        result.put("pathHint", displayName);
+        result.put("mimeType", mimeType);
+        result.put("markdown", markdown);
+        result.put("canWrite", canWrite(uri, grantIntent));
+        result.put("persisted", hasPersistedReadPermission(uri));
+        return result;
+    }
+
+    private Uri parseContentUri(String value) {
+        if (value == null || value.length() == 0) {
+            return null;
+        }
+
+        Uri uri = Uri.parse(value);
+        if (!"content".equals(uri.getScheme())) {
+            return null;
+        }
+        return uri;
+    }
+
+    private void persistUriPermission(Uri uri, Intent data) {
+        int grantFlags = data.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION;
+        if (grantFlags == 0) {
+            return;
+        }
+
+        try {
+            getContext().getContentResolver().takePersistableUriPermission(uri, grantFlags);
+        } catch (SecurityException ex) {
+            Log.w(TAG, "Could not persist Android document URI permission", ex);
+        }
+    }
+
+    private String readText(Uri uri) throws IOException, DocumentReadException {
+        ContentResolver resolver = getContext().getContentResolver();
+        try (InputStream input = resolver.openInputStream(uri)) {
+            if (input == null) {
+                throw new IOException("Content resolver returned no stream");
+            }
+
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int totalBytes = 0;
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                totalBytes += read;
+                if (totalBytes > MAX_MARKDOWN_BYTES) {
+                    throw new DocumentReadException(
+                        "DOCUMENT_TOO_LARGE",
+                        "Markdown document is larger than the current 5 MB limit"
+                    );
+                }
+                output.write(buffer, 0, read);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private String getDisplayName(Uri uri) {
+        ContentResolver resolver = getContext().getContentResolver();
+        try (
+            Cursor cursor = resolver.query(
+                uri,
+                new String[] { OpenableColumns.DISPLAY_NAME },
+                null,
+                null,
+                null
+            )
+        ) {
+            if (cursor != null && cursor.moveToFirst()) {
+                int index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                if (index >= 0) {
+                    String value = cursor.getString(index);
+                    if (value != null && value.trim().length() > 0) {
+                        return value.trim();
+                    }
+                }
+            }
+        } catch (SecurityException ex) {
+            Log.w(TAG, "Could not query Android document display name", ex);
+        }
+
+        String path = uri.getLastPathSegment();
+        if (path != null && path.trim().length() > 0) {
+            return path.trim();
+        }
+        return "Android document";
+    }
+
+    private String getMimeType(Uri uri) {
+        String type = getContext().getContentResolver().getType(uri);
+        return type == null ? "" : type.toLowerCase(Locale.US);
+    }
+
+    private String getProviderName(Uri uri) {
+        String authority = uri.getAuthority();
+        if (authority == null || authority.length() == 0) {
+            return "Android document";
+        }
+
+        PackageManager packageManager = getContext().getPackageManager();
+        ProviderInfo providerInfo = packageManager.resolveContentProvider(authority, 0);
+        if (providerInfo != null) {
+            CharSequence label = providerInfo.loadLabel(packageManager);
+            if (label != null && label.length() > 0) {
+                return label.toString();
+            }
+        }
+        return authority;
+    }
+
+    private boolean isMarkdownCandidate(String displayName, String mimeType) {
+        String lowerName = displayName == null ? "" : displayName.toLowerCase(Locale.US);
+        boolean markdownExtension =
+            lowerName.endsWith(".md") ||
+            lowerName.endsWith(".markdown") ||
+            lowerName.endsWith(".mdown") ||
+            lowerName.endsWith(".mkdn") ||
+            lowerName.endsWith(".mkd");
+
+        if (markdownExtension) {
+            return true;
+        }
+
+        return (
+            "text/markdown".equals(mimeType) ||
+            "text/x-markdown".equals(mimeType) ||
+            "text/plain".equals(mimeType)
+        );
+    }
+
+    private boolean canWrite(Uri uri, Intent grantIntent) {
+        if (grantIntent != null && (grantIntent.getFlags() & Intent.FLAG_GRANT_WRITE_URI_PERMISSION) != 0) {
+            return true;
+        }
+
+        for (UriPermission permission : getContext().getContentResolver().getPersistedUriPermissions()) {
+            if (uri.equals(permission.getUri()) && permission.isWritePermission()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasPersistedReadPermission(Uri uri) {
+        for (UriPermission permission : getContext().getContentResolver().getPersistedUriPermissions()) {
+            if (uri.equals(permission.getUri()) && permission.isReadPermission()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String safeForLog(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace('\r', ' ').replace('\n', ' ').trim();
+    }
+
+    private static class DocumentReadException extends Exception {
+
+        final String code;
+
+        DocumentReadException(String code, String message) {
+            super(message);
+            this.code = code;
+        }
+    }
+}

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
@@ -6,6 +6,7 @@ import com.getcapacitor.BridgeActivity;
 public class MainActivity extends BridgeActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        registerPlugin(AndroidDocumentsPlugin.class);
         registerPlugin(NativeLoggerPlugin.class);
         super.onCreate(savedInstanceState);
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,13 @@ import {
 } from '@muyajs/core'
 import DocumentHome from './components/DocumentHome.vue'
 import {
+  getAndroidDocumentErrorCode,
+  getAndroidDocumentUserMessage,
+  openAndroidMarkdownDocument,
+  readAndroidMarkdownDocument,
+  type OpenedAndroidDocument,
+} from './lib/androidDocuments'
+import {
   createUntitledDocument,
   markDocumentSaved,
   markDocumentSaveFailed,
@@ -25,13 +32,19 @@ import {
 } from './lib/localDrafts'
 import { createLogger, getNativeLogInfo } from './lib/logger'
 import {
+  createRecentDocumentFromAndroidDocument,
   createRecentDocumentFromLocalDraft,
   getRecentDocumentListItems,
+  parseRecentDocuments,
+  serializeRecentDocuments,
+  upsertRecentDocument,
   type RecentDocumentListItem,
+  type RecentDocumentRecord,
 } from './lib/recentDocuments'
 
 const LEGACY_DRAFT_STORAGE_KEY = 'marktext-for-android:draft'
 const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
+const RECENT_DOCUMENTS_STORAGE_KEY = 'marktext-for-android:recent-documents'
 const DRAFT_SAVE_DELAY_MS = 800
 
 const editorPlugins = [
@@ -44,7 +57,9 @@ const editorPlugins = [
 const editorElement = ref<HTMLElement | null>(null)
 const documentState = ref(createUntitledDocument())
 const localDrafts = ref<LocalDraftRecord[]>([])
+const androidRecentDocuments = ref<RecentDocumentRecord[]>([])
 const status = ref('Ready')
+const homeNotice = ref<string | null>(null)
 const currentScreen = ref<'home' | 'editor'>('home')
 
 let editor: Muya | null = null
@@ -54,6 +69,7 @@ let draftSaveTimer: number | null = null
 const appLog = createLogger('app')
 const editorLog = createLogger('editor')
 const draftLog = createLogger('draft')
+const androidDocumentLog = createLogger('android-document')
 const loggingLog = createLogger('logging')
 
 const lineCount = computed(() => documentState.value.stats.lines)
@@ -61,7 +77,10 @@ const characterCount = computed(() => documentState.value.stats.characters)
 const wordCount = computed(() => documentState.value.stats.words)
 const documentTitle = computed(() => documentState.value.title)
 const recentDocumentRecords = computed(() =>
-  localDrafts.value.map(createRecentDocumentFromLocalDraft),
+  [
+    ...localDrafts.value.map(createRecentDocumentFromLocalDraft),
+    ...androidRecentDocuments.value,
+  ],
 )
 const documentItems = computed(() => getRecentDocumentListItems(recentDocumentRecords.value))
 const continueDocumentItem = computed(() => documentItems.value[0] ?? null)
@@ -122,6 +141,21 @@ function createDocumentFromDraft(draft: LocalDraftRecord) {
   }
 }
 
+function createDocumentFromAndroidDocument(document: OpenedAndroidDocument) {
+  const openedDocument = createUntitledDocument({
+    markdown: document.markdown,
+    displayName: document.displayName,
+    sourceUri: document.sourceUri,
+    autosaveTarget: 'android-document',
+  })
+
+  return {
+    ...openedDocument,
+    id: `android-document:${document.sourceUri}`,
+    lastSavedAt: null,
+  }
+}
+
 function normalizeEditorMarkdown(markdown: string) {
   return markdown === '\n' ? '' : markdown
 }
@@ -135,10 +169,14 @@ function syncMarkdown(nextStatus: unknown = 'Edited') {
   const nextMarkdown = normalizeEditorMarkdown(editor.getMarkdown())
   const markDirty = resolvedStatus === 'Edited'
   documentState.value = updateDocumentMarkdown(documentState.value, nextMarkdown, { markDirty })
-  status.value = markDirty ? 'Autosaving locally' : resolvedStatus
+  if (markDirty && documentState.value.autosaveTarget === 'android-document') {
+    status.value = 'Unsaved changes'
+  } else {
+    status.value = markDirty ? 'Autosaving locally' : resolvedStatus
+  }
   logContentSnapshot(resolvedStatus)
 
-  if (markDirty) {
+  if (markDirty && documentState.value.autosaveTarget === 'local-draft') {
     scheduleDraftSave()
   }
 }
@@ -178,8 +216,28 @@ function persistLocalDrafts(nextDrafts: LocalDraftRecord[]) {
   localStorage.removeItem(LEGACY_DRAFT_STORAGE_KEY)
 }
 
+function persistAndroidRecentDocuments(nextDocuments: RecentDocumentRecord[]) {
+  const filteredDocuments = nextDocuments.filter(record => record.kind === 'android-document')
+  androidRecentDocuments.value = filteredDocuments
+
+  if (filteredDocuments.length > 0) {
+    localStorage.setItem(RECENT_DOCUMENTS_STORAGE_KEY, serializeRecentDocuments(filteredDocuments))
+  } else {
+    localStorage.removeItem(RECENT_DOCUMENTS_STORAGE_KEY)
+  }
+}
+
 function saveDraft() {
   if (!editor) {
+    return
+  }
+
+  if (documentState.value.autosaveTarget !== 'local-draft') {
+    androidDocumentLog.debug('skip local draft autosave for Android document', {
+      id: documentState.value.id,
+      sourceUri: documentState.value.sourceUri,
+      autosaveState: documentState.value.autosaveState,
+    })
     return
   }
 
@@ -270,33 +328,108 @@ function initEditor(initialMarkdown: string) {
 }
 
 async function openEditor(markdown: string) {
+  destroyEditor()
   currentScreen.value = 'editor'
   await nextTick()
   initEditor(markdown)
 }
 
-function openDocument(id: string) {
+function rememberAndroidDocument(document: OpenedAndroidDocument) {
+  const recentDocument = createRecentDocumentFromAndroidDocument({
+    sourceUri: document.sourceUri,
+    displayName: document.displayName,
+    providerName: document.providerName,
+    pathHint: document.pathHint,
+    markdown: document.markdown,
+    canWrite: document.canWrite,
+  })
+
+  persistAndroidRecentDocuments(upsertRecentDocument(androidRecentDocuments.value, recentDocument))
+}
+
+async function openAndroidDocumentResult(document: OpenedAndroidDocument) {
+  homeNotice.value = null
+  rememberAndroidDocument(document)
+  documentState.value = createDocumentFromAndroidDocument(document)
+  androidDocumentLog.info('open Android document in editor', {
+    displayName: document.displayName,
+    sourceUri: document.sourceUri,
+    canWrite: document.canWrite,
+    persisted: document.persisted,
+    characters: document.markdown.length,
+  })
+  await openEditor(document.markdown)
+  status.value = document.canWrite ? 'Opened from Android' : 'Opened read-only'
+}
+
+async function openFileFromAndroid() {
+  homeNotice.value = null
+  androidDocumentLog.info('open Android document picker')
+
+  try {
+    const document = await openAndroidMarkdownDocument()
+    if (document.canceled) {
+      androidDocumentLog.info('Android document picker canceled')
+      return
+    }
+
+    await openAndroidDocumentResult(document)
+  } catch (error) {
+    const code = getAndroidDocumentErrorCode(error)
+    homeNotice.value = getAndroidDocumentUserMessage(error)
+    if (code === 'UNAVAILABLE') {
+      androidDocumentLog.warn('Android document picker unavailable', error)
+    } else {
+      androidDocumentLog.error('Android document picker failed', error)
+    }
+  }
+}
+
+async function openDocument(id: string) {
   const recentDocument = documentItems.value.find(record => record.id === id)
-  if (recentDocument && recentDocument.kind !== 'local-draft') {
-    appLog.warn('recent document type is not openable yet', {
-      id,
-      kind: recentDocument.kind,
-    })
+  if (!recentDocument) {
+    appLog.warn('recent document not found', { id })
     return
   }
 
-  const draft = localDrafts.value.find(record => record.id === id)
-  if (!draft) {
-    draftLog.warn('recent local draft not found', { id })
+  if (recentDocument.kind === 'local-draft') {
+    const draft = localDrafts.value.find(record => record.id === id)
+    if (!draft) {
+      draftLog.warn('recent local draft not found', { id })
+      return
+    }
+
+    homeNotice.value = null
+    documentState.value = createDocumentFromDraft(draft)
+    appLog.info('open recent local document', { id })
+    await openEditor(draft.markdown)
     return
   }
 
-  documentState.value = createDocumentFromDraft(draft)
-  appLog.info('open recent local document', { id })
-  void openEditor(draft.markdown)
+  if (recentDocument.kind === 'android-document' && recentDocument.sourceUri) {
+    homeNotice.value = null
+    try {
+      const document = await readAndroidMarkdownDocument(recentDocument.sourceUri)
+      await openAndroidDocumentResult(document)
+    } catch (error) {
+      homeNotice.value = getAndroidDocumentUserMessage(error)
+      androidDocumentLog.error('open recent Android document failed', {
+        id,
+        sourceUri: recentDocument.sourceUri,
+        error,
+      })
+    }
+    return
+  }
+
+  appLog.warn('recent document type is not openable yet', {
+    id,
+    kind: recentDocument.kind,
+  })
 }
 
 function newDocument() {
+  homeNotice.value = null
   appLog.info('create new local document')
   documentState.value = createUntitledDocument({ autosaveTarget: 'local-draft' })
   void openEditor('')
@@ -321,7 +454,12 @@ function showHome() {
 onMounted(() => {
   appLog.info('app mounted')
   const restoredDrafts = parseLocalDrafts(localStorage.getItem(DRAFTS_STORAGE_KEY))
+  const restoredRecentDocuments = parseRecentDocuments(
+    localStorage.getItem(RECENT_DOCUMENTS_STORAGE_KEY),
+  ).filter(record => record.kind === 'android-document')
   const legacyDraft = localStorage.getItem(LEGACY_DRAFT_STORAGE_KEY)
+
+  androidRecentDocuments.value = restoredRecentDocuments
 
   if (restoredDrafts.length > 0) {
     localDrafts.value = restoredDrafts
@@ -345,6 +483,7 @@ onMounted(() => {
 
   draftLog.info('local draft checked', {
     restoredDrafts: localDrafts.value.length,
+    restoredAndroidDocuments: androidRecentDocuments.value.length,
     characters: characterCount.value,
   })
 
@@ -369,8 +508,10 @@ onBeforeUnmount(() => {
     <DocumentHome
       :continue-document="continueDocument"
       :earlier-documents="earlierDocuments"
+      :notice="homeNotice"
       @new-document="newDocument"
       @open-document="openDocument"
+      @open-file="openFileFromAndroid"
     />
   </main>
 

--- a/src/components/DocumentHome.vue
+++ b/src/components/DocumentHome.vue
@@ -8,12 +8,14 @@ interface DocumentListItem {
 interface Props {
   continueDocument: DocumentListItem | null
   earlierDocuments: DocumentListItem[]
+  notice: string | null
 }
 
 defineProps<Props>()
 
 defineEmits<{
   openDocument: [id: string]
+  openFile: []
   newDocument: []
 }>()
 </script>
@@ -24,17 +26,29 @@ defineEmits<{
       <div>
         <h1>MarkText</h1>
       </div>
-      <button
-        class="home-new-button"
-        type="button"
-        aria-label="New document"
-        data-testid="new-document-button"
-        title="New document"
-        @click="$emit('newDocument')"
-      >
-        +
-      </button>
+      <div class="home-actions">
+        <button
+          class="home-open-button"
+          type="button"
+          data-testid="open-file-button"
+          @click="$emit('openFile')"
+        >
+          Open
+        </button>
+        <button
+          class="home-new-button"
+          type="button"
+          aria-label="New document"
+          data-testid="new-document-button"
+          title="New document"
+          @click="$emit('newDocument')"
+        >
+          +
+        </button>
+      </div>
     </header>
+
+    <p v-if="notice" class="home-notice" role="status">{{ notice }}</p>
 
     <nav class="home-tabs" aria-label="Document sections">
       <button class="home-tab is-active" type="button">Recent</button>
@@ -76,7 +90,7 @@ defineEmits<{
       >
         <div class="empty-recent">
           <h2 id="recent-title">No recent Markdown files</h2>
-          <p>Use the plus button to start a local draft.</p>
+          <p>Start a local draft or open a Markdown file from this device.</p>
         </div>
       </section>
     </div>

--- a/src/lib/androidDocuments.ts
+++ b/src/lib/androidDocuments.ts
@@ -1,0 +1,111 @@
+import { Capacitor, registerPlugin } from '@capacitor/core'
+
+export interface OpenedAndroidDocument {
+  canceled?: false
+  sourceUri: string
+  displayName: string
+  providerName: string | null
+  pathHint: string | null
+  mimeType: string | null
+  markdown: string
+  canWrite: boolean
+  persisted: boolean
+}
+
+interface CanceledAndroidDocumentOpen {
+  canceled: true
+}
+
+interface AndroidDocumentsPlugin {
+  openMarkdownDocument(): Promise<OpenedAndroidDocument | CanceledAndroidDocumentOpen>
+  readMarkdownDocument(options: { sourceUri: string }): Promise<OpenedAndroidDocument>
+}
+
+export class AndroidDocumentError extends Error {
+  code: string
+
+  constructor(code: string, message: string) {
+    super(message)
+    this.name = 'AndroidDocumentError'
+    this.code = code
+  }
+}
+
+const AndroidDocuments = registerPlugin<AndroidDocumentsPlugin>('AndroidDocuments')
+
+export function isAndroidDocumentAccessAvailable() {
+  return Capacitor.getPlatform() === 'android' && Capacitor.isNativePlatform()
+}
+
+export async function openAndroidMarkdownDocument() {
+  ensureAndroidDocumentsAvailable()
+  const result = await AndroidDocuments.openMarkdownDocument()
+  if (result.canceled) {
+    return result
+  }
+
+  return normalizeOpenedDocument(result)
+}
+
+export async function readAndroidMarkdownDocument(sourceUri: string) {
+  ensureAndroidDocumentsAvailable()
+  return normalizeOpenedDocument(await AndroidDocuments.readMarkdownDocument({ sourceUri }))
+}
+
+export function getAndroidDocumentErrorCode(error: unknown) {
+  if (error instanceof AndroidDocumentError) {
+    return error.code
+  }
+
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = (error as { code?: unknown }).code
+    return typeof code === 'string' ? code : 'UNKNOWN'
+  }
+
+  return 'UNKNOWN'
+}
+
+export function getAndroidDocumentUserMessage(error: unknown) {
+  const code = getAndroidDocumentErrorCode(error)
+  if (code === 'UNAVAILABLE') {
+    return 'Open Markdown files from the Android app build.'
+  }
+
+  if (code === 'UNSUPPORTED_DOCUMENT') {
+    return 'Choose a Markdown or plain text file.'
+  }
+
+  if (code === 'DOCUMENT_TOO_LARGE') {
+    return 'This Markdown file is larger than the current 5 MB limit.'
+  }
+
+  if (code === 'INVALID_SOURCE_URI') {
+    return 'This recent file can no longer be opened.'
+  }
+
+  return 'Could not open this Markdown file.'
+}
+
+function ensureAndroidDocumentsAvailable() {
+  if (!isAndroidDocumentAccessAvailable()) {
+    throw new AndroidDocumentError('UNAVAILABLE', 'Android document access is only available in Android builds')
+  }
+}
+
+function normalizeOpenedDocument(value: OpenedAndroidDocument): OpenedAndroidDocument {
+  if (!value.sourceUri || !value.displayName || typeof value.markdown !== 'string') {
+    throw new AndroidDocumentError('INVALID_DOCUMENT_RESULT', 'Android document plugin returned an invalid result')
+  }
+
+  return {
+    canceled: false,
+    sourceUri: value.sourceUri,
+    displayName: value.displayName,
+    providerName: value.providerName ?? null,
+    pathHint: value.pathHint ?? null,
+    mimeType: value.mimeType ?? null,
+    markdown: value.markdown,
+    canWrite: Boolean(value.canWrite),
+    persisted: Boolean(value.persisted),
+  }
+}

--- a/src/lib/recentDocuments.test.ts
+++ b/src/lib/recentDocuments.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  createRecentDocumentFromAndroidDocument,
   createRecentDocumentFromLocalDraft,
   getRecentDocumentListItems,
   normalizeRecentDocuments,
@@ -56,6 +57,25 @@ describe('recentDocuments', () => {
     expect(record.providerName).toBe('Local draft')
     expect(record.markdownPreview).toBe(newerDraft.markdown)
     expect(record.canWrite).toBe(true)
+  })
+
+  it('creates recent document records from Android documents without storing markdown content', () => {
+    const record = createRecentDocumentFromAndroidDocument({
+      sourceUri: 'content://provider/android-note.md',
+      displayName: 'android-note.md',
+      providerName: 'Documents',
+      pathHint: 'Documents/android-note.md',
+      markdown: '# Android note\n\nopened from SAF',
+      canWrite: false,
+      openedAt: '2026-06-29T00:06:00.000Z',
+    })
+
+    expect(record.id).toBe('android-document:content://provider/android-note.md')
+    expect(record.kind).toBe('android-document')
+    expect(record.title).toBe('Android note')
+    expect(record.markdownPreview).toBeNull()
+    expect(record.lastOpenedAt).toBe('2026-06-29T00:06:00.000Z')
+    expect(record.canWrite).toBe(false)
   })
 
   it('sorts recent documents newest first by update or open time', () => {

--- a/src/lib/recentDocuments.ts
+++ b/src/lib/recentDocuments.ts
@@ -34,6 +34,16 @@ interface LocalDraftSource {
   lastSavedAt: string | null
 }
 
+interface AndroidDocumentSource {
+  sourceUri: string
+  displayName: string
+  providerName: string | null
+  pathHint: string | null
+  markdown: string
+  canWrite: boolean
+  openedAt?: string
+}
+
 const DEFAULT_RECENT_LIMIT = 50
 
 function isRecentDocumentKind(value: unknown): value is RecentDocumentKind {
@@ -98,6 +108,29 @@ export function createRecentDocumentFromLocalDraft(
     lastSavedAt: draft.lastSavedAt,
     autosaveState: 'clean',
     canWrite: true,
+  }
+}
+
+export function createRecentDocumentFromAndroidDocument(
+  document: AndroidDocumentSource,
+): RecentDocumentRecord {
+  const openedAt = document.openedAt ?? new Date().toISOString()
+  const title = getDocumentTitle(document.markdown, document.displayName)
+
+  return {
+    id: `android-document:${document.sourceUri}`,
+    kind: 'android-document',
+    displayName: document.displayName,
+    title,
+    sourceUri: document.sourceUri,
+    providerName: document.providerName,
+    pathHint: document.pathHint,
+    markdownPreview: null,
+    updatedAt: openedAt,
+    lastOpenedAt: openedAt,
+    lastSavedAt: null,
+    autosaveState: 'clean',
+    canWrite: document.canWrite,
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -73,7 +73,14 @@ body {
   font-weight: 760;
 }
 
+.home-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .home-new-button,
+.home-open-button,
 .nav-button {
   min-height: 44px;
   border: 1px solid var(--border);
@@ -83,6 +90,11 @@ body {
   font: inherit;
   font-size: 14px;
   font-weight: 700;
+}
+
+.home-open-button {
+  padding: 0 15px;
+  background: var(--surface);
 }
 
 .home-new-button {
@@ -102,9 +114,22 @@ body {
 }
 
 .home-new-button:active,
+.home-open-button:active,
 .nav-button:active,
 .document-row:active {
   transform: translateY(1px);
+}
+
+.home-notice {
+  max-width: 760px;
+  margin: 16px auto 0;
+  padding: 11px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-muted);
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.35;
 }
 
 .home-tabs {

--- a/tests/e2e/mobile-recent-home.spec.ts
+++ b/tests/e2e/mobile-recent-home.spec.ts
@@ -9,6 +9,7 @@ test('creates a local draft from real editor input and returns it to the recent 
 
   await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
   await expect(page.getByText('No recent Markdown files')).toBeVisible()
+  await expect(page.getByTestId('open-file-button')).toBeVisible()
   await expect(page.getByTestId('new-document-button')).toBeVisible()
 
   await page.getByTestId('new-document-button').click()
@@ -33,5 +34,17 @@ test('creates a local draft from real editor input and returns it to the recent 
   await expect(page.getByText('Continue writing')).toBeVisible()
   await expect(page.getByText('Fresh mobile note')).toBeVisible()
   await expect(page.getByText('No recent Markdown files')).toBeHidden()
+  await expect(page.getByTestId('new-document-button')).toBeVisible()
+})
+
+test('keeps the Android open-file action nonfatal in the browser shell', async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+
+  await page.getByTestId('open-file-button').click()
+
+  await expect(page.getByText('Open Markdown files from the Android app build.')).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
   await expect(page.getByTestId('new-document-button')).toBeVisible()
 })


### PR DESCRIPTION
## Summary

This PR adds the first Android Storage Access Framework path for opening Markdown documents in the Android app.

What changed:
- Add a native Capacitor `AndroidDocuments` plugin that launches Android `ACTION_OPEN_DOCUMENT`.
- Read Markdown/plain text content from `content://` URIs with a 5 MB limit.
- Persist read URI permission so Android recent documents can be reopened later.
- Add a mobile Home `Open` action while keeping the browser shell fallback nonfatal.
- Store Android recent metadata only, without storing the opened file Markdown content in localStorage.
- Keep Android document edits out of local draft autosave for now.

## Android and security scope

- Uses the system document picker instead of broad storage permissions.
- Adds no new open-with/share intent filters.
- Accepts only `content://` URIs from SAF.
- Persists read permission only. Save-back, save-as, share, and open-with are intentionally out of scope for this PR.

## Validation

Ran locally:
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:e2e -- --reporter=line`
- `pnpm android:sync`
- `./android/gradlew.bat -p android assembleDebug --no-daemon` with JDK 22

ADB/MuMu validation:
- Connected to MuMu at `127.0.0.1:7555`.
- Installed the debug APK with adb.
- Pushed a Markdown test file to `/sdcard/Download/marktext-adb-test.md`.
- Opened it through Android DocumentsUI from the app Home screen.
- Verified the editor rendered the selected Markdown content.
- Returned to Home and reopened it from the recent list through the persisted content URI.
- Captured `MarkTextAndroid` logcat output showing both open and read paths.

## Notes

A later PR should handle explicit save-back/save-as behavior and the related write-permission UX. This PR deliberately keeps the Android document path read-focused so the permission boundary stays clear.