### PR TITLE
Fix Android dirty exits and editor loading

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,14 +2,6 @@
 import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { App } from '@capacitor/app'
 import type { PluginListenerHandle } from '@capacitor/core'
-import {
-  CodeBlockLanguageSelector,
-  EmojiSelector,
-  InlineFormatToolbar,
-  Muya,
-  PreviewToolBar,
-  en,
-} from '@muyajs/core'
 import DocumentHome from './components/DocumentHome.vue'
 import {
   addAndroidOpenWithDocumentListener,
@@ -39,7 +31,7 @@ import {
   upsertLocalDraft,
   type LocalDraftRecord,
 } from './lib/localDrafts'
-import { createLogger, getNativeLogInfo } from './lib/logger'
+import { createLogger, getNativeLogInfo, isNativeLoggerAvailable } from './lib/logger'
 import {
   createRecentDocumentFromAndroidDocument,
   createRecentDocumentFromLocalDraft,
@@ -63,15 +55,13 @@ const OPEN_WITH_TEMPORARY_ACCESS_MESSAGE =
   'Opened with temporary Android access. Save a copy to keep editing later.'
 const ANDROID_RECOVERY_DRAFT_PREFIX = 'android-recovery:'
 const ANDROID_SAVE_RECOVERY_MESSAGE = 'Save failed. A local recovery draft was kept.'
+const ANDROID_EXIT_RECOVERY_MESSAGE = 'Unsaved changes were kept as a recovery draft.'
+const ANDROID_EXIT_DISCARD_MESSAGE = 'Unsaved changes were discarded.'
 const MARKDOWN_FILE_EXTENSION_REGEXP = /\.(markdown|mdown|mkdn|mkd|md)$/i
 const MARKDOWN_COPY_SUFFIX_REGEXP = /\s+copy(?:\s+(\d+))?$/
 
-const editorPlugins = [
-  InlineFormatToolbar,
-  PreviewToolBar,
-  CodeBlockLanguageSelector,
-  EmojiSelector,
-] as const
+type MuyaCoreModule = typeof import('@muyajs/core')
+type MuyaEditor = InstanceType<MuyaCoreModule['Muya']>
 
 const editorElement = ref<HTMLElement | null>(null)
 const documentState = ref(createUntitledDocument())
@@ -81,13 +71,17 @@ const currentAndroidDocumentCanWrite = ref(false)
 const status = ref('Ready')
 const homeNotice = ref<string | null>(null)
 const currentScreen = ref<'home' | 'editor'>('home')
+const editorReady = ref(false)
 const draftExitPromptOpen = ref(false)
+const androidExitPromptOpen = ref(false)
 const editorMenuOpen = ref(false)
 const promptLocalDraftSaveOnExit = ref(false)
 const savingLocalDraftToAndroid = ref(false)
 const savingAndroidDocumentCopy = ref(false)
 
-let editor: Muya | null = null
+let editor: MuyaEditor | null = null
+let muyaCore: MuyaCoreModule | null = null
+let editorInitToken = 0
 let lastContentLogAt = 0
 let draftSaveTimer: number | null = null
 let androidSaveTimer: number | null = null
@@ -189,6 +183,23 @@ function canShowEditorActions() {
   return canSaveLocalDraftToAndroidDocument() || canSaveAndroidDocumentCopy()
 }
 
+function shouldPromptAndroidExitAfterSaveFailure() {
+  return (
+    documentState.value.autosaveTarget === 'android-document' &&
+    documentState.value.isDirty &&
+    hasDraftContent() &&
+    (documentState.value.autosaveState === 'save-failed' || !currentAndroidDocumentCanWrite.value)
+  )
+}
+
+function getAndroidExitPromptMessage() {
+  if (!currentAndroidDocumentCanWrite.value) {
+    return 'This file cannot be saved directly. Save a copy or keep a recovery draft before leaving.'
+  }
+
+  return 'MarkText could not save this file. Save a copy or keep a recovery draft before leaving.'
+}
+
 function getSuggestedMarkdownCopyFileName(
   markdown: string,
   displayName: string,
@@ -215,14 +226,32 @@ function getSuggestedMarkdownCopyFileName(
   return `${copyBaseName} copy ${Date.now()}${extension}`
 }
 
-function registerMuyaPlugins() {
+async function loadMuyaCore() {
+  if (!muyaCore) {
+    await import('@muyajs/core/lib/core.css')
+    muyaCore = await import('@muyajs/core')
+  }
+
+  return muyaCore
+}
+
+async function registerMuyaPlugins() {
+  const core = await loadMuyaCore()
+  const editorPlugins = [
+    core.InlineFormatToolbar,
+    core.PreviewToolBar,
+    core.CodeBlockLanguageSelector,
+    core.EmojiSelector,
+  ] as const
+
   editorLog.debug('register Muya plugins start', { count: editorPlugins.length })
   for (const plugin of editorPlugins) {
-    if (!Muya.plugins.some(entry => entry.plugin === plugin)) {
-      Muya.use(plugin)
+    if (!core.Muya.plugins.some(entry => entry.plugin === plugin)) {
+      core.Muya.use(plugin)
     }
   }
-  editorLog.debug('register Muya plugins complete', { registered: Muya.plugins.length })
+  editorLog.debug('register Muya plugins complete', { registered: core.Muya.plugins.length })
+  return core
 }
 
 function createDocumentFromDraft(draft: LocalDraftRecord) {
@@ -609,7 +638,7 @@ async function saveLocalDraftToAndroidDocument(options: { returnHomeAfterSave?: 
   }
 }
 
-async function saveAndroidDocumentCopy() {
+async function saveAndroidDocumentCopy(options: { returnHomeAfterSave?: boolean } = {}) {
   editorMenuOpen.value = false
 
   if (!editor || !canSaveAndroidDocumentCopy() || savingAndroidDocumentCopy.value) {
@@ -679,6 +708,10 @@ async function saveAndroidDocumentCopy() {
       sourceUri: document.sourceUri,
       characters: copySourceDocument.markdown.length,
     })
+    androidExitPromptOpen.value = false
+    if (options.returnHomeAfterSave) {
+      closeEditorToHome()
+    }
     return true
   } catch (error) {
     if (originalSourceUri && copySourceDocument.isDirty) {
@@ -751,14 +784,18 @@ function saveDraft() {
   }
 }
 
-function initEditor(initialMarkdown: string) {
+async function initEditor(initialMarkdown: string) {
   if (!editorElement.value) {
     return
   }
 
-  registerMuyaPlugins()
-
   try {
+    const token = ++editorInitToken
+    const { Muya, en } = await registerMuyaPlugins()
+    if (token !== editorInitToken || !editorElement.value) {
+      return
+    }
+
     editorLog.info('Muya init start', {
       initialCharacters: initialMarkdown.length,
     })
@@ -794,6 +831,7 @@ function initEditor(initialMarkdown: string) {
       editorLog.debug('editor blurred')
     })
     syncMarkdown('Ready')
+    editorReady.value = true
     editorLog.info('Muya init complete', {
       characters: characterCount.value,
       words: wordCount.value,
@@ -816,6 +854,7 @@ function releaseEditorFocusAfterOpen() {
 }
 
 async function openEditor(markdown: string) {
+  editorReady.value = false
   const wasEditorOpen = currentScreen.value === 'editor'
   destroyEditor()
   if (wasEditorOpen) {
@@ -825,7 +864,7 @@ async function openEditor(markdown: string) {
 
   currentScreen.value = 'editor'
   await nextTick()
-  initEditor(markdown)
+  await initEditor(markdown)
 }
 
 function rememberAndroidDocument(document: OpenedAndroidDocument) {
@@ -930,6 +969,7 @@ async function handleAndroidOpenWithDocumentEvent(event: AndroidOpenWithDocument
 
   await preserveCurrentDocumentBeforeIncomingOpen()
   draftExitPromptOpen.value = false
+  androidExitPromptOpen.value = false
   editorMenuOpen.value = false
   await openAndroidDocumentResult(event.document, {
     source: 'open-with',
@@ -952,6 +992,7 @@ async function openDocument(id: string) {
     }
 
     homeNotice.value = null
+    androidExitPromptOpen.value = false
     promptLocalDraftSaveOnExit.value = false
     currentAndroidDocumentCanWrite.value = false
     documentState.value = createDocumentFromDraft(draft)
@@ -963,6 +1004,7 @@ async function openDocument(id: string) {
 
   if (recentDocument.kind === 'android-document' && recentDocument.sourceUri) {
     homeNotice.value = null
+    androidExitPromptOpen.value = false
     try {
       const document = await readAndroidMarkdownDocument(recentDocument.sourceUri)
       await openAndroidDocumentResult(document)
@@ -985,6 +1027,7 @@ async function openDocument(id: string) {
 
 function newDocument() {
   homeNotice.value = null
+  androidExitPromptOpen.value = false
   appLog.info('create new local document')
   currentAndroidDocumentCanWrite.value = false
   promptLocalDraftSaveOnExit.value = true
@@ -997,6 +1040,8 @@ function toggleEditorMenu() {
 }
 
 function destroyEditor() {
+  editorInitToken += 1
+  editorReady.value = false
   clearDraftSaveTimer()
   clearAndroidDocumentSaveTimer()
   editor?.destroy()
@@ -1005,6 +1050,7 @@ function destroyEditor() {
 
 function closeEditorToHome() {
   draftExitPromptOpen.value = false
+  androidExitPromptOpen.value = false
   editorMenuOpen.value = false
   destroyEditor()
   currentScreen.value = 'home'
@@ -1016,6 +1062,9 @@ async function showHome() {
   if (documentState.value.autosaveTarget === 'android-document') {
     const saved = await saveAndroidDocument()
     if (!saved) {
+      if (shouldPromptAndroidExitAfterSaveFailure()) {
+        androidExitPromptOpen.value = true
+      }
       return
     }
   } else {
@@ -1025,6 +1074,27 @@ async function showHome() {
       return
     }
   }
+  closeEditorToHome()
+}
+
+function keepAndroidRecoveryAndShowHome() {
+  const sourceUri = documentState.value.sourceUri
+  const currentDocument = syncDocumentFromEditor(documentState.value.isDirty)
+  if (sourceUri && currentDocument.markdown.trim()) {
+    persistAndroidRecoveryDraft(sourceUri, currentDocument.markdown)
+  }
+
+  homeNotice.value = ANDROID_EXIT_RECOVERY_MESSAGE
+  closeEditorToHome()
+}
+
+function discardAndroidChangesAndShowHome() {
+  const sourceUri = documentState.value.sourceUri
+  if (sourceUri) {
+    removeAndroidRecoveryDraft(sourceUri)
+  }
+
+  homeNotice.value = ANDROID_EXIT_DISCARD_MESSAGE
   closeEditorToHome()
 }
 
@@ -1065,8 +1135,15 @@ async function handleAppBackButton() {
   appLog.info('Android back button pressed', {
     screen: currentScreen.value,
     promptOpen: draftExitPromptOpen.value,
+    androidExitPromptOpen: androidExitPromptOpen.value,
     menuOpen: editorMenuOpen.value,
   })
+
+  if (androidExitPromptOpen.value) {
+    androidExitPromptOpen.value = false
+    status.value = getAndroidEditorStatus()
+    return
+  }
 
   if (draftExitPromptOpen.value) {
     draftExitPromptOpen.value = false
@@ -1210,13 +1287,15 @@ onMounted(() => {
 
   installAndroidDocumentIntentListeners()
 
-  getNativeLogInfo().then(info => {
-    if (info) {
-      loggingLog.info('native logging ready', info)
-    } else {
-      loggingLog.warn('native logging unavailable')
-    }
-  })
+  if (isNativeLoggerAvailable()) {
+    getNativeLogInfo().then(info => {
+      if (info) {
+        loggingLog.info('native logging ready', info)
+      } else {
+        loggingLog.warn('native logging unavailable')
+      }
+    })
+  }
 })
 
 onBeforeUnmount(() => {
@@ -1279,7 +1358,7 @@ onBeforeUnmount(() => {
             role="menuitem"
             data-testid="save-copy-button"
             :disabled="savingAndroidDocumentCopy"
-            @click="saveAndroidDocumentCopy"
+            @click="() => saveAndroidDocumentCopy()"
           >
             Save a copy
           </button>
@@ -1288,7 +1367,13 @@ onBeforeUnmount(() => {
     </header>
 
     <section class="editor-pane" aria-label="Markdown editor">
-      <div ref="editorElement" class="muya-host" data-testid="editor-host" />
+      <div
+        class="editor-host-shell"
+        :aria-busy="!editorReady"
+        :data-testid="editorReady ? 'editor-host' : 'editor-loading-host'"
+      >
+        <div ref="editorElement" class="muya-host" />
+      </div>
     </section>
 
     <footer class="status-bar">
@@ -1335,6 +1420,49 @@ onBeforeUnmount(() => {
             @click="discardLocalDraftAndShowHome"
           >
             Discard
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section
+      v-if="androidExitPromptOpen"
+      class="draft-save-sheet"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="android-exit-title"
+      data-testid="android-exit-prompt"
+    >
+      <div class="draft-save-panel">
+        <h2 id="android-exit-title">Save changes before leaving?</h2>
+        <p>{{ getAndroidExitPromptMessage() }}</p>
+        <div class="draft-save-actions">
+          <button
+            v-if="canSaveAndroidDocumentCopy()"
+            class="primary-action"
+            type="button"
+            data-testid="prompt-save-copy-button"
+            :disabled="savingAndroidDocumentCopy"
+            @click="saveAndroidDocumentCopy({ returnHomeAfterSave: true })"
+          >
+            Save a copy
+          </button>
+          <button
+            type="button"
+            data-testid="prompt-keep-recovery-button"
+            :disabled="savingAndroidDocumentCopy"
+            @click="keepAndroidRecoveryAndShowHome"
+          >
+            Keep recovery draft
+          </button>
+          <button
+            class="danger-action"
+            type="button"
+            data-testid="prompt-discard-android-changes-button"
+            :disabled="savingAndroidDocumentCopy"
+            @click="discardAndroidChangesAndShowHome"
+          >
+            Discard changes
           </button>
         </div>
       </div>

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -25,6 +25,12 @@ interface NativeLoggerPlugin {
   getInfo(): Promise<NativeLogInfo>
 }
 
+interface CapacitorWindow {
+  Capacitor?: {
+    PluginHeaders?: Array<{ name: string }>
+  }
+}
+
 const NativeLogger = registerPlugin<NativeLoggerPlugin>('NativeLogger')
 
 const STORAGE_KEY = 'marktext-for-android:debug-logs:v2'
@@ -33,9 +39,22 @@ const MAX_CONTEXT_LENGTH = 2400
 const REDACTED_CONTEXT_KEYS = new Set(['blocks', 'content', 'doc', 'markdown', 'prevdoc', 'text'])
 const sessionId = createSessionId()
 const platform = Capacitor.getPlatform()
+const nativeLoggingSupported = platform === 'android' && Capacitor.isNativePlatform()
 
 let globalLoggingInstalled = false
 let nativeLoggingUnavailable = false
+
+function hasNativeLoggerPlugin() {
+  const capacitor = (window as unknown as CapacitorWindow).Capacitor
+  return (
+    Array.isArray(capacitor?.PluginHeaders) &&
+    capacitor.PluginHeaders.some(header => header.name === 'NativeLogger')
+  )
+}
+
+export function isNativeLoggerAvailable() {
+  return nativeLoggingSupported && hasNativeLoggerPlugin()
+}
 
 function createSessionId() {
   const random = Math.random().toString(36).slice(2, 8)
@@ -158,6 +177,10 @@ function writeConsole(entry: NativeLogEntry) {
 }
 
 function writeNative(entry: NativeLogEntry) {
+  if (!isNativeLoggerAvailable()) {
+    return
+  }
+
   if (nativeLoggingUnavailable) {
     return
   }
@@ -265,6 +288,10 @@ export function downloadLocalLogs() {
 export async function clearLogs() {
   localStorage.removeItem(STORAGE_KEY)
   nativeLoggingUnavailable = false
+  if (!isNativeLoggerAvailable()) {
+    return
+  }
+
   try {
     await NativeLogger.clear()
   } catch {
@@ -273,6 +300,10 @@ export async function clearLogs() {
 }
 
 export async function getNativeLogInfo() {
+  if (!isNativeLoggerAvailable()) {
+    return null
+  }
+
   try {
     return await NativeLogger.getInfo()
   } catch {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import { createApp } from 'vue'
-import '@muyajs/core/lib/core.css'
 import './style.css'
 import App from './App.vue'
 import { appLogger, installGlobalLogging } from './lib/logger'

--- a/src/style.css
+++ b/src/style.css
@@ -364,7 +364,7 @@ body {
   overflow: hidden;
 }
 
-.muya-host {
+.editor-host-shell {
   width: min(100%, 980px);
   height: 100%;
   margin: 0 auto;
@@ -376,7 +376,11 @@ body {
   -webkit-overflow-scrolling: touch;
 }
 
-.muya-host .mu-editor {
+.editor-host-shell .muya-host {
+  min-height: 100%;
+}
+
+.editor-host-shell .mu-editor {
   min-height: 100%;
   padding: 42px 56px 56px;
 }
@@ -483,14 +487,14 @@ body {
     padding: 0;
   }
 
-  .muya-host {
+  .editor-host-shell {
     width: 100%;
     border-width: 0;
     border-radius: 0;
     box-shadow: none;
   }
 
-  .muya-host .mu-editor {
+  .editor-host-shell .mu-editor {
     padding: 24px 18px 48px;
   }
 

--- a/tests/e2e/mobile-recent-home.spec.ts
+++ b/tests/e2e/mobile-recent-home.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 
+test.describe.configure({ timeout: 60000 })
+
 interface MockCapacitorWindow {
   androidBridge?: unknown
   __emitCapacitorAppBackButton?: () => void
@@ -70,6 +72,10 @@ interface MockAndroidDocument {
 
 interface MockAndroidAppOptions {
   pendingOpenWithEvent?: MockAndroidOpenWithEvent
+}
+
+async function expectEditorReady(page: Page) {
+  await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
 }
 
 async function installTransientAndroidCreateMock(page: Page) {
@@ -339,7 +345,7 @@ test('creates a local draft from real editor input and returns it to the recent 
   await expect(page.getByTestId('new-document-button')).toBeVisible()
 
   await page.getByTestId('new-document-button').click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
   await expect(page.getByTestId('back-button')).toHaveText('Back')
 
   await page.getByTestId('editor-host').click()
@@ -374,7 +380,7 @@ test('flushes local draft edits when the WebView becomes hidden', async ({ page 
   await page.reload()
 
   await page.getByTestId('new-document-button').click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
 
   await page.getByTestId('editor-host').click()
   await page.keyboard.type('# Pause flush note')
@@ -401,7 +407,7 @@ test('flushes local draft edits when the WebView page is hidden', async ({ page 
   await page.reload()
 
   await page.getByTestId('new-document-button').click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
 
   await page.getByTestId('editor-host').click()
   await page.keyboard.type('# Pagehide flush note')
@@ -438,7 +444,7 @@ test('flushes local draft edits on Capacitor app pause', async ({ page }) => {
   })
 
   await page.getByTestId('new-document-button').click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
 
   await page.getByTestId('editor-host').click()
   await page.keyboard.type('# Capacitor pause note')
@@ -467,7 +473,7 @@ test('flushes local draft edits on Capacitor app inactive', async ({ page }) => 
   })
 
   await page.getByTestId('new-document-button').click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
 
   await page.getByTestId('editor-host').click()
   await page.keyboard.type('# Capacitor inactive note')
@@ -498,7 +504,7 @@ test('opens the draft exit prompt from the Android back button', async ({ page }
   })
 
   await page.getByTestId('new-document-button').click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
 
   await page.getByTestId('editor-host').click()
   await page.keyboard.type('# Android back note')
@@ -560,7 +566,7 @@ test('returns a clean Android document to recent home from the Android back butt
   })
 
   await page.getByRole('button', { name: /Clean Android Note/ }).click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
 
   await page.evaluate(() => {
     const win = window as unknown as MockCapacitorWindow
@@ -641,7 +647,7 @@ test('opens a Markdown document delivered by Android open-with on app launch', a
   await page.addInitScript(() => localStorage.clear())
   await page.goto('/')
 
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
   await expect(page.getByTestId('editor-host')).toContainText('Open With Cold')
   await expect(page.getByText('Read only', { exact: true })).toBeVisible()
 
@@ -664,7 +670,7 @@ test('opens a warm Android open-with document after preserving the current draft
   })
 
   await page.getByTestId('new-document-button').click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
   await page.getByTestId('editor-host').click()
   await page.keyboard.type('# Draft Before Open With')
   await page.keyboard.press('Enter')
@@ -757,7 +763,7 @@ test('keeps dirty Android edits in the editor and in a recovery draft when save 
   await page.reload()
 
   await page.getByRole('button', { name: /Write Fails/ }).click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
 
   await page.getByTestId('editor-host').click()
   await page.keyboard.press('End')
@@ -767,14 +773,125 @@ test('keeps dirty Android edits in the editor and in a recovery draft when save 
 
   await page.getByTestId('back-button').click()
 
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
+  await expect(page.getByTestId('android-exit-prompt')).toBeVisible()
   await expect(
     page.getByText(/Reopen this file from Android before saving again/),
   ).toBeVisible()
+  await page.getByTestId('prompt-keep-recovery-button').click()
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  await expect(page.getByText('Unsaved changes were kept as a recovery draft.')).toBeVisible()
 
   const drafts = await page.evaluate(() => localStorage.getItem('marktext-for-android:drafts') ?? '')
   expect(drafts).toContain('android-recovery:content://test/write-fails')
   expect(drafts).toContain('unsaved recovery line')
+})
+
+test('offers save-copy when leaving a dirty read-only Android document', async ({ page }) => {
+  const now = '2026-06-29T06:25:00.000Z'
+  const document = {
+    sourceUri: 'content://test/read-only-exit',
+    displayName: 'Read Only Exit.md',
+    markdown: '# Read Only Exit\n\nInitial text.',
+    canWrite: false,
+    createResult: {
+      sourceUri: 'content://test/read-only-exit-copy',
+      displayName: 'Read Only Exit copy.md',
+      canWrite: true,
+    },
+  }
+
+  await installAndroidAppMock(page, document)
+  await page.goto('/')
+  await page.evaluate(({ now, document }) => {
+    localStorage.clear()
+    localStorage.setItem(
+      'marktext-for-android:recent-documents',
+      JSON.stringify([
+        {
+          id: `android-document:${document.sourceUri}`,
+          kind: 'android-document',
+          displayName: document.displayName,
+          title: 'Read Only Exit',
+          sourceUri: document.sourceUri,
+          providerName: 'Test Documents',
+          pathHint: document.displayName,
+          markdownPreview: null,
+          updatedAt: now,
+          lastOpenedAt: now,
+          lastSavedAt: null,
+          autosaveState: 'clean',
+          canWrite: false,
+        },
+      ]),
+    )
+  }, { now, document })
+  await page.reload()
+
+  await page.getByRole('button', { name: /Read Only Exit/ }).click()
+  await expect(page.getByText('Read only', { exact: true })).toBeVisible()
+  await expectEditorReady(page)
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.press('End')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('exit through save copy')
+
+  await page.getByTestId('back-button').click()
+  await expect(page.getByTestId('android-exit-prompt')).toBeVisible()
+  await expect(page.getByText('This file cannot be saved directly.')).toBeVisible()
+  await page.getByTestId('prompt-save-copy-button').click()
+
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  await expect(page.getByText('Read Only Exit').first()).toBeVisible()
+
+  const storage = await page.evaluate(() => ({
+    createOptions: (window as unknown as MockCapacitorWindow).__lastAndroidCreateOptions,
+    recentDocuments: localStorage.getItem('marktext-for-android:recent-documents') ?? '',
+  }))
+  expect(storage.createOptions?.suggestedName).toBe('Read Only Exit copy.md')
+  expect(storage.recentDocuments).toContain('content://test/read-only-exit-copy')
+  expect(storage.recentDocuments).toContain('Read Only Exit copy.md')
+})
+
+test('keeps temporary open-with edits as a recovery draft when leaving', async ({ page }) => {
+  await installAndroidAppMock(page, undefined, {
+    pendingOpenWithEvent: {
+      document: {
+        sourceUri: 'content://test/open-with-temporary-exit',
+        displayName: 'Temporary Exit.md',
+        providerName: 'Test Documents',
+        pathHint: 'Temporary Exit.md',
+        mimeType: 'text/markdown',
+        markdown: '# Temporary Exit\n\nInitial text.',
+        canWrite: false,
+        persisted: false,
+      },
+    },
+  })
+  await page.addInitScript(() => localStorage.clear())
+  await page.goto('/')
+
+  await expectEditorReady(page)
+  await expect(page.getByText('Opened temporarily')).toBeVisible()
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.press('End')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('temporary open-with edit')
+
+  await page.getByTestId('back-button').click()
+  await expect(page.getByTestId('android-exit-prompt')).toBeVisible()
+  await page.getByTestId('prompt-keep-recovery-button').click()
+
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  await expect(page.getByText('Unsaved changes were kept as a recovery draft.')).toBeVisible()
+
+  const storage = await page.evaluate(() => ({
+    drafts: localStorage.getItem('marktext-for-android:drafts') ?? '',
+    recentDocuments: localStorage.getItem('marktext-for-android:recent-documents') ?? '',
+  }))
+  expect(storage.drafts).toContain('android-recovery:content://test/open-with-temporary-exit')
+  expect(storage.drafts).toContain('temporary open-with edit')
+  expect(storage.recentDocuments).not.toContain('content://test/open-with-temporary-exit')
 })
 
 test('saves a writable Android document as a copy and switches to the new document', async ({
@@ -834,7 +951,7 @@ test('saves a writable Android document as a copy and switches to the new docume
   await page.reload()
 
   await page.getByRole('button', { name: /Original Save Copy/ }).click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
   await page.getByTestId('editor-host').click()
   await page.keyboard.press('End')
   await page.keyboard.press('Enter')
@@ -925,7 +1042,7 @@ test('increments the save-copy name when the current Android document is already
   await page.reload()
 
   await page.getByRole('button', { name: /Original Copy Name copy/ }).first().click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
 
   await page.getByTestId('editor-menu-button').click()
   await page.getByTestId('save-copy-button').click()
@@ -981,6 +1098,7 @@ test('saves a read-only Android document as a writable copy', async ({ page }) =
 
   await page.getByRole('button', { name: /Read Only Original/ }).click()
   await expect(page.getByText('Read only', { exact: true })).toBeVisible()
+  await expectEditorReady(page)
   await page.getByTestId('editor-host').click()
   await page.keyboard.press('End')
   await page.keyboard.press('Enter')
@@ -1010,7 +1128,7 @@ test('keeps the local draft when Android document access is not persisted', asyn
   await page.reload()
 
   await page.getByTestId('new-document-button').click()
-  await expect(page.getByTestId('editor-host')).toBeVisible()
+  await expectEditorReady(page)
 
   await page.getByTestId('editor-host').click()
   await page.keyboard.type('# Transient grant note')


### PR DESCRIPTION
This PR is a bug-sweep pass for the mobile editor and Android document flows.

What changed:
- Adds an Android exit recovery prompt for dirty documents that cannot be saved directly, including read-only files, save failures, and temporary open-with access.
- Lets users save a copy, keep a local recovery draft, or discard changes before leaving those Android document states.
- Keeps temporary open-with edits as recovery drafts instead of treating transient URIs as the only continuation path.
- Lazy-loads Muya editor code and CSS so the recent/home shell is no longer blocked by the full editor bundle.
- Avoids native logger calls in browser/test shells when the native plugin is not actually available.
- Updates the existing mobile E2E spec with targeted coverage for dirty Android exits, read-only save-copy, temporary open-with recovery, and editor-ready waits after lazy loading.

Validation performed locally:
- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm test:e2e
- pnpm build
- pnpm android:sync
- .\android\gradlew.bat -p android assembleDebug --no-daemon
- ADB install and launch on emulator-5554
- Real emulator smoke test for home render, new draft, Muya lazy editor load, local autosave, Back prompt, Keep as draft, and native log file output

Notes:
- The Vite large chunk warning still exists for Muya/diagram dependencies, but the initial app chunk is now much smaller. This PR only splits the editor load; it does not remove editor capabilities.
- E2E files are intentionally not split in this PR. We can do that separately when we add the next TypeScript/helper/worker structure.