### PR TITLE
Improve Android document error recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 # Local agent handoff notes
 HANDOFF.md
 todolist.md
+AGENTS.md
 
 # Environment
 .env

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -19,6 +19,7 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.ActivityCallback;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -119,7 +120,13 @@ public class AndroidDocumentsPlugin extends Plugin {
         } catch (DocumentReadException ex) {
             Log.w(TAG, "Android document read rejected: " + ex.getMessage());
             call.reject(ex.getMessage(), ex.code, ex);
-        } catch (IOException | SecurityException ex) {
+        } catch (FileNotFoundException ex) {
+            Log.w(TAG, "Android document no longer exists", ex);
+            call.reject("This Android document was moved or deleted", "DOCUMENT_NOT_FOUND", ex);
+        } catch (SecurityException ex) {
+            Log.w(TAG, "Android document read permission is no longer available", ex);
+            call.reject("Android document permission is no longer available", "DOCUMENT_PERMISSION_LOST", ex);
+        } catch (IOException ex) {
             Log.e(TAG, "Failed to read Android document", ex);
             call.reject("Failed to read Android document", "DOCUMENT_READ_FAILED", ex);
         }
@@ -146,9 +153,12 @@ public class AndroidDocumentsPlugin extends Plugin {
         } catch (DocumentReadException ex) {
             Log.w(TAG, "Android document write rejected: " + ex.getMessage());
             call.reject(ex.getMessage(), ex.code, ex);
+        } catch (FileNotFoundException ex) {
+            Log.w(TAG, "Android document no longer exists", ex);
+            call.reject("This Android document was moved or deleted", "DOCUMENT_NOT_FOUND", ex);
         } catch (SecurityException ex) {
-            Log.e(TAG, "Missing write permission for Android document", ex);
-            call.reject("Missing write permission for Android document", "DOCUMENT_WRITE_PERMISSION_MISSING", ex);
+            Log.w(TAG, "Android document write permission is no longer available", ex);
+            call.reject("Android document permission is no longer available", "DOCUMENT_PERMISSION_LOST", ex);
         } catch (IOException ex) {
             Log.e(TAG, "Failed to write Android document", ex);
             call.reject("Failed to write Android document", "DOCUMENT_WRITE_FAILED", ex);
@@ -232,7 +242,13 @@ public class AndroidDocumentsPlugin extends Plugin {
         } catch (DocumentReadException ex) {
             Log.w(TAG, "Android document open rejected: " + ex.getMessage());
             call.reject(ex.getMessage(), ex.code, ex);
-        } catch (IOException | SecurityException ex) {
+        } catch (FileNotFoundException ex) {
+            Log.w(TAG, "Android document no longer exists", ex);
+            call.reject("This Android document was moved or deleted", "DOCUMENT_NOT_FOUND", ex);
+        } catch (SecurityException ex) {
+            Log.w(TAG, "Android document read permission is no longer available", ex);
+            call.reject("Android document permission is no longer available", "DOCUMENT_PERMISSION_LOST", ex);
+        } catch (IOException ex) {
             Log.e(TAG, "Failed to open Android document", ex);
             call.reject("Failed to open Android document", "DOCUMENT_READ_FAILED", ex);
         }

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,6 +57,8 @@ const DRAFT_SAVE_DELAY_MS = 800
 const ANDROID_DOCUMENT_SAVE_DELAY_MS = 1200
 const TRANSIENT_ANDROID_DOCUMENT_MESSAGE =
   'Saved to device. Kept local draft because Android did not grant long-term access.'
+const ANDROID_RECOVERY_DRAFT_PREFIX = 'android-recovery:'
+const ANDROID_SAVE_RECOVERY_MESSAGE = 'Save failed. A local recovery draft was kept.'
 
 const editorPlugins = [
   InlineFormatToolbar,
@@ -317,6 +319,37 @@ function persistAndroidRecentDocuments(nextDocuments: RecentDocumentRecord[]) {
   }
 }
 
+function getAndroidRecoveryDraftId(sourceUri: string) {
+  return `${ANDROID_RECOVERY_DRAFT_PREFIX}${sourceUri}`
+}
+
+function persistAndroidRecoveryDraft(sourceUri: string, markdown: string) {
+  if (!markdown.trim()) {
+    return
+  }
+
+  const now = new Date().toISOString()
+  persistLocalDrafts(
+    upsertLocalDraft(localDrafts.value, {
+      id: getAndroidRecoveryDraftId(sourceUri),
+      markdown,
+      updatedAt: now,
+      lastSavedAt: null,
+    }),
+  )
+  draftLog.warn('kept Android document edits as a local recovery draft', {
+    sourceUri,
+    characters: markdown.length,
+  })
+}
+
+function removeAndroidRecoveryDraft(sourceUri: string) {
+  const recoveryDraftId = getAndroidRecoveryDraftId(sourceUri)
+  if (localDrafts.value.some(draft => draft.id === recoveryDraftId)) {
+    persistLocalDrafts(removeLocalDraft(localDrafts.value, recoveryDraftId))
+  }
+}
+
 function markAndroidRecentDocumentSaved(savedAt: string) {
   const sourceUri = documentState.value.sourceUri
   if (!sourceUri) {
@@ -339,13 +372,14 @@ function markAndroidRecentDocumentSaved(savedAt: string) {
       }),
     ),
   )
+  removeAndroidRecoveryDraft(sourceUri)
 }
 
 async function saveAndroidDocument() {
   clearAndroidDocumentSaveTimer()
 
   if (!editor || documentState.value.autosaveTarget !== 'android-document') {
-    return
+    return true
   }
 
   const sourceUri = documentState.value.sourceUri
@@ -354,25 +388,25 @@ async function saveAndroidDocument() {
     androidDocumentLog.error('Android document save missing source URI', {
       id: documentState.value.id,
     })
-    return
+    return false
   }
 
   if (!currentAndroidDocumentCanWrite.value) {
-    status.value = 'Read only'
+    status.value = documentState.value.isDirty ? 'This file is read-only.' : 'Read only'
     androidDocumentLog.debug('skip Android document autosave without write access', {
       id: documentState.value.id,
       sourceUri,
     })
-    return
+    return !documentState.value.isDirty
   }
 
   if (!documentState.value.isDirty && documentState.value.autosaveState !== 'save-failed') {
-    return
+    return true
   }
 
   if (androidSaveInFlight) {
     androidSaveRequestedAfterCurrent = true
-    return
+    return false
   }
 
   const value = normalizeEditorMarkdown(editor.getMarkdown())
@@ -408,19 +442,23 @@ async function saveAndroidDocument() {
         sourceUri,
         characters: saveMarkdown.length,
       })
+      return true
     } else {
       androidSaveRequestedAfterCurrent = true
       androidDocumentLog.debug('Android document changed during save; scheduling another save', {
         sourceUri,
       })
+      return false
     }
   } catch (error) {
     documentState.value = markDocumentSaveFailed(documentState.value, error)
-    status.value = 'Save failed'
+    persistAndroidRecoveryDraft(sourceUri, saveMarkdown)
+    status.value = `${getAndroidDocumentUserMessage(error)} ${ANDROID_SAVE_RECOVERY_MESSAGE}`
     androidDocumentLog.error('Android document autosave failed', {
       sourceUri,
       error,
     })
+    return false
   } finally {
     androidSaveInFlight = false
     if (androidSaveRequestedAfterCurrent) {
@@ -786,7 +824,10 @@ async function showHome() {
   appLog.info('show recent home')
   editorMenuOpen.value = false
   if (documentState.value.autosaveTarget === 'android-document') {
-    await saveAndroidDocument()
+    const saved = await saveAndroidDocument()
+    if (!saved) {
+      return
+    }
   } else {
     saveDraft()
     if (shouldPromptLocalDraftSaveToDevice()) {

--- a/src/lib/androidDocuments.test.ts
+++ b/src/lib/androidDocuments.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AndroidDocumentError,
+  getAndroidDocumentErrorCode,
+  getAndroidDocumentUserMessage,
+} from './androidDocuments'
+
+describe('androidDocuments', () => {
+  it('reads Capacitor-style document error codes', () => {
+    expect(
+      getAndroidDocumentErrorCode({
+        code: 'DOCUMENT_NOT_FOUND',
+        message: 'missing',
+      }),
+    ).toBe('DOCUMENT_NOT_FOUND')
+  })
+
+  it('reads local AndroidDocumentError codes', () => {
+    expect(
+      getAndroidDocumentErrorCode(
+        new AndroidDocumentError('DOCUMENT_PERMISSION_LOST', 'permission lost'),
+      ),
+    ).toBe('DOCUMENT_PERMISSION_LOST')
+  })
+
+  it('maps recoverable Android document failures to user messages', () => {
+    expect(getAndroidDocumentUserMessage({ code: 'DOCUMENT_NOT_FOUND' })).toBe(
+      'This file was moved or deleted. Open it again from Android.',
+    )
+    expect(getAndroidDocumentUserMessage({ code: 'DOCUMENT_PERMISSION_LOST' })).toBe(
+      'Reopen this file from Android before saving again.',
+    )
+    expect(getAndroidDocumentUserMessage({ code: 'DOCUMENT_READ_FAILED' })).toBe(
+      'Could not read this Markdown file.',
+    )
+    expect(getAndroidDocumentUserMessage({ code: 'DOCUMENT_WRITE_FAILED' })).toBe(
+      'Could not save this Markdown file.',
+    )
+  })
+})

--- a/src/lib/androidDocuments.ts
+++ b/src/lib/androidDocuments.ts
@@ -121,6 +121,18 @@ export function getAndroidDocumentUserMessage(error: unknown) {
     return 'This recent file can no longer be opened.'
   }
 
+  if (code === 'DOCUMENT_NOT_FOUND') {
+    return 'This file was moved or deleted. Open it again from Android.'
+  }
+
+  if (code === 'DOCUMENT_PERMISSION_LOST') {
+    return 'Reopen this file from Android before saving again.'
+  }
+
+  if (code === 'DOCUMENT_READ_FAILED') {
+    return 'Could not read this Markdown file.'
+  }
+
   if (code === 'DOCUMENT_WRITE_PERMISSION_MISSING') {
     return 'This file is read-only.'
   }

--- a/tests/e2e/mobile-recent-home.spec.ts
+++ b/tests/e2e/mobile-recent-home.spec.ts
@@ -29,6 +29,15 @@ interface MockAndroidDocument {
   sourceUri: string
   displayName: string
   markdown: string
+  canWrite?: boolean
+  readError?: {
+    code: string
+    message: string
+  }
+  writeError?: {
+    code: string
+    message: string
+  }
 }
 
 async function installTransientAndroidCreateMock(page: Page) {
@@ -174,7 +183,7 @@ async function installAndroidAppMock(page: Page, androidDocument?: MockAndroidDo
             pathHint: documentMock.displayName,
             mimeType: 'text/markdown',
             markdown: documentMock.markdown,
-            canWrite: true,
+            canWrite: documentMock.canWrite ?? true,
             persisted: true,
           }
 
@@ -186,6 +195,9 @@ async function installAndroidAppMock(page: Page, androidDocument?: MockAndroidDo
             methodName === 'readMarkdownDocument' &&
             options.sourceUri === documentMock.sourceUri
           ) {
+            if (documentMock.readError) {
+              return Promise.reject(documentMock.readError)
+            }
             return Promise.resolve(documentResult)
           }
 
@@ -193,6 +205,9 @@ async function installAndroidAppMock(page: Page, androidDocument?: MockAndroidDo
             methodName === 'writeMarkdownDocument' &&
             options.sourceUri === documentMock.sourceUri
           ) {
+            if (documentMock.writeError) {
+              return Promise.reject(documentMock.writeError)
+            }
             return Promise.resolve({
               ...documentResult,
               markdown: undefined,
@@ -447,6 +462,117 @@ test('returns a clean Android document to recent home from the Android back butt
   await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
   await expect(page.getByTestId('editor-host')).toBeHidden()
   await expect(page.getByText('Clean Android Note')).toBeVisible()
+})
+
+test('keeps a stale Android recent file on home with a recovery notice', async ({ page }) => {
+  const now = '2026-06-29T06:10:00.000Z'
+  const document = {
+    sourceUri: 'content://test/missing-document',
+    displayName: 'Missing Android Note.md',
+    markdown: '# Missing Android Note\n\nThis provider will reject reads.',
+    readError: {
+      code: 'DOCUMENT_NOT_FOUND',
+      message: 'missing',
+    },
+  }
+
+  await installAndroidAppMock(page, document)
+  await page.goto('/')
+  await page.evaluate(({ now, document }) => {
+    localStorage.clear()
+    localStorage.setItem(
+      'marktext-for-android:recent-documents',
+      JSON.stringify([
+        {
+          id: `android-document:${document.sourceUri}`,
+          kind: 'android-document',
+          displayName: document.displayName,
+          title: 'Missing Android Note',
+          sourceUri: document.sourceUri,
+          providerName: 'Test Documents',
+          pathHint: document.displayName,
+          markdownPreview: null,
+          updatedAt: now,
+          lastOpenedAt: now,
+          lastSavedAt: null,
+          autosaveState: 'clean',
+          canWrite: true,
+        },
+      ]),
+    )
+  }, { now, document })
+  await page.reload()
+
+  await page.getByRole('button', { name: /Missing Android Note/ }).click()
+
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  await expect(page.getByTestId('editor-host')).toBeHidden()
+  await expect(
+    page.getByText('This file was moved or deleted. Open it again from Android.'),
+  ).toBeVisible()
+  await expect(page.getByText('Missing Android Note')).toBeVisible()
+})
+
+test('keeps dirty Android edits in the editor and in a recovery draft when save fails', async ({
+  page,
+}) => {
+  const now = '2026-06-29T06:20:00.000Z'
+  const document = {
+    sourceUri: 'content://test/write-fails',
+    displayName: 'Write Fails.md',
+    markdown: '# Write Fails\n\nInitial text.',
+    writeError: {
+      code: 'DOCUMENT_PERMISSION_LOST',
+      message: 'permission lost',
+    },
+  }
+
+  await installAndroidAppMock(page, document)
+  await page.goto('/')
+  await page.evaluate(({ now, document }) => {
+    localStorage.clear()
+    localStorage.setItem(
+      'marktext-for-android:recent-documents',
+      JSON.stringify([
+        {
+          id: `android-document:${document.sourceUri}`,
+          kind: 'android-document',
+          displayName: document.displayName,
+          title: 'Write Fails',
+          sourceUri: document.sourceUri,
+          providerName: 'Test Documents',
+          pathHint: document.displayName,
+          markdownPreview: null,
+          updatedAt: now,
+          lastOpenedAt: now,
+          lastSavedAt: null,
+          autosaveState: 'clean',
+          canWrite: true,
+        },
+      ]),
+    )
+  }, { now, document })
+  await page.reload()
+
+  await page.getByRole('button', { name: /Write Fails/ }).click()
+  await expect(page.getByTestId('editor-host')).toBeVisible()
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.press('End')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('unsaved recovery line')
+  await expect(page.getByTestId('editor-host')).toContainText('unsaved recovery line')
+
+  await page.getByTestId('back-button').click()
+
+  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expect(
+    page.getByText(/Reopen this file from Android before saving again/),
+  ).toBeVisible()
+
+  const drafts = await page.evaluate(() => localStorage.getItem('marktext-for-android:drafts') ?? '')
+  expect(drafts).toContain('android-recovery:content://test/write-fails')
+  expect(drafts).toContain('unsaved recovery line')
 })
 
 test('keeps the local draft when Android document access is not persisted', async ({ page }) => {


### PR DESCRIPTION
## Summary

This PR improves Android document error recovery for the mobile editor.

It separates native Android document failures into clearer error codes, including moved/deleted files, lost URI permissions, read failures, and write failures. The Vue shell now keeps dirty Android document edits in the editor when save fails, writes a local recovery draft, and only returns to the recent home after an Android document save succeeds.

It also adds tests for stale recent files and failed Android saves, plus small local ignore cleanup for AGENTS.md.

## Validation

Automated checks run locally:

- pnpm test
- pnpm typecheck
- pnpm test:e2e
- pnpm lint
- pnpm build
- pnpm android:sync
- Gradle assembleDebug

Real Android / ADB validation on emulator-5554:

- Installed and launched debug APK
- Verified home render
- Created a local draft and typed through ADB input
- Verified local draft autosave and Android back handling
- Saved a draft through Android DocumentsUI
- Verified SAF-created file content under /sdcard/Download/Untitled-1.md
- Verified Android document autosave writes back to the real file
- Verified lifecycle flush on HOME/app pause writes dirty Android document edits before debounce
- Deleted the file through Android provider/MediaStore and verified stale recent open returns DOCUMENT_NOT_FOUND with a user-visible recovery notice instead of crashing

Notes:

- Logs were checked through logcat and the app private log files under run-as.
- The generated logs/screenshots stay ignored under logs/ and are not committed.