### PR TITLE
feat: save local drafts as Android documents

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -31,6 +31,7 @@ public class AndroidDocumentsPlugin extends Plugin {
     private static final String TAG = "MarkTextAndroid";
     private static final int MAX_MARKDOWN_BYTES = 5 * 1024 * 1024;
     private static final String CALLBACK_OPEN_MARKDOWN_DOCUMENT = "openMarkdownDocumentResult";
+    private static final String CALLBACK_CREATE_MARKDOWN_DOCUMENT = "createMarkdownDocumentResult";
 
     @PluginMethod
     public void openMarkdownDocument(PluginCall call) {
@@ -57,6 +58,48 @@ public class AndroidDocumentsPlugin extends Plugin {
         } catch (ActivityNotFoundException ex) {
             Log.e(TAG, "No Android document picker is available", ex);
             call.reject("No Android document picker is available", "DOCUMENT_PICKER_UNAVAILABLE", ex);
+        }
+    }
+
+    @PluginMethod
+    public void createMarkdownDocument(PluginCall call) {
+        String markdown = call.getString("markdown", null);
+        if (markdown == null) {
+            call.reject("Markdown content is required", "INVALID_MARKDOWN");
+            return;
+        }
+
+        try {
+            validateMarkdownBytes(markdown);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android document create rejected: " + ex.getMessage());
+            call.reject(ex.getMessage(), ex.code, ex);
+            return;
+        }
+
+        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("text/markdown");
+        intent.putExtra(
+            Intent.EXTRA_MIME_TYPES,
+            new String[] {
+                "text/markdown",
+                "text/x-markdown",
+                "text/plain"
+            }
+        );
+        intent.putExtra(Intent.EXTRA_TITLE, normalizeSuggestedMarkdownName(call.getString("suggestedName", "")));
+        intent.addFlags(
+            Intent.FLAG_GRANT_READ_URI_PERMISSION |
+            Intent.FLAG_GRANT_WRITE_URI_PERMISSION |
+            Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+        );
+
+        try {
+            startActivityForResult(call, intent, CALLBACK_CREATE_MARKDOWN_DOCUMENT);
+        } catch (ActivityNotFoundException ex) {
+            Log.e(TAG, "No Android document creator is available", ex);
+            call.reject("No Android document creator is available", "DOCUMENT_CREATOR_UNAVAILABLE", ex);
         }
     }
 
@@ -109,6 +152,52 @@ public class AndroidDocumentsPlugin extends Plugin {
         } catch (IOException ex) {
             Log.e(TAG, "Failed to write Android document", ex);
             call.reject("Failed to write Android document", "DOCUMENT_WRITE_FAILED", ex);
+        }
+    }
+
+    @ActivityCallback
+    private void createMarkdownDocumentResult(PluginCall call, ActivityResult result) {
+        if (call == null) {
+            Log.w(TAG, "Missing plugin call for Android document create result");
+            return;
+        }
+
+        if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
+            JSObject canceled = new JSObject();
+            canceled.put("canceled", true);
+            call.resolve(canceled);
+            return;
+        }
+
+        String markdown = call.getString("markdown", null);
+        if (markdown == null) {
+            call.reject("Markdown content is required", "INVALID_MARKDOWN");
+            return;
+        }
+
+        Intent data = result.getData();
+        Uri uri = data.getData();
+        if (uri == null) {
+            call.reject("Android document creator returned no URI", "DOCUMENT_URI_MISSING");
+            return;
+        }
+
+        try {
+            JSObject document = createDocumentResult(uri, data, markdown);
+            persistUriPermission(uri, data);
+            document.put("persisted", hasPersistedReadPermission(uri));
+            document.put("canWrite", canWrite(uri, data));
+            Log.i(TAG, "Created Android document: " + safeForLog(document.getString("displayName")));
+            call.resolve(document);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android document create rejected: " + ex.getMessage());
+            call.reject(ex.getMessage(), ex.code, ex);
+        } catch (SecurityException ex) {
+            Log.e(TAG, "Missing write permission for created Android document", ex);
+            call.reject("Missing write permission for Android document", "DOCUMENT_WRITE_PERMISSION_MISSING", ex);
+        } catch (IOException ex) {
+            Log.e(TAG, "Failed to create Android document", ex);
+            call.reject("Failed to create Android document", "DOCUMENT_WRITE_FAILED", ex);
         }
     }
 
@@ -173,6 +262,25 @@ public class AndroidDocumentsPlugin extends Plugin {
         return result;
     }
 
+    private JSObject createDocumentResult(Uri uri, Intent grantIntent, String markdown) throws IOException, DocumentReadException {
+        byte[] bytes = validateMarkdownBytes(markdown);
+        writeText(uri, bytes);
+
+        String displayName = getDisplayName(uri);
+        String mimeType = getMimeType(uri);
+        JSObject result = new JSObject();
+        result.put("canceled", false);
+        result.put("sourceUri", uri.toString());
+        result.put("displayName", displayName);
+        result.put("providerName", getProviderName(uri));
+        result.put("pathHint", displayName);
+        result.put("mimeType", mimeType);
+        result.put("markdown", markdown);
+        result.put("canWrite", canWrite(uri, grantIntent));
+        result.put("persisted", hasPersistedReadPermission(uri));
+        return result;
+    }
+
     private JSObject writeDocumentResult(Uri uri, String markdown) throws IOException, DocumentReadException {
         String displayName = getDisplayName(uri);
         String mimeType = getMimeType(uri);
@@ -183,14 +291,7 @@ public class AndroidDocumentsPlugin extends Plugin {
             );
         }
 
-        byte[] bytes = markdown.getBytes(StandardCharsets.UTF_8);
-        if (bytes.length > MAX_MARKDOWN_BYTES) {
-            throw new DocumentReadException(
-                "DOCUMENT_TOO_LARGE",
-                "Markdown document is larger than the current 5 MB limit"
-            );
-        }
-
+        byte[] bytes = validateMarkdownBytes(markdown);
         writeText(uri, bytes);
         JSObject result = new JSObject();
         result.put("sourceUri", uri.toString());
@@ -213,6 +314,38 @@ public class AndroidDocumentsPlugin extends Plugin {
             return null;
         }
         return uri;
+    }
+
+    private byte[] validateMarkdownBytes(String markdown) throws DocumentReadException {
+        byte[] bytes = markdown.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length > MAX_MARKDOWN_BYTES) {
+            throw new DocumentReadException(
+                "DOCUMENT_TOO_LARGE",
+                "Markdown document is larger than the current 5 MB limit"
+            );
+        }
+        return bytes;
+    }
+
+    private String normalizeSuggestedMarkdownName(String suggestedName) {
+        String cleaned = suggestedName == null ? "" : suggestedName.trim();
+        cleaned = cleaned.replaceAll("[\\\\/:*?\"<>|\\r\\n]+", " ");
+        cleaned = cleaned.replaceAll("\\s+", " ").trim();
+        if (cleaned.length() == 0) {
+            cleaned = "Untitled";
+        }
+
+        String lowerName = cleaned.toLowerCase(Locale.US);
+        if (
+            lowerName.endsWith(".md") ||
+            lowerName.endsWith(".markdown") ||
+            lowerName.endsWith(".mdown") ||
+            lowerName.endsWith(".mkdn") ||
+            lowerName.endsWith(".mkd")
+        ) {
+            return cleaned;
+        }
+        return cleaned + ".md";
     }
 
     private void persistUriPermission(Uri uri, Intent data) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,8 +10,10 @@ import {
 } from '@muyajs/core'
 import DocumentHome from './components/DocumentHome.vue'
 import {
+  createAndroidMarkdownDocument,
   getAndroidDocumentErrorCode,
   getAndroidDocumentUserMessage,
+  isAndroidDocumentAccessAvailable,
   openAndroidMarkdownDocument,
   readAndroidMarkdownDocument,
   writeAndroidMarkdownDocument,
@@ -19,6 +21,7 @@ import {
 } from './lib/androidDocuments'
 import {
   createUntitledDocument,
+  getSuggestedMarkdownFileName,
   markDocumentSaved,
   markDocumentSaveFailed,
   markDocumentSaving,
@@ -50,6 +53,8 @@ const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
 const RECENT_DOCUMENTS_STORAGE_KEY = 'marktext-for-android:recent-documents'
 const DRAFT_SAVE_DELAY_MS = 800
 const ANDROID_DOCUMENT_SAVE_DELAY_MS = 1200
+const TRANSIENT_ANDROID_DOCUMENT_MESSAGE =
+  'Saved to device. Kept local draft because Android did not grant long-term access.'
 
 const editorPlugins = [
   InlineFormatToolbar,
@@ -66,6 +71,10 @@ const currentAndroidDocumentCanWrite = ref(false)
 const status = ref('Ready')
 const homeNotice = ref<string | null>(null)
 const currentScreen = ref<'home' | 'editor'>('home')
+const draftExitPromptOpen = ref(false)
+const editorMenuOpen = ref(false)
+const promptLocalDraftSaveOnExit = ref(false)
+const savingLocalDraftToAndroid = ref(false)
 
 let editor: Muya | null = null
 let lastContentLogAt = 0
@@ -142,6 +151,22 @@ function getAndroidEditorStatus() {
   return 'Saved'
 }
 
+function isLocalDraftDocument() {
+  return documentState.value.autosaveTarget === 'local-draft'
+}
+
+function hasDraftContent() {
+  return documentState.value.markdown.trim().length > 0
+}
+
+function shouldPromptLocalDraftSaveToDevice() {
+  return promptLocalDraftSaveOnExit.value && isLocalDraftDocument() && hasDraftContent()
+}
+
+function canSaveLocalDraftToAndroidDocument() {
+  return isLocalDraftDocument() && isAndroidDocumentAccessAvailable()
+}
+
 function registerMuyaPlugins() {
   editorLog.debug('register Muya plugins start', { count: editorPlugins.length })
   for (const plugin of editorPlugins) {
@@ -182,6 +207,16 @@ function createDocumentFromAndroidDocument(document: OpenedAndroidDocument) {
 
 function normalizeEditorMarkdown(markdown: string) {
   return markdown === '\n' ? '' : markdown
+}
+
+function syncDocumentFromEditor(markDirty = false) {
+  if (!editor) {
+    return documentState.value
+  }
+
+  const value = normalizeEditorMarkdown(editor.getMarkdown())
+  documentState.value = updateDocumentMarkdown(documentState.value, value, { markDirty })
+  return documentState.value
 }
 
 function syncMarkdown(nextStatus: unknown = 'Edited') {
@@ -390,6 +425,99 @@ async function saveAndroidDocument() {
   }
 }
 
+async function saveLocalDraftToAndroidDocument(options: { returnHomeAfterSave?: boolean } = {}) {
+  editorMenuOpen.value = false
+
+  if (!editor || !isLocalDraftDocument() || savingLocalDraftToAndroid.value) {
+    return false
+  }
+
+  saveDraft()
+  const draftDocument = syncDocumentFromEditor(false)
+  if (!draftDocument.markdown.trim()) {
+    status.value = 'Ready'
+    return false
+  }
+
+  const reopenPromptOnCancel = draftExitPromptOpen.value && options.returnHomeAfterSave === true
+  draftExitPromptOpen.value = false
+  savingLocalDraftToAndroid.value = true
+  status.value = 'Choose a location'
+
+  try {
+    const markdownForSave = prepareMarkdownForSave(draftDocument.markdown, draftDocument)
+    const suggestedName = getSuggestedMarkdownFileName(
+      draftDocument.markdown,
+      draftDocument.displayName,
+    )
+    const document = await createAndroidMarkdownDocument(markdownForSave, suggestedName)
+    if (document.canceled) {
+      status.value = 'Autosaved locally'
+      if (reopenPromptOnCancel) {
+        draftExitPromptOpen.value = true
+      }
+      androidDocumentLog.info('Android document create canceled')
+      return false
+    }
+
+    const savedAt = new Date().toISOString()
+    const createdDocument = {
+      ...document,
+      markdown: draftDocument.markdown,
+    }
+
+    if (!document.persisted) {
+      status.value = TRANSIENT_ANDROID_DOCUMENT_MESSAGE
+      homeNotice.value = TRANSIENT_ANDROID_DOCUMENT_MESSAGE
+      currentAndroidDocumentCanWrite.value = false
+      androidDocumentLog.warn('created Android document without persisted access; kept local draft', {
+        displayName: document.displayName,
+        sourceUri: document.sourceUri,
+        characters: draftDocument.markdown.length,
+      })
+
+      if (options.returnHomeAfterSave) {
+        closeEditorToHome()
+      }
+      return false
+    }
+
+    persistLocalDrafts(removeLocalDraft(localDrafts.value, draftDocument.id))
+    rememberAndroidDocument(createdDocument)
+    currentAndroidDocumentCanWrite.value = document.canWrite
+    promptLocalDraftSaveOnExit.value = false
+    documentState.value = markDocumentSaved(
+      {
+        ...createDocumentFromAndroidDocument(createdDocument),
+        updatedAt: savedAt,
+        lastSavedAt: savedAt,
+      },
+      { autosaveTarget: 'android-document', now: savedAt },
+    )
+    status.value = getAndroidEditorStatus()
+    androidDocumentLog.info('local draft saved as Android document', {
+      displayName: document.displayName,
+      sourceUri: document.sourceUri,
+      characters: draftDocument.markdown.length,
+    })
+
+    if (options.returnHomeAfterSave) {
+      closeEditorToHome()
+    }
+    return true
+  } catch (error) {
+    documentState.value = markDocumentSaveFailed(documentState.value, error)
+    status.value = getAndroidDocumentUserMessage(error)
+    if (reopenPromptOnCancel) {
+      draftExitPromptOpen.value = true
+    }
+    androidDocumentLog.error('local draft save to Android document failed', error)
+    return false
+  } finally {
+    savingLocalDraftToAndroid.value = false
+  }
+}
+
 function saveDraft() {
   if (!editor) {
     return
@@ -520,6 +648,7 @@ function rememberAndroidDocument(document: OpenedAndroidDocument) {
 async function openAndroidDocumentResult(document: OpenedAndroidDocument) {
   homeNotice.value = null
   rememberAndroidDocument(document)
+  promptLocalDraftSaveOnExit.value = false
   currentAndroidDocumentCanWrite.value = document.canWrite
   documentState.value = createDocumentFromAndroidDocument(document)
   androidDocumentLog.info('open Android document in editor', {
@@ -571,6 +700,7 @@ async function openDocument(id: string) {
     }
 
     homeNotice.value = null
+    promptLocalDraftSaveOnExit.value = false
     currentAndroidDocumentCanWrite.value = false
     documentState.value = createDocumentFromDraft(draft)
     appLog.info('open recent local document', { id })
@@ -604,8 +734,13 @@ function newDocument() {
   homeNotice.value = null
   appLog.info('create new local document')
   currentAndroidDocumentCanWrite.value = false
+  promptLocalDraftSaveOnExit.value = true
   documentState.value = createUntitledDocument({ autosaveTarget: 'local-draft' })
   void openEditor('')
+}
+
+function toggleEditorMenu() {
+  editorMenuOpen.value = !editorMenuOpen.value
 }
 
 function destroyEditor() {
@@ -618,15 +753,40 @@ function destroyEditor() {
   editor = null
 }
 
+function closeEditorToHome() {
+  draftExitPromptOpen.value = false
+  editorMenuOpen.value = false
+  destroyEditor()
+  currentScreen.value = 'home'
+}
+
 async function showHome() {
   appLog.info('show recent home')
+  editorMenuOpen.value = false
   if (documentState.value.autosaveTarget === 'android-document') {
     await saveAndroidDocument()
   } else {
     saveDraft()
+    if (shouldPromptLocalDraftSaveToDevice()) {
+      draftExitPromptOpen.value = true
+      return
+    }
   }
-  destroyEditor()
-  currentScreen.value = 'home'
+  closeEditorToHome()
+}
+
+function keepLocalDraftAndShowHome() {
+  appLog.info('keep local draft and show recent home')
+  promptLocalDraftSaveOnExit.value = false
+  saveDraft()
+  closeEditorToHome()
+}
+
+function discardLocalDraftAndShowHome() {
+  appLog.info('discard local draft and show recent home', { id: documentState.value.id })
+  promptLocalDraftSaveOnExit.value = false
+  persistLocalDrafts(removeLocalDraft(localDrafts.value, documentState.value.id))
+  closeEditorToHome()
 }
 
 onMounted(() => {
@@ -705,6 +865,29 @@ onBeforeUnmount(() => {
         <h1>{{ documentTitle }}</h1>
         <p>{{ status }}</p>
       </div>
+      <div v-if="canSaveLocalDraftToAndroidDocument()" class="editor-actions">
+        <button
+          class="menu-button"
+          type="button"
+          aria-label="More actions"
+          :aria-expanded="editorMenuOpen"
+          data-testid="editor-menu-button"
+          @click="toggleEditorMenu"
+        >
+          ...
+        </button>
+        <div v-if="editorMenuOpen" class="editor-menu" role="menu">
+          <button
+            type="button"
+            role="menuitem"
+            data-testid="save-to-device-button"
+            :disabled="savingLocalDraftToAndroid"
+            @click="() => saveLocalDraftToAndroidDocument()"
+          >
+            Save to device
+          </button>
+        </div>
+      </div>
     </header>
 
     <section class="editor-pane" aria-label="Markdown editor">
@@ -716,5 +899,48 @@ onBeforeUnmount(() => {
       <span>{{ characterCount }} chars</span>
       <span>{{ lineCount }} lines</span>
     </footer>
+
+    <section
+      v-if="draftExitPromptOpen"
+      class="draft-save-sheet"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="draft-save-title"
+      data-testid="draft-save-prompt"
+    >
+      <div class="draft-save-panel">
+        <h2 id="draft-save-title">Save this draft to your device?</h2>
+        <p>This draft is saved inside MarkText, but it has not been saved as a Markdown file yet.</p>
+        <div class="draft-save-actions">
+          <button
+            v-if="canSaveLocalDraftToAndroidDocument()"
+            class="primary-action"
+            type="button"
+            data-testid="prompt-save-to-device-button"
+            :disabled="savingLocalDraftToAndroid"
+            @click="saveLocalDraftToAndroidDocument({ returnHomeAfterSave: true })"
+          >
+            Save to device
+          </button>
+          <button
+            type="button"
+            data-testid="prompt-keep-draft-button"
+            :disabled="savingLocalDraftToAndroid"
+            @click="keepLocalDraftAndShowHome"
+          >
+            Keep as draft
+          </button>
+          <button
+            class="danger-action"
+            type="button"
+            data-testid="prompt-discard-draft-button"
+            :disabled="savingLocalDraftToAndroid"
+            @click="discardLocalDraftAndShowHome"
+          >
+            Discard
+          </button>
+        </div>
+      </div>
+    </section>
   </main>
 </template>

--- a/src/lib/androidDocuments.ts
+++ b/src/lib/androidDocuments.ts
@@ -27,6 +27,10 @@ interface CanceledAndroidDocumentOpen {
 }
 
 interface AndroidDocumentsPlugin {
+  createMarkdownDocument(options: {
+    markdown: string
+    suggestedName: string
+  }): Promise<OpenedAndroidDocument | CanceledAndroidDocumentOpen>
   openMarkdownDocument(): Promise<OpenedAndroidDocument | CanceledAndroidDocumentOpen>
   readMarkdownDocument(options: { sourceUri: string }): Promise<OpenedAndroidDocument>
   writeMarkdownDocument(options: { sourceUri: string; markdown: string }): Promise<SavedAndroidDocument>
@@ -51,6 +55,19 @@ export function isAndroidDocumentAccessAvailable() {
 export async function openAndroidMarkdownDocument() {
   ensureAndroidDocumentsAvailable()
   const result = await AndroidDocuments.openMarkdownDocument()
+  if (result.canceled) {
+    return result
+  }
+
+  return normalizeOpenedDocument(result)
+}
+
+export async function createAndroidMarkdownDocument(markdown: string, suggestedName: string) {
+  ensureAndroidDocumentsAvailable()
+  const result = await AndroidDocuments.createMarkdownDocument({
+    markdown,
+    suggestedName,
+  })
   if (result.canceled) {
     return result
   }
@@ -110,6 +127,10 @@ export function getAndroidDocumentUserMessage(error: unknown) {
 
   if (code === 'DOCUMENT_WRITE_FAILED') {
     return 'Could not save this Markdown file.'
+  }
+
+  if (code === 'DOCUMENT_CREATOR_UNAVAILABLE') {
+    return 'Could not create a Markdown file on this device.'
   }
 
   return 'Could not open this Markdown file.'

--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -3,6 +3,7 @@ import {
   createUntitledDocument,
   getDocumentStats,
   getDocumentTitle,
+  getSuggestedMarkdownFileName,
   normalizeMarkdownForEditor,
   prepareMarkdownForSave,
   updateDocumentMarkdown,
@@ -17,6 +18,14 @@ describe('documentState', () => {
 
   it('falls back to the display name without markdown extension', () => {
     expect(getDocumentTitle('plain text', 'notes.md')).toBe('notes')
+  })
+
+  it('suggests a Markdown file name from the first heading', () => {
+    expect(getSuggestedMarkdownFileName('# Trip notes\n\nbody', 'draft.md')).toBe('Trip notes.md')
+  })
+
+  it('sanitizes suggested Markdown file names for Android document creation', () => {
+    expect(getSuggestedMarkdownFileName('# Meeting: A/B?')).toBe('Meeting A B.md')
   })
 
   it('counts latin words and CJK characters for mobile status text', () => {

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -56,6 +56,7 @@ interface SaveDocumentOptions {
 
 const DEFAULT_UNTITLED_NAME = 'Untitled-1'
 const MARKDOWN_EXTENSION_REGEXP = /\.(markdown|mdown|mkdn|mkd|md)$/i
+const INVALID_FILENAME_CHARS_REGEXP = /[\\/:*?"<>|\r\n]+/g
 const LINE_ENDING_REGEXP = /\r\n|\r|\n/g
 
 function createDocumentId() {
@@ -176,6 +177,17 @@ export function getDocumentTitle(markdown: string, displayName = DEFAULT_UNTITLE
     .find(Boolean)
 
   return heading || stripMarkdownExtension(displayName) || 'Untitled'
+}
+
+export function getSuggestedMarkdownFileName(markdown: string, displayName = DEFAULT_UNTITLED_NAME) {
+  const title = getDocumentTitle(markdown, displayName)
+  const baseName = stripMarkdownExtension(title)
+    .replace(INVALID_FILENAME_CHARS_REGEXP, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  const safeName = baseName || 'Untitled'
+  return MARKDOWN_EXTENSION_REGEXP.test(safeName) ? safeName : `${safeName}.md`
 }
 
 export function createUntitledDocument(options: CreateDocumentOptions = {}): MarkdownDocumentState {

--- a/src/style.css
+++ b/src/style.css
@@ -251,7 +251,7 @@ body {
 
 .top-bar {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 12px;
   min-height: 68px;
@@ -263,6 +263,63 @@ body {
 
 .nav-button {
   padding: 0 12px;
+}
+
+.editor-actions {
+  position: relative;
+}
+
+.menu-button {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 18px;
+  font-weight: 760;
+  line-height: 1;
+}
+
+.menu-button:active {
+  transform: translateY(1px);
+}
+
+.editor-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 10;
+  width: 180px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.editor-menu button {
+  width: 100%;
+  min-height: 46px;
+  padding: 0 14px;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  text-align: left;
+}
+
+.editor-menu button:active {
+  background: var(--surface-muted);
+}
+
+.editor-menu button:disabled {
+  color: var(--text-muted);
 }
 
 .document-heading {
@@ -331,6 +388,76 @@ body {
   background: var(--surface-muted);
   font-size: 12px;
   line-height: 1.2;
+}
+
+.draft-save-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  align-items: end;
+  padding: 18px;
+  background: rgba(31, 42, 46, 0.38);
+}
+
+.draft-save-panel {
+  width: min(100%, 520px);
+  margin: 0 auto;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.draft-save-panel h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 19px;
+  line-height: 1.25;
+  font-weight: 760;
+}
+
+.draft-save-panel p {
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.42;
+}
+
+.draft-save-actions {
+  display: grid;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.draft-save-actions button {
+  min-height: 46px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 760;
+}
+
+.draft-save-actions button:active {
+  transform: translateY(1px);
+}
+
+.draft-save-actions button:disabled {
+  color: var(--text-muted);
+}
+
+.draft-save-actions .primary-action {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--surface);
+}
+
+.draft-save-actions .danger-action {
+  color: #9b2f2f;
 }
 
 @media (max-width: 720px) {

--- a/tests/e2e/mobile-recent-home.spec.ts
+++ b/tests/e2e/mobile-recent-home.spec.ts
@@ -1,4 +1,62 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
+
+async function installTransientAndroidCreateMock(page: Page) {
+  await page.addInitScript(() => {
+    const win = window as unknown as {
+      androidBridge?: unknown
+      Capacitor?: {
+        PluginHeaders?: Array<{
+          name: string
+          methods: Array<{ name: string; rtype: string }>
+        }>
+        nativePromise?: (
+          pluginName: string,
+          methodName: string,
+          options?: Record<string, unknown>,
+        ) => Promise<unknown>
+      }
+    }
+
+    win.androidBridge = {}
+    win.Capacitor = {
+      ...(win.Capacitor ?? {}),
+      PluginHeaders: [
+        {
+          name: 'AndroidDocuments',
+          methods: [
+            { name: 'createMarkdownDocument', rtype: 'promise' },
+            { name: 'openMarkdownDocument', rtype: 'promise' },
+            { name: 'readMarkdownDocument', rtype: 'promise' },
+            { name: 'writeMarkdownDocument', rtype: 'promise' },
+          ],
+        },
+      ],
+      nativePromise(pluginName, methodName, options = {}) {
+        if (pluginName === 'AndroidDocuments' && methodName === 'createMarkdownDocument') {
+          const markdown = typeof options.markdown === 'string' ? options.markdown : ''
+          const displayName =
+            typeof options.suggestedName === 'string' ? options.suggestedName : 'Transient.md'
+          return Promise.resolve({
+            canceled: false,
+            sourceUri: 'content://test/transient-document',
+            displayName,
+            providerName: 'Test Documents',
+            pathHint: displayName,
+            mimeType: 'text/markdown',
+            markdown,
+            canWrite: true,
+            persisted: false,
+          })
+        }
+
+        return Promise.reject({
+          code: 'UNIMPLEMENTED',
+          message: `${pluginName}.${methodName} is not mocked`,
+        })
+      },
+    }
+  })
+}
 
 test('creates a local draft from real editor input and returns it to the recent home', async ({
   page,
@@ -30,11 +88,50 @@ test('creates a local draft from real editor input and returns it to the recent 
 
   await page.getByTestId('back-button').click()
 
+  await expect(page.getByTestId('draft-save-prompt')).toBeVisible()
+  await expect(page.getByText('Save this draft to your device?')).toBeVisible()
+  await expect(page.getByTestId('prompt-save-to-device-button')).toBeHidden()
+  await page.getByTestId('prompt-keep-draft-button').click()
+
   await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
   await expect(page.getByText('Continue writing')).toBeVisible()
   await expect(page.getByText('Fresh mobile note')).toBeVisible()
   await expect(page.getByText('No recent Markdown files')).toBeHidden()
   await expect(page.getByTestId('new-document-button')).toBeVisible()
+})
+
+test('keeps the local draft when Android document access is not persisted', async ({ page }) => {
+  await installTransientAndroidCreateMock(page)
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+
+  await page.getByTestId('new-document-button').click()
+  await expect(page.getByTestId('editor-host')).toBeVisible()
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('# Transient grant note')
+  await page.keyboard.press('Enter')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('this should stay recoverable as a local draft')
+
+  await page.getByTestId('back-button').click()
+  await expect(page.getByTestId('draft-save-prompt')).toBeVisible()
+  await expect(page.getByTestId('prompt-save-to-device-button')).toBeVisible()
+  await page.getByTestId('prompt-save-to-device-button').click()
+
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  await expect(
+    page.getByText('Saved to device. Kept local draft because Android did not grant long-term access.'),
+  ).toBeVisible()
+  await expect(page.getByText('Transient grant note')).toBeVisible()
+
+  const storage = await page.evaluate(() => ({
+    drafts: localStorage.getItem('marktext-for-android:drafts') ?? '',
+    androidRecentDocuments: localStorage.getItem('marktext-for-android:recent-documents') ?? '',
+  }))
+  expect(storage.drafts).toContain('Transient grant note')
+  expect(storage.androidRecentDocuments).not.toContain('content://test/transient-document')
 })
 
 test('keeps the Android open-file action nonfatal in the browser shell', async ({ page }) => {


### PR DESCRIPTION
## Summary

This PR completes the local draft to Android document path for the mobile editor.

- Adds Android SAF create-document support for Markdown files.
- Saves local draft content into the selected `content://` document and persists read/write URI permission.
- Promotes the draft into an Android document only after long-term URI access is confirmed.
- Keeps the local draft as a recovery path if Android writes the file but does not grant persisted access.
- Adds a mobile exit prompt for newly created local drafts with `Save to device`, `Keep as draft`, and `Discard`.
- Hides Android-only save-to-device controls in the browser shell and keeps browser failures nonfatal.

Out of scope: share/open-with, images, broad file manager behavior, system back handling, and conflict detection.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm test:e2e -- --reporter=line`
- `pnpm android:sync`
- `./android/gradlew.bat -p android assembleDebug --no-daemon`
- MuMu/ADB real flow:
  - installed the debug APK
  - created a new local draft
  - used the mobile exit prompt to save through Android DocumentsUI
  - verified `/sdcard/Download/PR6PersistedFixTest.md` exists with the expected Markdown content
  - verified logcat reached `Created Android document` and `local draft saved as Android document`

## Review fixes included

- If a provider returns `persisted:false`, the app no longer deletes the local draft or promotes the transient URI as the only continuation path.
- Browser shell no longer exposes Android-only save-to-device controls, and the save path uses the same Android document user-message mapping as open-file errors.