### PR TITLE
feat: autosave Android documents

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -21,6 +21,7 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
@@ -47,6 +48,7 @@ public class AndroidDocumentsPlugin extends Plugin {
         );
         intent.addFlags(
             Intent.FLAG_GRANT_READ_URI_PERMISSION |
+            Intent.FLAG_GRANT_WRITE_URI_PERMISSION |
             Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
         );
 
@@ -80,6 +82,36 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
     }
 
+    @PluginMethod
+    public void writeMarkdownDocument(PluginCall call) {
+        String sourceUri = call.getString("sourceUri", "");
+        String markdown = call.getString("markdown", null);
+        Uri uri = parseContentUri(sourceUri);
+        if (uri == null) {
+            call.reject("A valid content URI is required", "INVALID_SOURCE_URI");
+            return;
+        }
+        if (markdown == null) {
+            call.reject("Markdown content is required", "INVALID_MARKDOWN");
+            return;
+        }
+
+        try {
+            JSObject result = writeDocumentResult(uri, markdown);
+            Log.i(TAG, "Wrote Android document: " + safeForLog(result.getString("displayName")));
+            call.resolve(result);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android document write rejected: " + ex.getMessage());
+            call.reject(ex.getMessage(), ex.code, ex);
+        } catch (SecurityException ex) {
+            Log.e(TAG, "Missing write permission for Android document", ex);
+            call.reject("Missing write permission for Android document", "DOCUMENT_WRITE_PERMISSION_MISSING", ex);
+        } catch (IOException ex) {
+            Log.e(TAG, "Failed to write Android document", ex);
+            call.reject("Failed to write Android document", "DOCUMENT_WRITE_FAILED", ex);
+        }
+    }
+
     @ActivityCallback
     private void openMarkdownDocumentResult(PluginCall call, ActivityResult result) {
         if (call == null) {
@@ -105,6 +137,7 @@ public class AndroidDocumentsPlugin extends Plugin {
             JSObject document = buildDocumentResult(uri, data);
             persistUriPermission(uri, data);
             document.put("persisted", hasPersistedReadPermission(uri));
+            document.put("canWrite", canWrite(uri, data));
             Log.i(TAG, "Opened Android document: " + safeForLog(document.getString("displayName")));
             call.resolve(document);
         } catch (DocumentReadException ex) {
@@ -140,6 +173,36 @@ public class AndroidDocumentsPlugin extends Plugin {
         return result;
     }
 
+    private JSObject writeDocumentResult(Uri uri, String markdown) throws IOException, DocumentReadException {
+        String displayName = getDisplayName(uri);
+        String mimeType = getMimeType(uri);
+        if (!isMarkdownCandidate(displayName, mimeType)) {
+            throw new DocumentReadException(
+                "UNSUPPORTED_DOCUMENT",
+                "Choose a Markdown or plain text document"
+            );
+        }
+
+        byte[] bytes = markdown.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length > MAX_MARKDOWN_BYTES) {
+            throw new DocumentReadException(
+                "DOCUMENT_TOO_LARGE",
+                "Markdown document is larger than the current 5 MB limit"
+            );
+        }
+
+        writeText(uri, bytes);
+        JSObject result = new JSObject();
+        result.put("sourceUri", uri.toString());
+        result.put("displayName", displayName);
+        result.put("providerName", getProviderName(uri));
+        result.put("pathHint", displayName);
+        result.put("mimeType", mimeType);
+        result.put("canWrite", canWrite(uri, null));
+        result.put("persisted", hasPersistedReadPermission(uri));
+        return result;
+    }
+
     private Uri parseContentUri(String value) {
         if (value == null || value.length() == 0) {
             return null;
@@ -153,7 +216,8 @@ public class AndroidDocumentsPlugin extends Plugin {
     }
 
     private void persistUriPermission(Uri uri, Intent data) {
-        int grantFlags = data.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION;
+        int grantFlags = data.getFlags() &
+            (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
         if (grantFlags == 0) {
             return;
         }
@@ -162,6 +226,17 @@ public class AndroidDocumentsPlugin extends Plugin {
             getContext().getContentResolver().takePersistableUriPermission(uri, grantFlags);
         } catch (SecurityException ex) {
             Log.w(TAG, "Could not persist Android document URI permission", ex);
+        }
+    }
+
+    private void writeText(Uri uri, byte[] bytes) throws IOException {
+        ContentResolver resolver = getContext().getContentResolver();
+        try (OutputStream output = resolver.openOutputStream(uri, "wt")) {
+            if (output == null) {
+                throw new IOException("Content resolver returned no output stream");
+            }
+            output.write(bytes);
+            output.flush();
         }
     }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,7 @@ import {
   getAndroidDocumentUserMessage,
   openAndroidMarkdownDocument,
   readAndroidMarkdownDocument,
+  writeAndroidMarkdownDocument,
   type OpenedAndroidDocument,
 } from './lib/androidDocuments'
 import {
@@ -21,6 +22,7 @@ import {
   markDocumentSaved,
   markDocumentSaveFailed,
   markDocumentSaving,
+  prepareMarkdownForSave,
   updateDocumentMarkdown,
 } from './lib/documentState'
 import {
@@ -35,6 +37,7 @@ import {
   createRecentDocumentFromAndroidDocument,
   createRecentDocumentFromLocalDraft,
   getRecentDocumentListItems,
+  markRecentDocumentSaved,
   parseRecentDocuments,
   serializeRecentDocuments,
   upsertRecentDocument,
@@ -46,6 +49,7 @@ const LEGACY_DRAFT_STORAGE_KEY = 'marktext-for-android:draft'
 const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
 const RECENT_DOCUMENTS_STORAGE_KEY = 'marktext-for-android:recent-documents'
 const DRAFT_SAVE_DELAY_MS = 800
+const ANDROID_DOCUMENT_SAVE_DELAY_MS = 1200
 
 const editorPlugins = [
   InlineFormatToolbar,
@@ -58,6 +62,7 @@ const editorElement = ref<HTMLElement | null>(null)
 const documentState = ref(createUntitledDocument())
 const localDrafts = ref<LocalDraftRecord[]>([])
 const androidRecentDocuments = ref<RecentDocumentRecord[]>([])
+const currentAndroidDocumentCanWrite = ref(false)
 const status = ref('Ready')
 const homeNotice = ref<string | null>(null)
 const currentScreen = ref<'home' | 'editor'>('home')
@@ -65,6 +70,9 @@ const currentScreen = ref<'home' | 'editor'>('home')
 let editor: Muya | null = null
 let lastContentLogAt = 0
 let draftSaveTimer: number | null = null
+let androidSaveTimer: number | null = null
+let androidSaveInFlight = false
+let androidSaveRequestedAfterCurrent = false
 
 const appLog = createLogger('app')
 const editorLog = createLogger('editor')
@@ -116,6 +124,22 @@ function formatSavedTime(value: string | null) {
     hour: '2-digit',
     minute: '2-digit',
   }).format(date)
+}
+
+function getAndroidEditorStatus() {
+  if (documentState.value.autosaveState === 'save-failed') {
+    return 'Save failed'
+  }
+
+  if (!currentAndroidDocumentCanWrite.value) {
+    return 'Read only'
+  }
+
+  if (documentState.value.autosaveState === 'saving' || documentState.value.isDirty) {
+    return 'Saving'
+  }
+
+  return 'Saved'
 }
 
 function registerMuyaPlugins() {
@@ -170,7 +194,10 @@ function syncMarkdown(nextStatus: unknown = 'Edited') {
   const markDirty = resolvedStatus === 'Edited'
   documentState.value = updateDocumentMarkdown(documentState.value, nextMarkdown, { markDirty })
   if (markDirty && documentState.value.autosaveTarget === 'android-document') {
-    status.value = 'Unsaved changes'
+    status.value = getAndroidEditorStatus()
+    if (currentAndroidDocumentCanWrite.value) {
+      scheduleAndroidDocumentSave()
+    }
   } else {
     status.value = markDirty ? 'Autosaving locally' : resolvedStatus
   }
@@ -204,6 +231,23 @@ function scheduleDraftSave() {
   draftSaveTimer = window.setTimeout(saveDraft, DRAFT_SAVE_DELAY_MS)
 }
 
+function scheduleAndroidDocumentSave() {
+  if (androidSaveTimer !== null) {
+    window.clearTimeout(androidSaveTimer)
+  }
+
+  androidSaveTimer = window.setTimeout(() => {
+    void saveAndroidDocument()
+  }, ANDROID_DOCUMENT_SAVE_DELAY_MS)
+}
+
+function clearAndroidDocumentSaveTimer() {
+  if (androidSaveTimer !== null) {
+    window.clearTimeout(androidSaveTimer)
+    androidSaveTimer = null
+  }
+}
+
 function persistLocalDrafts(nextDrafts: LocalDraftRecord[]) {
   localDrafts.value = nextDrafts
 
@@ -224,6 +268,125 @@ function persistAndroidRecentDocuments(nextDocuments: RecentDocumentRecord[]) {
     localStorage.setItem(RECENT_DOCUMENTS_STORAGE_KEY, serializeRecentDocuments(filteredDocuments))
   } else {
     localStorage.removeItem(RECENT_DOCUMENTS_STORAGE_KEY)
+  }
+}
+
+function markAndroidRecentDocumentSaved(savedAt: string) {
+  const sourceUri = documentState.value.sourceUri
+  if (!sourceUri) {
+    return
+  }
+
+  const existingDocument = androidRecentDocuments.value.find(record => record.sourceUri === sourceUri)
+  if (!existingDocument) {
+    androidDocumentLog.warn('saved Android recent document not found', { sourceUri })
+    return
+  }
+
+  persistAndroidRecentDocuments(
+    upsertRecentDocument(
+      androidRecentDocuments.value,
+      markRecentDocumentSaved(existingDocument, {
+        markdown: documentState.value.markdown,
+        savedAt,
+        canWrite: currentAndroidDocumentCanWrite.value,
+      }),
+    ),
+  )
+}
+
+async function saveAndroidDocument() {
+  clearAndroidDocumentSaveTimer()
+
+  if (!editor || documentState.value.autosaveTarget !== 'android-document') {
+    return
+  }
+
+  const sourceUri = documentState.value.sourceUri
+  if (!sourceUri) {
+    status.value = 'Save failed'
+    androidDocumentLog.error('Android document save missing source URI', {
+      id: documentState.value.id,
+    })
+    return
+  }
+
+  if (!currentAndroidDocumentCanWrite.value) {
+    status.value = 'Read only'
+    androidDocumentLog.debug('skip Android document autosave without write access', {
+      id: documentState.value.id,
+      sourceUri,
+    })
+    return
+  }
+
+  if (!documentState.value.isDirty && documentState.value.autosaveState !== 'save-failed') {
+    return
+  }
+
+  if (androidSaveInFlight) {
+    androidSaveRequestedAfterCurrent = true
+    return
+  }
+
+  const value = normalizeEditorMarkdown(editor.getMarkdown())
+  const nextDocument = updateDocumentMarkdown(documentState.value, value, {
+    markDirty: documentState.value.isDirty,
+  })
+  const markdownForSave = prepareMarkdownForSave(nextDocument.markdown, nextDocument)
+  const saveMarkdown = nextDocument.markdown
+
+  androidSaveInFlight = true
+  documentState.value = markDocumentSaving(nextDocument)
+  status.value = 'Saving'
+
+  try {
+    await writeAndroidMarkdownDocument(sourceUri, markdownForSave)
+    const savedAt = new Date().toISOString()
+
+    if (
+      documentState.value.autosaveTarget === 'android-document' &&
+      documentState.value.sourceUri === sourceUri &&
+      documentState.value.markdown === saveMarkdown
+    ) {
+      documentState.value = markDocumentSaved(
+        updateDocumentMarkdown(documentState.value, saveMarkdown, {
+          markDirty: false,
+          now: savedAt,
+        }),
+        { autosaveTarget: 'android-document', now: savedAt },
+      )
+      markAndroidRecentDocumentSaved(savedAt)
+      status.value = 'Saved'
+      androidDocumentLog.info('Android document autosaved', {
+        sourceUri,
+        characters: saveMarkdown.length,
+      })
+    } else {
+      androidSaveRequestedAfterCurrent = true
+      androidDocumentLog.debug('Android document changed during save; scheduling another save', {
+        sourceUri,
+      })
+    }
+  } catch (error) {
+    documentState.value = markDocumentSaveFailed(documentState.value, error)
+    status.value = 'Save failed'
+    androidDocumentLog.error('Android document autosave failed', {
+      sourceUri,
+      error,
+    })
+  } finally {
+    androidSaveInFlight = false
+    if (androidSaveRequestedAfterCurrent) {
+      androidSaveRequestedAfterCurrent = false
+      if (
+        editor &&
+        documentState.value.autosaveTarget === 'android-document' &&
+        currentAndroidDocumentCanWrite.value
+      ) {
+        scheduleAndroidDocumentSave()
+      }
+    }
   }
 }
 
@@ -308,11 +471,18 @@ function initEditor(initialMarkdown: string) {
     editor.on('content-change', syncMarkdown)
     editor.on('json-change', syncMarkdown)
     editor.on('focus', () => {
-      status.value = 'Editing'
+      status.value =
+        documentState.value.autosaveTarget === 'android-document' &&
+        !currentAndroidDocumentCanWrite.value
+          ? 'Read only'
+          : 'Editing'
       editorLog.debug('editor focused')
     })
     editor.on('blur', () => {
-      status.value = 'Ready'
+      status.value =
+        documentState.value.autosaveTarget === 'android-document'
+          ? getAndroidEditorStatus()
+          : 'Ready'
       editorLog.debug('editor blurred')
     })
     syncMarkdown('Ready')
@@ -350,6 +520,7 @@ function rememberAndroidDocument(document: OpenedAndroidDocument) {
 async function openAndroidDocumentResult(document: OpenedAndroidDocument) {
   homeNotice.value = null
   rememberAndroidDocument(document)
+  currentAndroidDocumentCanWrite.value = document.canWrite
   documentState.value = createDocumentFromAndroidDocument(document)
   androidDocumentLog.info('open Android document in editor', {
     displayName: document.displayName,
@@ -359,7 +530,7 @@ async function openAndroidDocumentResult(document: OpenedAndroidDocument) {
     characters: document.markdown.length,
   })
   await openEditor(document.markdown)
-  status.value = document.canWrite ? 'Opened from Android' : 'Opened read-only'
+  status.value = getAndroidEditorStatus()
 }
 
 async function openFileFromAndroid() {
@@ -400,6 +571,7 @@ async function openDocument(id: string) {
     }
 
     homeNotice.value = null
+    currentAndroidDocumentCanWrite.value = false
     documentState.value = createDocumentFromDraft(draft)
     appLog.info('open recent local document', { id })
     await openEditor(draft.markdown)
@@ -431,6 +603,7 @@ async function openDocument(id: string) {
 function newDocument() {
   homeNotice.value = null
   appLog.info('create new local document')
+  currentAndroidDocumentCanWrite.value = false
   documentState.value = createUntitledDocument({ autosaveTarget: 'local-draft' })
   void openEditor('')
 }
@@ -440,13 +613,18 @@ function destroyEditor() {
     window.clearTimeout(draftSaveTimer)
     draftSaveTimer = null
   }
+  clearAndroidDocumentSaveTimer()
   editor?.destroy()
   editor = null
 }
 
-function showHome() {
+async function showHome() {
   appLog.info('show recent home')
-  saveDraft()
+  if (documentState.value.autosaveTarget === 'android-document') {
+    await saveAndroidDocument()
+  } else {
+    saveDraft()
+  }
   destroyEditor()
   currentScreen.value = 'home'
 }
@@ -498,7 +676,11 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   appLog.info('app before unmount')
-  saveDraft()
+  if (documentState.value.autosaveTarget === 'android-document') {
+    void saveAndroidDocument()
+  } else {
+    saveDraft()
+  }
   destroyEditor()
 })
 </script>

--- a/src/lib/androidDocuments.ts
+++ b/src/lib/androidDocuments.ts
@@ -12,6 +12,16 @@ export interface OpenedAndroidDocument {
   persisted: boolean
 }
 
+export interface SavedAndroidDocument {
+  sourceUri: string
+  displayName: string
+  providerName: string | null
+  pathHint: string | null
+  mimeType: string | null
+  canWrite: boolean
+  persisted: boolean
+}
+
 interface CanceledAndroidDocumentOpen {
   canceled: true
 }
@@ -19,6 +29,7 @@ interface CanceledAndroidDocumentOpen {
 interface AndroidDocumentsPlugin {
   openMarkdownDocument(): Promise<OpenedAndroidDocument | CanceledAndroidDocumentOpen>
   readMarkdownDocument(options: { sourceUri: string }): Promise<OpenedAndroidDocument>
+  writeMarkdownDocument(options: { sourceUri: string; markdown: string }): Promise<SavedAndroidDocument>
 }
 
 export class AndroidDocumentError extends Error {
@@ -52,6 +63,16 @@ export async function readAndroidMarkdownDocument(sourceUri: string) {
   return normalizeOpenedDocument(await AndroidDocuments.readMarkdownDocument({ sourceUri }))
 }
 
+export async function writeAndroidMarkdownDocument(sourceUri: string, markdown: string) {
+  ensureAndroidDocumentsAvailable()
+  return normalizeSavedDocument(
+    await AndroidDocuments.writeMarkdownDocument({
+      sourceUri,
+      markdown,
+    }),
+  )
+}
+
 export function getAndroidDocumentErrorCode(error: unknown) {
   if (error instanceof AndroidDocumentError) {
     return error.code
@@ -83,6 +104,14 @@ export function getAndroidDocumentUserMessage(error: unknown) {
     return 'This recent file can no longer be opened.'
   }
 
+  if (code === 'DOCUMENT_WRITE_PERMISSION_MISSING') {
+    return 'This file is read-only.'
+  }
+
+  if (code === 'DOCUMENT_WRITE_FAILED') {
+    return 'Could not save this Markdown file.'
+  }
+
   return 'Could not open this Markdown file.'
 }
 
@@ -105,6 +134,22 @@ function normalizeOpenedDocument(value: OpenedAndroidDocument): OpenedAndroidDoc
     pathHint: value.pathHint ?? null,
     mimeType: value.mimeType ?? null,
     markdown: value.markdown,
+    canWrite: Boolean(value.canWrite),
+    persisted: Boolean(value.persisted),
+  }
+}
+
+function normalizeSavedDocument(value: SavedAndroidDocument): SavedAndroidDocument {
+  if (!value.sourceUri || !value.displayName) {
+    throw new AndroidDocumentError('INVALID_DOCUMENT_RESULT', 'Android document plugin returned an invalid result')
+  }
+
+  return {
+    sourceUri: value.sourceUri,
+    displayName: value.displayName,
+    providerName: value.providerName ?? null,
+    pathHint: value.pathHint ?? null,
+    mimeType: value.mimeType ?? null,
     canWrite: Boolean(value.canWrite),
     persisted: Boolean(value.persisted),
   }

--- a/src/lib/recentDocuments.test.ts
+++ b/src/lib/recentDocuments.test.ts
@@ -3,6 +3,7 @@ import {
   createRecentDocumentFromAndroidDocument,
   createRecentDocumentFromLocalDraft,
   getRecentDocumentListItems,
+  markRecentDocumentSaved,
   normalizeRecentDocuments,
   parseRecentDocuments,
   serializeRecentDocuments,
@@ -105,6 +106,20 @@ describe('recentDocuments', () => {
 
     expect(records).toHaveLength(1)
     expect(records[0].id).toBe('android-2')
+  })
+
+  it('updates recent document metadata after a save without storing Android markdown', () => {
+    const saved = markRecentDocumentSaved(androidDocument, {
+      markdown: '# Updated Android title\n\nsaved',
+      savedAt: '2026-06-29T00:07:00.000Z',
+      canWrite: true,
+    })
+
+    expect(saved.title).toBe('Updated Android title')
+    expect(saved.updatedAt).toBe('2026-06-29T00:07:00.000Z')
+    expect(saved.lastSavedAt).toBe('2026-06-29T00:07:00.000Z')
+    expect(saved.markdownPreview).toBeNull()
+    expect(saved.canWrite).toBe(true)
   })
 
   it('deduplicates local drafts by id', () => {

--- a/src/lib/recentDocuments.ts
+++ b/src/lib/recentDocuments.ts
@@ -44,6 +44,12 @@ interface AndroidDocumentSource {
   openedAt?: string
 }
 
+interface SavedDocumentOptions {
+  markdown: string
+  savedAt?: string
+  canWrite?: boolean
+}
+
 const DEFAULT_RECENT_LIMIT = 50
 
 function isRecentDocumentKind(value: unknown): value is RecentDocumentKind {
@@ -190,6 +196,22 @@ export function upsertRecentDocument(
     [nextRecord, ...records.filter(record => getRecentDocumentKey(record) !== nextKey)],
     limit,
   )
+}
+
+export function markRecentDocumentSaved(
+  record: RecentDocumentRecord,
+  options: SavedDocumentOptions,
+): RecentDocumentRecord {
+  const savedAt = options.savedAt ?? new Date().toISOString()
+
+  return {
+    ...record,
+    title: getDocumentTitle(options.markdown, record.displayName),
+    updatedAt: savedAt,
+    lastSavedAt: savedAt,
+    autosaveState: 'clean',
+    canWrite: options.canWrite ?? record.canWrite,
+  }
 }
 
 export function getRecentDocumentListItems(


### PR DESCRIPTION
## Summary

This PR adds Android document autosave for Markdown files opened through the Android Storage Access Framework.

- Requests writable SAF access when opening Markdown/plain-text documents.
- Adds a native `writeMarkdownDocument` bridge that writes back to the same `content://` URI with the existing 5 MB guard and Markdown/plain-text validation.
- Adds mobile-style autosave behavior in the editor instead of a desktop Save button.
- Shows lightweight editor status: `Saving`, `Saved`, `Read only`, and `Save failed`.
- Updates recent document metadata after Android document saves without storing Android file contents in localStorage.

Out of scope for this PR: save-as, share/open-with, a full file manager, image handling, or visible developer log UI.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm test:e2e -- --reporter=line`
- `pnpm android:sync`
- `./android/gradlew.bat -p android assembleDebug --no-daemon` with JDK 22
- MuMu/ADB real device path on `127.0.0.1:7555`:
  - installed debug APK
  - opened `/sdcard/Download/marktext-autosave-test.md` through Android DocumentsUI
  - typed into the Muya editor via ADB input
  - confirmed UI returned to `Saved`
  - confirmed file contents were written back on disk
  - confirmed logcat emitted `Wrote Android document` and `Android document autosaved`
  - force-stopped and relaunched the app, then reopened from recent documents to confirm persisted URI read/write access remained available