### PR TITLE
Add Android Markdown open-with intent flow

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,27 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <intent-filter android:label="@string/app_name">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="content" />
+                <data android:mimeType="text/markdown" />
+                <data android:mimeType="text/x-markdown" />
+                <data android:mimeType="text/vnd.daringfireball.markdown" />
+            </intent-filter>
+
+            <intent-filter android:label="@string/app_name">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="content" />
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="application/octet-stream" />
+            </intent-filter>
+
         </activity>
 
         <provider

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
+import java.util.Set;
 
 @CapacitorPlugin(name = "AndroidDocuments")
 public class AndroidDocumentsPlugin extends Plugin {
@@ -33,6 +34,13 @@ public class AndroidDocumentsPlugin extends Plugin {
     private static final int MAX_MARKDOWN_BYTES = 5 * 1024 * 1024;
     private static final String CALLBACK_OPEN_MARKDOWN_DOCUMENT = "openMarkdownDocumentResult";
     private static final String CALLBACK_CREATE_MARKDOWN_DOCUMENT = "createMarkdownDocumentResult";
+    private static final String EVENT_OPEN_WITH_DOCUMENT = "openWithDocument";
+
+    @Override
+    protected void handleOnNewIntent(Intent intent) {
+        super.handleOnNewIntent(intent);
+        handleOpenWithIntent(intent);
+    }
 
     @PluginMethod
     public void openMarkdownDocument(PluginCall call) {
@@ -165,6 +173,56 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
     }
 
+    private void handleOpenWithIntent(Intent intent) {
+        if (intent == null || !Intent.ACTION_VIEW.equals(intent.getAction())) {
+            return;
+        }
+
+        Uri uri = intent.getData();
+        if (uri == null) {
+            notifyOpenWithRejected("DOCUMENT_URI_MISSING", "Android open-with intent returned no URI");
+            return;
+        }
+
+        if (!hasOnlyAllowedViewCategories(intent)) {
+            Log.w(TAG, "Rejected Android open-with intent with unsupported categories");
+            notifyOpenWithRejected("INVALID_OPEN_WITH_INTENT", "This Android open-with request is not supported");
+            return;
+        }
+
+        if (!"content".equals(uri.getScheme())) {
+            Log.w(TAG, "Rejected Android open-with URI with unsupported scheme: " + safeForLog(uri.getScheme()));
+            notifyOpenWithRejected("INVALID_SOURCE_URI", "A valid content URI is required");
+            return;
+        }
+
+        try {
+            JSObject document = buildOpenWithDocumentResult(uri, intent);
+            if ((intent.getFlags() & Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION) != 0) {
+                persistUriPermission(uri, intent);
+            }
+            document.put("persisted", hasPersistedReadPermission(uri));
+            document.put("canWrite", canWrite(uri, intent));
+            JSObject event = new JSObject();
+            event.put("document", document);
+            event.put("source", "open-with");
+            Log.i(TAG, "Received Android open-with Markdown document: " + safeForLog(document.getString("displayName")));
+            notifyListeners(EVENT_OPEN_WITH_DOCUMENT, event, true);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android open-with document rejected: " + ex.getMessage());
+            notifyOpenWithRejected(ex.code, ex.getMessage());
+        } catch (FileNotFoundException ex) {
+            Log.w(TAG, "Android open-with document no longer exists", ex);
+            notifyOpenWithRejected("DOCUMENT_NOT_FOUND", "This Android document was moved or deleted");
+        } catch (SecurityException ex) {
+            Log.w(TAG, "Android open-with document permission is not available", ex);
+            notifyOpenWithRejected("DOCUMENT_PERMISSION_LOST", "Android document permission is no longer available");
+        } catch (IOException ex) {
+            Log.e(TAG, "Failed to open Android open-with document", ex);
+            notifyOpenWithRejected("DOCUMENT_READ_FAILED", "Failed to read Android document");
+        }
+    }
+
     @ActivityCallback
     private void createMarkdownDocumentResult(PluginCall call, ActivityResult result) {
         if (call == null) {
@@ -278,6 +336,30 @@ public class AndroidDocumentsPlugin extends Plugin {
         return result;
     }
 
+    private JSObject buildOpenWithDocumentResult(Uri uri, Intent grantIntent) throws IOException, DocumentReadException {
+        String displayName = getDisplayName(uri);
+        String mimeType = getMimeType(uri, grantIntent);
+        if (!isOpenWithMarkdownCandidate(uri, displayName, mimeType)) {
+            throw new DocumentReadException(
+                "UNSUPPORTED_OPEN_WITH_DOCUMENT",
+                "Open a Markdown document"
+            );
+        }
+
+        String markdown = readText(uri);
+        JSObject result = new JSObject();
+        result.put("canceled", false);
+        result.put("sourceUri", uri.toString());
+        result.put("displayName", displayName);
+        result.put("providerName", getProviderName(uri));
+        result.put("pathHint", displayName);
+        result.put("mimeType", mimeType);
+        result.put("markdown", markdown);
+        result.put("canWrite", canWrite(uri, grantIntent));
+        result.put("persisted", hasPersistedReadPermission(uri));
+        return result;
+    }
+
     private JSObject createDocumentResult(Uri uri, Intent grantIntent, String markdown) throws IOException, DocumentReadException {
         byte[] bytes = validateMarkdownBytes(markdown);
         writeText(uri, bytes);
@@ -365,6 +447,10 @@ public class AndroidDocumentsPlugin extends Plugin {
     }
 
     private void persistUriPermission(Uri uri, Intent data) {
+        if (data == null) {
+            return;
+        }
+
         int grantFlags = data.getFlags() &
             (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
         if (grantFlags == 0) {
@@ -450,6 +536,21 @@ public class AndroidDocumentsPlugin extends Plugin {
         return type == null ? "" : type.toLowerCase(Locale.US);
     }
 
+    private String getMimeType(Uri uri, Intent grantIntent) {
+        String resolverType = getMimeType(uri);
+        String intentType = grantIntent == null ? null : grantIntent.getType();
+        String normalizedIntentType = intentType == null ? "" : intentType.toLowerCase(Locale.US);
+        if (isMarkdownMimeType(normalizedIntentType)) {
+            return normalizedIntentType;
+        }
+
+        if (resolverType.length() > 0) {
+            return resolverType;
+        }
+
+        return normalizedIntentType;
+    }
+
     private String getProviderName(Uri uri) {
         String authority = uri.getAuthority();
         if (authority == null || authority.length() == 0) {
@@ -468,23 +569,67 @@ public class AndroidDocumentsPlugin extends Plugin {
     }
 
     private boolean isMarkdownCandidate(String displayName, String mimeType) {
-        String lowerName = displayName == null ? "" : displayName.toLowerCase(Locale.US);
-        boolean markdownExtension =
-            lowerName.endsWith(".md") ||
-            lowerName.endsWith(".markdown") ||
-            lowerName.endsWith(".mdown") ||
-            lowerName.endsWith(".mkdn") ||
-            lowerName.endsWith(".mkd");
-
-        if (markdownExtension) {
+        if (hasMarkdownExtension(displayName)) {
             return true;
         }
 
         return (
-            "text/markdown".equals(mimeType) ||
-            "text/x-markdown".equals(mimeType) ||
+            isMarkdownMimeType(mimeType) ||
             "text/plain".equals(mimeType)
         );
+    }
+
+    private boolean isOpenWithMarkdownCandidate(Uri uri, String displayName, String mimeType) {
+        return (
+            hasMarkdownExtension(displayName) ||
+            hasMarkdownExtension(uri.getLastPathSegment()) ||
+            isMarkdownMimeType(mimeType)
+        );
+    }
+
+    private boolean hasMarkdownExtension(String value) {
+        String lowerName = value == null ? "" : value.toLowerCase(Locale.US);
+        return (
+            lowerName.endsWith(".md") ||
+            lowerName.endsWith(".markdown") ||
+            lowerName.endsWith(".mdown") ||
+            lowerName.endsWith(".mkdn") ||
+            lowerName.endsWith(".mkd")
+        );
+    }
+
+    private boolean isMarkdownMimeType(String mimeType) {
+        return (
+            "text/markdown".equals(mimeType) ||
+            "text/x-markdown".equals(mimeType) ||
+            "text/vnd.daringfireball.markdown".equals(mimeType)
+        );
+    }
+
+    private boolean hasOnlyAllowedViewCategories(Intent intent) {
+        Set<String> categories = intent.getCategories();
+        if (categories == null) {
+            return true;
+        }
+
+        for (String category : categories) {
+            if (
+                !Intent.CATEGORY_DEFAULT.equals(category) &&
+                !Intent.CATEGORY_BROWSABLE.equals(category) &&
+                !Intent.CATEGORY_OPENABLE.equals(category)
+            ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void notifyOpenWithRejected(String code, String message) {
+        JSObject event = new JSObject();
+        event.put("source", "open-with");
+        event.put("errorCode", code);
+        event.put("message", message);
+        notifyListeners(EVENT_OPEN_WITH_DOCUMENT, event, true);
     }
 
     private boolean canWrite(Uri uri, Intent grantIntent) {

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
@@ -1,5 +1,6 @@
 package io.github.renakoni.marktextandroid;
 
+import android.content.Intent;
 import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;
 
@@ -9,5 +10,13 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(AndroidDocumentsPlugin.class);
         registerPlugin(NativeLoggerPlugin.class);
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        if (intent != null) {
+            setIntent(intent);
+        }
+        super.onNewIntent(intent);
     }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@ import {
 } from '@muyajs/core'
 import DocumentHome from './components/DocumentHome.vue'
 import {
+  addAndroidOpenWithDocumentListener,
   createAndroidMarkdownDocument,
   getAndroidDocumentErrorCode,
   getAndroidDocumentUserMessage,
@@ -19,6 +20,7 @@ import {
   openAndroidMarkdownDocument,
   readAndroidMarkdownDocument,
   writeAndroidMarkdownDocument,
+  type AndroidOpenWithDocumentEvent,
   type OpenedAndroidDocument,
 } from './lib/androidDocuments'
 import {
@@ -57,6 +59,8 @@ const DRAFT_SAVE_DELAY_MS = 800
 const ANDROID_DOCUMENT_SAVE_DELAY_MS = 1200
 const TRANSIENT_ANDROID_DOCUMENT_MESSAGE =
   'Saved to device. Kept local draft because Android did not grant long-term access.'
+const OPEN_WITH_TEMPORARY_ACCESS_MESSAGE =
+  'Opened with temporary Android access. Save a copy to keep editing later.'
 const ANDROID_RECOVERY_DRAFT_PREFIX = 'android-recovery:'
 const ANDROID_SAVE_RECOVERY_MESSAGE = 'Save failed. A local recovery draft was kept.'
 const MARKDOWN_FILE_EXTENSION_REGEXP = /\.(markdown|mdown|mkdn|mkd|md)$/i
@@ -90,6 +94,7 @@ let androidSaveTimer: number | null = null
 let androidSaveInFlight = false
 let androidSaveRequestedAfterCurrent = false
 let appLifecycleListenerHandles: PluginListenerHandle[] = []
+let androidDocumentListenerHandles: PluginListenerHandle[] = []
 let browserLifecycleListenersInstalled = false
 
 const appLog = createLogger('app')
@@ -811,7 +816,13 @@ function releaseEditorFocusAfterOpen() {
 }
 
 async function openEditor(markdown: string) {
+  const wasEditorOpen = currentScreen.value === 'editor'
   destroyEditor()
+  if (wasEditorOpen) {
+    currentScreen.value = 'home'
+    await nextTick()
+  }
+
   currentScreen.value = 'editor'
   await nextTick()
   initEditor(markdown)
@@ -830,9 +841,23 @@ function rememberAndroidDocument(document: OpenedAndroidDocument) {
   persistAndroidRecentDocuments(upsertRecentDocument(androidRecentDocuments.value, recentDocument))
 }
 
-async function openAndroidDocumentResult(document: OpenedAndroidDocument) {
-  homeNotice.value = null
-  rememberAndroidDocument(document)
+async function openAndroidDocumentResult(
+  document: OpenedAndroidDocument,
+  options: { source?: 'picker' | 'recent' | 'open-with'; remember?: boolean } = {},
+) {
+  const source = options.source ?? 'picker'
+  const shouldRemember = options.remember ?? true
+  homeNotice.value =
+    source === 'open-with' && !document.persisted ? OPEN_WITH_TEMPORARY_ACCESS_MESSAGE : null
+  if (shouldRemember) {
+    rememberAndroidDocument(document)
+  } else {
+    androidDocumentLog.warn('opened Android document without durable recent access', {
+      displayName: document.displayName,
+      sourceUri: document.sourceUri,
+      source,
+    })
+  }
   promptLocalDraftSaveOnExit.value = false
   currentAndroidDocumentCanWrite.value = document.canWrite
   documentState.value = createDocumentFromAndroidDocument(document)
@@ -841,10 +866,13 @@ async function openAndroidDocumentResult(document: OpenedAndroidDocument) {
     sourceUri: document.sourceUri,
     canWrite: document.canWrite,
     persisted: document.persisted,
+    source,
     characters: document.markdown.length,
   })
   await openEditor(document.markdown)
-  status.value = getAndroidEditorStatus()
+  status.value = source === 'open-with' && !document.persisted
+    ? 'Opened temporarily'
+    : getAndroidEditorStatus()
   releaseEditorFocusAfterOpen()
 }
 
@@ -869,6 +897,44 @@ async function openFileFromAndroid() {
       androidDocumentLog.error('Android document picker failed', error)
     }
   }
+}
+
+async function preserveCurrentDocumentBeforeIncomingOpen() {
+  if (currentScreen.value !== 'editor' || !editor) {
+    return
+  }
+
+  appLog.info('preserve current document before Android open-with')
+
+  if (documentState.value.autosaveTarget === 'android-document') {
+    syncDocumentFromEditor(documentState.value.isDirty)
+    const sourceUri = documentState.value.sourceUri
+    const saved = await saveAndroidDocument()
+    if (!saved && sourceUri && documentState.value.markdown.trim()) {
+      persistAndroidRecoveryDraft(sourceUri, documentState.value.markdown)
+    }
+    return
+  }
+
+  saveDraft()
+}
+
+async function handleAndroidOpenWithDocumentEvent(event: AndroidOpenWithDocumentEvent) {
+  if (event.error) {
+    const message = getAndroidDocumentUserMessage(event.error)
+    homeNotice.value = message
+    status.value = message
+    androidDocumentLog.warn('Android open-with document rejected', event.error)
+    return
+  }
+
+  await preserveCurrentDocumentBeforeIncomingOpen()
+  draftExitPromptOpen.value = false
+  editorMenuOpen.value = false
+  await openAndroidDocumentResult(event.document, {
+    source: 'open-with',
+    remember: event.document.persisted,
+  })
 }
 
 async function openDocument(id: string) {
@@ -1054,6 +1120,23 @@ function installAppLifecycleListeners() {
     })
 }
 
+function installAndroidDocumentIntentListeners() {
+  if (!isAndroidDocumentAccessAvailable()) {
+    return
+  }
+
+  addAndroidOpenWithDocumentListener(event => {
+    void handleAndroidOpenWithDocumentEvent(event)
+  })
+    .then(handle => {
+      androidDocumentListenerHandles = [handle]
+      androidDocumentLog.info('Android open-with listener installed')
+    })
+    .catch(error => {
+      androidDocumentLog.warn('Android open-with listener unavailable', error)
+    })
+}
+
 function removeAppLifecycleListeners() {
   if (browserLifecycleListenersInstalled) {
     browserLifecycleListenersInstalled = false
@@ -1064,6 +1147,12 @@ function removeAppLifecycleListeners() {
   const handles = appLifecycleListenerHandles
   appLifecycleListenerHandles = []
   for (const handle of handles) {
+    void handle.remove()
+  }
+
+  const documentHandles = androidDocumentListenerHandles
+  androidDocumentListenerHandles = []
+  for (const handle of documentHandles) {
     void handle.remove()
   }
 }
@@ -1118,6 +1207,8 @@ onMounted(() => {
     restoredAndroidDocuments: androidRecentDocuments.value.length,
     characters: characterCount.value,
   })
+
+  installAndroidDocumentIntentListeners()
 
   getNativeLogInfo().then(info => {
     if (info) {

--- a/src/lib/androidDocuments.ts
+++ b/src/lib/androidDocuments.ts
@@ -1,4 +1,4 @@
-import { Capacitor, registerPlugin } from '@capacitor/core'
+import { Capacitor, registerPlugin, type PluginListenerHandle } from '@capacitor/core'
 
 export interface OpenedAndroidDocument {
   canceled?: false
@@ -22,11 +22,31 @@ export interface SavedAndroidDocument {
   persisted: boolean
 }
 
+export type AndroidOpenWithDocumentEvent =
+  | {
+      document: OpenedAndroidDocument
+      error: null
+    }
+  | {
+      document: null
+      error: AndroidDocumentError
+    }
+
 interface CanceledAndroidDocumentOpen {
   canceled: true
 }
 
+interface AndroidOpenWithDocumentPluginEvent {
+  document?: OpenedAndroidDocument
+  errorCode?: string
+  message?: string
+}
+
 interface AndroidDocumentsPlugin {
+  addListener(
+    eventName: 'openWithDocument',
+    listenerFunc: (event: AndroidOpenWithDocumentPluginEvent) => void,
+  ): Promise<PluginListenerHandle>
   createMarkdownDocument(options: {
     markdown: string
     suggestedName: string
@@ -90,6 +110,15 @@ export async function writeAndroidMarkdownDocument(sourceUri: string, markdown: 
   )
 }
 
+export async function addAndroidOpenWithDocumentListener(
+  listener: (event: AndroidOpenWithDocumentEvent) => void,
+) {
+  ensureAndroidDocumentsAvailable()
+  return AndroidDocuments.addListener('openWithDocument', event => {
+    listener(normalizeOpenWithDocumentEvent(event))
+  })
+}
+
 export function getAndroidDocumentErrorCode(error: unknown) {
   if (error instanceof AndroidDocumentError) {
     return error.code
@@ -111,6 +140,14 @@ export function getAndroidDocumentUserMessage(error: unknown) {
 
   if (code === 'UNSUPPORTED_DOCUMENT') {
     return 'Choose a Markdown or plain text file.'
+  }
+
+  if (code === 'UNSUPPORTED_OPEN_WITH_DOCUMENT') {
+    return 'Open a Markdown file.'
+  }
+
+  if (code === 'INVALID_OPEN_WITH_INTENT') {
+    return 'This Android open-with request is not supported.'
   }
 
   if (code === 'DOCUMENT_TOO_LARGE') {
@@ -185,5 +222,24 @@ function normalizeSavedDocument(value: SavedAndroidDocument): SavedAndroidDocume
     mimeType: value.mimeType ?? null,
     canWrite: Boolean(value.canWrite),
     persisted: Boolean(value.persisted),
+  }
+}
+
+function normalizeOpenWithDocumentEvent(
+  value: AndroidOpenWithDocumentPluginEvent,
+): AndroidOpenWithDocumentEvent {
+  if (value.document) {
+    return {
+      document: normalizeOpenedDocument(value.document),
+      error: null,
+    }
+  }
+
+  const code = typeof value.errorCode === 'string' ? value.errorCode : 'DOCUMENT_READ_FAILED'
+  const message = typeof value.message === 'string' ? value.message : 'Could not open this Markdown file'
+
+  return {
+    document: null,
+    error: new AndroidDocumentError(code, message),
   }
 }

--- a/tests/e2e/mobile-recent-home.spec.ts
+++ b/tests/e2e/mobile-recent-home.spec.ts
@@ -5,7 +5,9 @@ interface MockCapacitorWindow {
   __emitCapacitorAppBackButton?: () => void
   __emitCapacitorAppPause?: () => void
   __emitCapacitorAppStateChange?: (isActive: boolean) => void
+  __emitAndroidOpenWithDocument?: (event: MockAndroidOpenWithEvent) => void
   __appListenerCount?: (eventName: string) => number
+  __androidDocumentListenerCount?: (eventName: string) => number
   __lastAndroidCreateOptions?: Record<string, unknown>
   Capacitor?: {
     PluginHeaders?: Array<{
@@ -24,6 +26,21 @@ interface MockCapacitorWindow {
       options?: Record<string, unknown>,
     ) => Promise<unknown>
   }
+}
+
+interface MockAndroidOpenWithEvent {
+  document?: {
+    sourceUri: string
+    displayName: string
+    providerName?: string
+    pathHint?: string
+    mimeType?: string
+    markdown: string
+    canWrite?: boolean
+    persisted?: boolean
+  }
+  errorCode?: string
+  message?: string
 }
 
 interface MockAndroidDocument {
@@ -51,6 +68,10 @@ interface MockAndroidDocument {
   }
 }
 
+interface MockAndroidAppOptions {
+  pendingOpenWithEvent?: MockAndroidOpenWithEvent
+}
+
 async function installTransientAndroidCreateMock(page: Page) {
   await page.addInitScript(() => {
     const win = window as unknown as MockCapacitorWindow
@@ -71,6 +92,8 @@ async function installTransientAndroidCreateMock(page: Page) {
         {
           name: 'AndroidDocuments',
           methods: [
+            { name: 'addListener', rtype: 'callback' },
+            { name: 'removeListener', rtype: 'promise' },
             { name: 'createMarkdownDocument', rtype: 'promise' },
             { name: 'openMarkdownDocument', rtype: 'promise' },
             { name: 'readMarkdownDocument', rtype: 'promise' },
@@ -81,6 +104,10 @@ async function installTransientAndroidCreateMock(page: Page) {
       nativeCallback(pluginName, methodName, options) {
         if (pluginName === 'App' && methodName === 'addListener') {
           return Promise.resolve(`app-listener-${String(options.eventName)}`)
+        }
+
+        if (pluginName === 'AndroidDocuments' && methodName === 'addListener') {
+          return Promise.resolve(`android-documents-listener-${String(options.eventName)}`)
         }
 
         return Promise.reject({
@@ -110,6 +137,10 @@ async function installTransientAndroidCreateMock(page: Page) {
           return Promise.resolve()
         }
 
+        if (pluginName === 'AndroidDocuments' && methodName === 'removeListener') {
+          return Promise.resolve()
+        }
+
         return Promise.reject({
           code: 'UNIMPLEMENTED',
           message: `${pluginName}.${methodName} is not mocked`,
@@ -119,12 +150,23 @@ async function installTransientAndroidCreateMock(page: Page) {
   })
 }
 
-async function installAndroidAppMock(page: Page, androidDocument?: MockAndroidDocument) {
-  await page.addInitScript((documentMock: MockAndroidDocument | null) => {
+async function installAndroidAppMock(
+  page: Page,
+  androidDocument?: MockAndroidDocument,
+  options: MockAndroidAppOptions = {},
+) {
+  await page.addInitScript(({ documentMock, mockOptions }) => {
     const win = window as unknown as MockCapacitorWindow
     const appListeners = new Map<string, Array<(data: unknown) => void>>()
+    const androidDocumentListeners = new Map<string, Array<(data: unknown) => void>>()
+    let pendingOpenWithEvent = mockOptions.pendingOpenWithEvent ?? null
     const emitAppEvent = (eventName: string, data: unknown) => {
       for (const listener of appListeners.get(eventName) ?? []) {
+        listener(data)
+      }
+    }
+    const emitAndroidDocumentEvent = (eventName: string, data: unknown) => {
+      for (const listener of androidDocumentListeners.get(eventName) ?? []) {
         listener(data)
       }
     }
@@ -139,7 +181,12 @@ async function installAndroidAppMock(page: Page, androidDocument?: MockAndroidDo
     win.__emitCapacitorAppStateChange = (isActive: boolean) => {
       emitAppEvent('appStateChange', { isActive })
     }
+    win.__emitAndroidOpenWithDocument = (event: MockAndroidOpenWithEvent) => {
+      emitAndroidDocumentEvent('openWithDocument', event)
+    }
     win.__appListenerCount = (eventName: string) => appListeners.get(eventName)?.length ?? 0
+    win.__androidDocumentListenerCount = (eventName: string) =>
+      androidDocumentListeners.get(eventName)?.length ?? 0
     win.Capacitor = {
       ...(win.Capacitor ?? {}),
       PluginHeaders: [
@@ -152,19 +199,17 @@ async function installAndroidAppMock(page: Page, androidDocument?: MockAndroidDo
             { name: 'exitApp', rtype: 'promise' },
           ],
         },
-        ...(documentMock
-          ? [
-              {
-                name: 'AndroidDocuments',
-                methods: [
-                  { name: 'createMarkdownDocument', rtype: 'promise' },
-                  { name: 'openMarkdownDocument', rtype: 'promise' },
-                  { name: 'readMarkdownDocument', rtype: 'promise' },
-                  { name: 'writeMarkdownDocument', rtype: 'promise' },
-                ],
-              },
-            ]
-          : []),
+        {
+          name: 'AndroidDocuments',
+          methods: [
+            { name: 'addListener', rtype: 'callback' },
+            { name: 'removeListener', rtype: 'promise' },
+            { name: 'createMarkdownDocument', rtype: 'promise' },
+            { name: 'openMarkdownDocument', rtype: 'promise' },
+            { name: 'readMarkdownDocument', rtype: 'promise' },
+            { name: 'writeMarkdownDocument', rtype: 'promise' },
+          ],
+        },
       ],
       nativeCallback(pluginName, methodName, options, callback) {
         if (pluginName === 'App' && methodName === 'addListener') {
@@ -176,6 +221,23 @@ async function installAndroidAppMock(page: Page, androidDocument?: MockAndroidDo
           return Promise.resolve(`app-listener-${String(options.eventName)}`)
         }
 
+        if (pluginName === 'AndroidDocuments' && methodName === 'addListener') {
+          if (typeof options.eventName === 'string' && callback) {
+            const listeners = androidDocumentListeners.get(options.eventName) ?? []
+            listeners.push(callback)
+            androidDocumentListeners.set(options.eventName, listeners)
+            if (options.eventName === 'openWithDocument' && pendingOpenWithEvent) {
+              window.setTimeout(() => {
+                if (pendingOpenWithEvent) {
+                  callback(pendingOpenWithEvent)
+                  pendingOpenWithEvent = null
+                }
+              }, 0)
+            }
+          }
+          return Promise.resolve(`android-documents-listener-${String(options.eventName)}`)
+        }
+
         return Promise.reject({
           code: 'UNIMPLEMENTED',
           message: `${pluginName}.${methodName} is not mocked`,
@@ -183,6 +245,10 @@ async function installAndroidAppMock(page: Page, androidDocument?: MockAndroidDo
       },
       nativePromise(pluginName, methodName, options = {}) {
         if (pluginName === 'App' && (methodName === 'removeListener' || methodName === 'exitApp')) {
+          return Promise.resolve()
+        }
+
+        if (pluginName === 'AndroidDocuments' && methodName === 'removeListener') {
           return Promise.resolve()
         }
 
@@ -257,7 +323,7 @@ async function installAndroidAppMock(page: Page, androidDocument?: MockAndroidDo
         })
       },
     }
-  }, androidDocument ?? null)
+  }, { documentMock: androidDocument ?? null, mockOptions: options })
 }
 
 test('creates a local draft from real editor input and returns it to the recent home', async ({
@@ -343,6 +409,12 @@ test('flushes local draft edits when the WebView page is hidden', async ({ page 
   await page.keyboard.press('Enter')
   await page.keyboard.type('pagehide extension')
   await expect(page.getByTestId('editor-host')).toContainText('pagehide extension')
+  await page.waitForFunction(
+    () =>
+      new Promise(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+      }),
+  )
 
   await page.evaluate(() => {
     window.dispatchEvent(new Event('pagehide'))
@@ -547,6 +619,100 @@ test('keeps a stale Android recent file on home with a recovery notice', async (
     page.getByText('This file was moved or deleted. Open it again from Android.'),
   ).toBeVisible()
   await expect(page.getByText('Missing Android Note')).toBeVisible()
+})
+
+test('opens a Markdown document delivered by Android open-with on app launch', async ({
+  page,
+}) => {
+  await installAndroidAppMock(page, undefined, {
+    pendingOpenWithEvent: {
+      document: {
+        sourceUri: 'content://test/open-with-cold',
+        displayName: 'Open With Cold.md',
+        providerName: 'Test Documents',
+        pathHint: 'Open With Cold.md',
+        mimeType: 'text/markdown',
+        markdown: '# Open With Cold\n\nfrom Android chooser',
+        canWrite: false,
+        persisted: true,
+      },
+    },
+  })
+  await page.addInitScript(() => localStorage.clear())
+  await page.goto('/')
+
+  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expect(page.getByTestId('editor-host')).toContainText('Open With Cold')
+  await expect(page.getByText('Read only', { exact: true })).toBeVisible()
+
+  const recentDocuments = await page.evaluate(
+    () => localStorage.getItem('marktext-for-android:recent-documents') ?? '',
+  )
+  expect(recentDocuments).toContain('content://test/open-with-cold')
+  expect(recentDocuments).toContain('Open With Cold.md')
+})
+
+test('opens a warm Android open-with document after preserving the current draft', async ({
+  page,
+}) => {
+  await installAndroidAppMock(page)
+  await page.addInitScript(() => localStorage.clear())
+  await page.goto('/')
+  await page.waitForFunction(() => {
+    const win = window as unknown as MockCapacitorWindow
+    return (win.__androidDocumentListenerCount?.('openWithDocument') ?? 0) > 0
+  })
+
+  await page.getByTestId('new-document-button').click()
+  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('# Draft Before Open With')
+  await page.keyboard.press('Enter')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('preserve this local draft before switching')
+
+  await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    win.__emitAndroidOpenWithDocument?.({
+      document: {
+        sourceUri: 'content://test/open-with-warm-transient',
+        displayName: 'Open With Warm.md',
+        providerName: 'Test Documents',
+        pathHint: 'Open With Warm.md',
+        mimeType: 'text/markdown',
+        markdown: '# Open With Warm\n\nopened while app was alive',
+        canWrite: false,
+        persisted: false,
+      },
+    })
+  })
+
+  await expect(page.getByTestId('editor-host')).toContainText('Open With Warm')
+  await expect(page.getByText('Opened temporarily')).toBeVisible()
+
+  const storage = await page.evaluate(() => ({
+    drafts: localStorage.getItem('marktext-for-android:drafts') ?? '',
+    recentDocuments: localStorage.getItem('marktext-for-android:recent-documents') ?? '',
+  }))
+  expect(storage.drafts).toContain('Draft Before Open With')
+  expect(storage.recentDocuments).not.toContain('content://test/open-with-warm-transient')
+})
+
+test('shows a safe home notice when Android open-with rejects a non-Markdown file', async ({
+  page,
+}) => {
+  await installAndroidAppMock(page, undefined, {
+    pendingOpenWithEvent: {
+      errorCode: 'UNSUPPORTED_OPEN_WITH_DOCUMENT',
+      message: 'Open a Markdown document',
+    },
+  })
+  await page.addInitScript(() => localStorage.clear())
+  await page.goto('/')
+
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  await expect(page.getByTestId('editor-host')).toBeHidden()
+  await expect(page.getByText('Open a Markdown file.')).toBeVisible()
 })
 
 test('keeps dirty Android edits in the editor and in a recovery draft when save fails', async ({


### PR DESCRIPTION
## Summary

This PR adds the first Android open-with flow for Markdown files. It lets Android file managers or other apps send a Markdown document to MarkText Android through `ACTION_VIEW`, then opens the document directly in the editor.

What changed:
- Registers Android `ACTION_VIEW` handlers for Markdown-oriented content URIs.
- Handles both cold-start and warm `onNewIntent` open-with delivery.
- Validates incoming intents before reading: action, category, `content://` scheme, Markdown MIME/extension, and current 5 MB read limit.
- Keeps non-Markdown files safe: broad MIME fallbacks may make Android list the app, but native validation rejects `.txt`/unsupported files before entering the editor.
- Avoids treating temporary URI grants as durable recent-document entries.
- Preserves the current editor document before switching on a warm open-with event.
- Stabilizes the pagehide E2E test that could lose the last typed characters on slower CI runners.

## Validation

Automated checks run locally:
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:e2e`
- `pnpm build`
- `pnpm android:sync`
- `./android/gradlew.bat -p android assembleDebug --no-daemon`

Real Android Emulator / ADB checks on `emulator-5554`:
- Installed the debug APK successfully.
- Verified Android resolver matches `text/markdown` `ACTION_VIEW` to `io.github.renakoni.marktextandroid/.MainActivity`.
- Opened a real MediaStore Markdown `content://media/external/file/...` URI by ADB `ACTION_VIEW` cold start.
- Confirmed the editor rendered the Markdown content by screenshot.
- Confirmed warm `ACTION_VIEW` delivery reaches the running Activity through `onNewIntent`.
- Confirmed a `.txt` file sent as `text/plain` is rejected with the safe home notice instead of opening as Markdown.
- Captured `MarkTextAndroid` logcat and app-private native logs under local ignored `logs/android-open-with-2026-07-01_02-06-30/`.

## Notes

ADB cannot directly grant some DocumentsProvider URIs as the shell UID, so the real automated test uses MediaStore `content://media/...` URIs. That still validates the actual Android open-with Activity path, native plugin event delivery, WebView handling, and UI rendering.