### PR TITLE
Add Android document save copy flow

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -59,6 +59,8 @@ const TRANSIENT_ANDROID_DOCUMENT_MESSAGE =
   'Saved to device. Kept local draft because Android did not grant long-term access.'
 const ANDROID_RECOVERY_DRAFT_PREFIX = 'android-recovery:'
 const ANDROID_SAVE_RECOVERY_MESSAGE = 'Save failed. A local recovery draft was kept.'
+const MARKDOWN_FILE_EXTENSION_REGEXP = /\.(markdown|mdown|mkdn|mkd|md)$/i
+const MARKDOWN_COPY_SUFFIX_REGEXP = /\s+copy(?:\s+(\d+))?$/
 
 const editorPlugins = [
   InlineFormatToolbar,
@@ -79,6 +81,7 @@ const draftExitPromptOpen = ref(false)
 const editorMenuOpen = ref(false)
 const promptLocalDraftSaveOnExit = ref(false)
 const savingLocalDraftToAndroid = ref(false)
+const savingAndroidDocumentCopy = ref(false)
 
 let editor: Muya | null = null
 let lastContentLogAt = 0
@@ -171,6 +174,40 @@ function shouldPromptLocalDraftSaveToDevice() {
 
 function canSaveLocalDraftToAndroidDocument() {
   return isLocalDraftDocument() && isAndroidDocumentAccessAvailable()
+}
+
+function canSaveAndroidDocumentCopy() {
+  return documentState.value.autosaveTarget === 'android-document' && isAndroidDocumentAccessAvailable()
+}
+
+function canShowEditorActions() {
+  return canSaveLocalDraftToAndroidDocument() || canSaveAndroidDocumentCopy()
+}
+
+function getSuggestedMarkdownCopyFileName(
+  markdown: string,
+  displayName: string,
+  reservedNames: string[] = [],
+) {
+  const suggestedName = getSuggestedMarkdownFileName(markdown, displayName)
+  const extension = suggestedName.match(MARKDOWN_FILE_EXTENSION_REGEXP)?.[0] ?? '.md'
+  const baseName = suggestedName.slice(0, -extension.length) || 'Untitled'
+  const copySuffix = baseName.match(MARKDOWN_COPY_SUFFIX_REGEXP)
+  const copyBaseName = copySuffix
+    ? baseName.slice(0, copySuffix.index).trim() || 'Untitled'
+    : baseName
+  const firstCopyIndex = copySuffix ? Number(copySuffix[1] ?? '1') + 1 : 1
+  const normalizedReservedNames = new Set(reservedNames.map(name => name.toLocaleLowerCase()))
+
+  for (let index = firstCopyIndex; index < firstCopyIndex + 100; index += 1) {
+    const suffix = index === 1 ? 'copy' : `copy ${index}`
+    const candidate = `${copyBaseName} ${suffix}${extension}`
+    if (!normalizedReservedNames.has(candidate.toLocaleLowerCase())) {
+      return candidate
+    }
+  }
+
+  return `${copyBaseName} copy ${Date.now()}${extension}`
 }
 
 function registerMuyaPlugins() {
@@ -564,6 +601,93 @@ async function saveLocalDraftToAndroidDocument(options: { returnHomeAfterSave?: 
     return false
   } finally {
     savingLocalDraftToAndroid.value = false
+  }
+}
+
+async function saveAndroidDocumentCopy() {
+  editorMenuOpen.value = false
+
+  if (!editor || !canSaveAndroidDocumentCopy() || savingAndroidDocumentCopy.value) {
+    return false
+  }
+
+  const originalSourceUri = documentState.value.sourceUri
+  const copySourceDocument = syncDocumentFromEditor(documentState.value.isDirty)
+  const markdownForSave = prepareMarkdownForSave(copySourceDocument.markdown, copySourceDocument)
+  const suggestedName = getSuggestedMarkdownCopyFileName(
+    copySourceDocument.markdown,
+    copySourceDocument.displayName,
+    androidRecentDocuments.value.map(document => document.displayName),
+  )
+
+  savingAndroidDocumentCopy.value = true
+  status.value = 'Choose a location'
+
+  try {
+    const document = await createAndroidMarkdownDocument(markdownForSave, suggestedName)
+    if (document.canceled) {
+      status.value = getAndroidEditorStatus()
+      androidDocumentLog.info('Android document save copy canceled', {
+        sourceUri: originalSourceUri,
+      })
+      return false
+    }
+
+    const savedAt = new Date().toISOString()
+    const createdDocument = {
+      ...document,
+      markdown: copySourceDocument.markdown,
+    }
+
+    if (!document.persisted) {
+      if (originalSourceUri && copySourceDocument.isDirty) {
+        persistAndroidRecoveryDraft(originalSourceUri, copySourceDocument.markdown)
+      }
+      status.value = TRANSIENT_ANDROID_DOCUMENT_MESSAGE
+      androidDocumentLog.warn('saved Android document copy without persisted access', {
+        originalSourceUri,
+        displayName: document.displayName,
+        sourceUri: document.sourceUri,
+        characters: copySourceDocument.markdown.length,
+      })
+      return false
+    }
+
+    if (originalSourceUri) {
+      removeAndroidRecoveryDraft(originalSourceUri)
+    }
+    rememberAndroidDocument(createdDocument)
+    currentAndroidDocumentCanWrite.value = document.canWrite
+    promptLocalDraftSaveOnExit.value = false
+    documentState.value = markDocumentSaved(
+      {
+        ...createDocumentFromAndroidDocument(createdDocument),
+        updatedAt: savedAt,
+        lastSavedAt: savedAt,
+      },
+      { autosaveTarget: 'android-document', now: savedAt },
+    )
+    status.value = getAndroidEditorStatus()
+    androidDocumentLog.info('Android document saved as copy', {
+      originalSourceUri,
+      displayName: document.displayName,
+      sourceUri: document.sourceUri,
+      characters: copySourceDocument.markdown.length,
+    })
+    return true
+  } catch (error) {
+    if (originalSourceUri && copySourceDocument.isDirty) {
+      persistAndroidRecoveryDraft(originalSourceUri, copySourceDocument.markdown)
+    }
+    documentState.value = markDocumentSaveFailed(documentState.value, error)
+    status.value = getAndroidDocumentUserMessage(error)
+    androidDocumentLog.error('Android document save copy failed', {
+      originalSourceUri,
+      error,
+    })
+    return false
+  } finally {
+    savingAndroidDocumentCopy.value = false
   }
 }
 
@@ -1036,7 +1160,7 @@ onBeforeUnmount(() => {
         <h1>{{ documentTitle }}</h1>
         <p>{{ status }}</p>
       </div>
-      <div v-if="canSaveLocalDraftToAndroidDocument()" class="editor-actions">
+      <div v-if="canShowEditorActions()" class="editor-actions">
         <button
           class="menu-button"
           type="button"
@@ -1049,6 +1173,7 @@ onBeforeUnmount(() => {
         </button>
         <div v-if="editorMenuOpen" class="editor-menu" role="menu">
           <button
+            v-if="canSaveLocalDraftToAndroidDocument()"
             type="button"
             role="menuitem"
             data-testid="save-to-device-button"
@@ -1056,6 +1181,16 @@ onBeforeUnmount(() => {
             @click="() => saveLocalDraftToAndroidDocument()"
           >
             Save to device
+          </button>
+          <button
+            v-if="canSaveAndroidDocumentCopy()"
+            type="button"
+            role="menuitem"
+            data-testid="save-copy-button"
+            :disabled="savingAndroidDocumentCopy"
+            @click="saveAndroidDocumentCopy"
+          >
+            Save a copy
           </button>
         </div>
       </div>

--- a/src/style.css
+++ b/src/style.css
@@ -250,6 +250,8 @@ body {
 }
 
 .top-bar {
+  position: relative;
+  z-index: 20;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
@@ -290,10 +292,12 @@ body {
 
 .editor-menu {
   position: absolute;
-  top: calc(100% + 8px);
+  top: calc(100% + 6px);
   right: 0;
-  z-index: 10;
-  width: 180px;
+  z-index: 30;
+  min-width: 124px;
+  width: max-content;
+  max-width: calc(100vw - 32px);
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 8px;

--- a/tests/e2e/mobile-recent-home.spec.ts
+++ b/tests/e2e/mobile-recent-home.spec.ts
@@ -6,6 +6,7 @@ interface MockCapacitorWindow {
   __emitCapacitorAppPause?: () => void
   __emitCapacitorAppStateChange?: (isActive: boolean) => void
   __appListenerCount?: (eventName: string) => number
+  __lastAndroidCreateOptions?: Record<string, unknown>
   Capacitor?: {
     PluginHeaders?: Array<{
       name: string
@@ -30,6 +31,16 @@ interface MockAndroidDocument {
   displayName: string
   markdown: string
   canWrite?: boolean
+  createResult?: {
+    sourceUri: string
+    displayName: string
+    canWrite?: boolean
+    persisted?: boolean
+  }
+  createError?: {
+    code: string
+    message: string
+  }
   readError?: {
     code: string
     message: string
@@ -146,6 +157,7 @@ async function installAndroidAppMock(page: Page, androidDocument?: MockAndroidDo
               {
                 name: 'AndroidDocuments',
                 methods: [
+                  { name: 'createMarkdownDocument', rtype: 'promise' },
                   { name: 'openMarkdownDocument', rtype: 'promise' },
                   { name: 'readMarkdownDocument', rtype: 'promise' },
                   { name: 'writeMarkdownDocument', rtype: 'promise' },
@@ -185,6 +197,30 @@ async function installAndroidAppMock(page: Page, androidDocument?: MockAndroidDo
             markdown: documentMock.markdown,
             canWrite: documentMock.canWrite ?? true,
             persisted: true,
+          }
+
+          if (methodName === 'createMarkdownDocument') {
+            win.__lastAndroidCreateOptions = options
+            if (documentMock.createError) {
+              return Promise.reject(documentMock.createError)
+            }
+
+            const markdown = typeof options.markdown === 'string' ? options.markdown : ''
+            const displayName =
+              documentMock.createResult?.displayName ??
+              (typeof options.suggestedName === 'string' ? options.suggestedName : 'Saved Copy.md')
+
+            return Promise.resolve({
+              canceled: false,
+              sourceUri: documentMock.createResult?.sourceUri ?? 'content://test/saved-copy',
+              displayName,
+              providerName: 'Test Documents',
+              pathHint: displayName,
+              mimeType: 'text/markdown',
+              markdown,
+              canWrite: documentMock.createResult?.canWrite ?? true,
+              persisted: documentMock.createResult?.persisted ?? true,
+            })
           }
 
           if (methodName === 'openMarkdownDocument') {
@@ -573,6 +609,232 @@ test('keeps dirty Android edits in the editor and in a recovery draft when save 
   const drafts = await page.evaluate(() => localStorage.getItem('marktext-for-android:drafts') ?? '')
   expect(drafts).toContain('android-recovery:content://test/write-fails')
   expect(drafts).toContain('unsaved recovery line')
+})
+
+test('saves a writable Android document as a copy and switches to the new document', async ({
+  page,
+}) => {
+  const now = '2026-06-29T06:30:00.000Z'
+  const document = {
+    sourceUri: 'content://test/original-save-copy',
+    displayName: 'Original Save Copy.md',
+    markdown: '# Original Save Copy\n\nInitial text.',
+    createResult: {
+      sourceUri: 'content://test/copied-save-copy',
+      displayName: 'Copied Save Copy.md',
+    },
+  }
+
+  await installAndroidAppMock(page, document)
+  await page.goto('/')
+  await page.evaluate(({ now, document }) => {
+    localStorage.clear()
+    localStorage.setItem(
+      'marktext-for-android:recent-documents',
+      JSON.stringify([
+        {
+          id: `android-document:${document.sourceUri}`,
+          kind: 'android-document',
+          displayName: document.displayName,
+          title: 'Original Save Copy',
+          sourceUri: document.sourceUri,
+          providerName: 'Test Documents',
+          pathHint: document.displayName,
+          markdownPreview: null,
+          updatedAt: now,
+          lastOpenedAt: now,
+          lastSavedAt: null,
+          autosaveState: 'clean',
+          canWrite: true,
+        },
+        {
+          id: 'android-document:content://test/existing-save-copy',
+          kind: 'android-document',
+          displayName: 'Original Save Copy copy.md',
+          title: 'Existing Save Copy',
+          sourceUri: 'content://test/existing-save-copy',
+          providerName: 'Test Documents',
+          pathHint: 'Original Save Copy copy.md',
+          markdownPreview: null,
+          updatedAt: '2026-06-29T06:00:00.000Z',
+          lastOpenedAt: '2026-06-29T06:00:00.000Z',
+          lastSavedAt: '2026-06-29T06:00:00.000Z',
+          autosaveState: 'clean',
+          canWrite: true,
+        },
+      ]),
+    )
+  }, { now, document })
+  await page.reload()
+
+  await page.getByRole('button', { name: /Original Save Copy/ }).click()
+  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.press('End')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('copy target text')
+
+  await page.getByTestId('editor-menu-button').click()
+  await expect(page.getByTestId('save-copy-button')).toBeVisible()
+  const menuButtonBox = await page.getByTestId('editor-menu-button').boundingBox()
+  const menuBox = await page.locator('.editor-menu').boundingBox()
+  expect(menuButtonBox).not.toBeNull()
+  expect(menuBox).not.toBeNull()
+  expect(
+    Math.abs(menuBox!.x + menuBox!.width - (menuButtonBox!.x + menuButtonBox!.width)),
+  ).toBeLessThanOrEqual(2)
+  expect(menuBox!.width).toBeLessThanOrEqual(150)
+  await page.getByTestId('save-copy-button').click()
+
+  await expect(page.getByText('Saved', { exact: true })).toBeVisible()
+  const createOptions = await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    return win.__lastAndroidCreateOptions
+  })
+  expect(createOptions?.suggestedName).toBe('Original Save Copy copy 2.md')
+
+  const storage = await page.evaluate(() => ({
+    drafts: localStorage.getItem('marktext-for-android:drafts') ?? '',
+    recentDocuments: localStorage.getItem('marktext-for-android:recent-documents') ?? '',
+  }))
+  expect(storage.recentDocuments).toContain('content://test/copied-save-copy')
+  expect(storage.recentDocuments).toContain('Copied Save Copy.md')
+  expect(storage.drafts).not.toContain('android-recovery:content://test/original-save-copy')
+})
+
+test('increments the save-copy name when the current Android document is already a copy', async ({
+  page,
+}) => {
+  const now = '2026-06-29T06:35:00.000Z'
+  const document = {
+    sourceUri: 'content://test/original-copy-name',
+    displayName: 'Original Copy Name copy.md',
+    markdown: 'Initial text without a heading.',
+    createResult: {
+      sourceUri: 'content://test/original-copy-name-copy-3',
+      displayName: 'Original Copy Name copy 3.md',
+    },
+  }
+
+  await installAndroidAppMock(page, document)
+  await page.goto('/')
+  await page.evaluate(({ now, document }) => {
+    localStorage.clear()
+    localStorage.setItem(
+      'marktext-for-android:recent-documents',
+      JSON.stringify([
+        {
+          id: `android-document:${document.sourceUri}`,
+          kind: 'android-document',
+          displayName: document.displayName,
+          title: 'Original Copy Name copy',
+          sourceUri: document.sourceUri,
+          providerName: 'Test Documents',
+          pathHint: document.displayName,
+          markdownPreview: null,
+          updatedAt: now,
+          lastOpenedAt: now,
+          lastSavedAt: null,
+          autosaveState: 'clean',
+          canWrite: true,
+        },
+        {
+          id: 'android-document:content://test/original-copy-name-copy-2',
+          kind: 'android-document',
+          displayName: 'Original Copy Name copy 2.md',
+          title: 'Original Copy Name copy 2',
+          sourceUri: 'content://test/original-copy-name-copy-2',
+          providerName: 'Test Documents',
+          pathHint: 'Original Copy Name copy 2.md',
+          markdownPreview: null,
+          updatedAt: '2026-06-29T06:00:00.000Z',
+          lastOpenedAt: '2026-06-29T06:00:00.000Z',
+          lastSavedAt: '2026-06-29T06:00:00.000Z',
+          autosaveState: 'clean',
+          canWrite: true,
+        },
+      ]),
+    )
+  }, { now, document })
+  await page.reload()
+
+  await page.getByRole('button', { name: /Original Copy Name copy/ }).first().click()
+  await expect(page.getByTestId('editor-host')).toBeVisible()
+
+  await page.getByTestId('editor-menu-button').click()
+  await page.getByTestId('save-copy-button').click()
+
+  await expect(page.getByText('Saved', { exact: true })).toBeVisible()
+  const createOptions = await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    return win.__lastAndroidCreateOptions
+  })
+  expect(createOptions?.suggestedName).toBe('Original Copy Name copy 3.md')
+})
+
+test('saves a read-only Android document as a writable copy', async ({ page }) => {
+  const now = '2026-06-29T06:40:00.000Z'
+  const document = {
+    sourceUri: 'content://test/read-only-original',
+    displayName: 'Read Only Original.md',
+    markdown: '# Read Only Original\n\nInitial text.',
+    canWrite: false,
+    createResult: {
+      sourceUri: 'content://test/read-only-copy',
+      displayName: 'Read Only Copy.md',
+      canWrite: true,
+    },
+  }
+
+  await installAndroidAppMock(page, document)
+  await page.goto('/')
+  await page.evaluate(({ now, document }) => {
+    localStorage.clear()
+    localStorage.setItem(
+      'marktext-for-android:recent-documents',
+      JSON.stringify([
+        {
+          id: `android-document:${document.sourceUri}`,
+          kind: 'android-document',
+          displayName: document.displayName,
+          title: 'Read Only Original',
+          sourceUri: document.sourceUri,
+          providerName: 'Test Documents',
+          pathHint: document.displayName,
+          markdownPreview: null,
+          updatedAt: now,
+          lastOpenedAt: now,
+          lastSavedAt: null,
+          autosaveState: 'clean',
+          canWrite: false,
+        },
+      ]),
+    )
+  }, { now, document })
+  await page.reload()
+
+  await page.getByRole('button', { name: /Read Only Original/ }).click()
+  await expect(page.getByText('Read only', { exact: true })).toBeVisible()
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.press('End')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('saved through copy')
+
+  await page.getByTestId('editor-menu-button').click()
+  await page.getByTestId('save-copy-button').click()
+
+  await expect(page.getByText('Saved', { exact: true })).toBeVisible()
+  await page.getByTestId('back-button').click()
+
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  await expect(page.getByText('Read Only Original').first()).toBeVisible()
+
+  const recentDocuments = await page.evaluate(
+    () => localStorage.getItem('marktext-for-android:recent-documents') ?? '',
+  )
+  expect(recentDocuments).toContain('content://test/read-only-copy')
+  expect(recentDocuments).toContain('Read Only Copy.md')
+  expect(recentDocuments).toContain('"canWrite":true')
 })
 
 test('keeps the local draft when Android document access is not persisted', async ({ page }) => {


### PR DESCRIPTION
## Summary

This PR adds the Android document "Save a copy" flow for Markdown files opened through Android document access.

- Adds an editor action for Android documents to save the current document as a new Markdown file through SAF create-document.
- Switches the active editor state to the newly created persisted document after a successful copy save.
- Supports read-only Android documents by letting the user create a writable copy instead of trying to overwrite the original.
- Keeps the original/recovery path safe when Android returns a transient non-persisted URI grant.
- Adds copy-name collision handling for known recent documents, including `copy`, `copy 2`, `copy 3` style names.
- Tightens the editor action menu positioning so the Save a copy menu stays visually anchored to the three-dot button on mobile.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:e2e`
- `pnpm build`
- `pnpm android:sync`
- `./android/gradlew.bat -p android assembleDebug --no-daemon`
- Real official Android Emulator / ADB validation:
  - installed debug APK on `emulator-5554`
  - created `/sdcard/Download/Untitled-1.md`
  - saved copies as `/sdcard/Download/Untitled-1 copy.md` and `/sdcard/Download/Untitled-1 copy 2.md`
  - verified file contents and MarkText Android native/logcat save-copy entries
  - checked the mobile menu placement by screenshot after APK install