### PR TITLE
Add Android share intent support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,6 +43,23 @@
                 <data android:mimeType="application/octet-stream" />
             </intent-filter>
 
+            <intent-filter android:label="@string/app_name">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="text/markdown" />
+                <data android:mimeType="text/x-markdown" />
+                <data android:mimeType="text/vnd.daringfireball.markdown" />
+            </intent-filter>
+
+            <intent-filter android:label="@string/app_name">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="application/octet-stream" />
+            </intent-filter>
+
         </activity>
 
         <provider

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -2,6 +2,8 @@ package io.github.renakoni.marktextandroid;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.ClipData;
+import android.content.ComponentName;
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.content.UriPermission;
@@ -9,9 +11,11 @@ import android.content.pm.PackageManager;
 import android.content.pm.ProviderInfo;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.OpenableColumns;
 import android.util.Log;
 import androidx.activity.result.ActivityResult;
+import androidx.core.content.FileProvider;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -19,7 +23,9 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.ActivityCallback;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -35,11 +41,23 @@ public class AndroidDocumentsPlugin extends Plugin {
     private static final String CALLBACK_OPEN_MARKDOWN_DOCUMENT = "openMarkdownDocumentResult";
     private static final String CALLBACK_CREATE_MARKDOWN_DOCUMENT = "createMarkdownDocumentResult";
     private static final String EVENT_OPEN_WITH_DOCUMENT = "openWithDocument";
+    private static final String EVENT_SHARE_DOCUMENT = "shareDocument";
+    private static final String SHARE_CACHE_DIRECTORY = "shared-markdown";
+    private String lastHandledIncomingIntentId = "";
+
+    @Override
+    public void load() {
+        super.load();
+        Activity activity = getActivity();
+        if (activity != null) {
+            handleIncomingIntent(activity.getIntent());
+        }
+    }
 
     @Override
     protected void handleOnNewIntent(Intent intent) {
         super.handleOnNewIntent(intent);
-        handleOpenWithIntent(intent);
+        handleIncomingIntent(intent);
     }
 
     @PluginMethod
@@ -113,6 +131,63 @@ public class AndroidDocumentsPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void shareMarkdownDocument(PluginCall call) {
+        Activity activity = getActivity();
+        if (activity == null) {
+            call.reject("No Android activity is available for sharing", "SHARE_TARGET_UNAVAILABLE");
+            return;
+        }
+
+        String markdown = call.getString("markdown", null);
+        if (markdown == null) {
+            call.reject("Markdown content is required", "INVALID_MARKDOWN");
+            return;
+        }
+
+        String suggestedName = normalizeSuggestedMarkdownName(call.getString("suggestedName", ""));
+        byte[] bytes;
+        try {
+            bytes = validateMarkdownBytes(markdown);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android share rejected: " + ex.getMessage());
+            call.reject(ex.getMessage(), ex.code, ex);
+            return;
+        }
+
+        try {
+            Uri uri = writeShareCacheFile(suggestedName, bytes);
+            Intent shareIntent = new Intent(Intent.ACTION_SEND);
+            shareIntent.setType("text/markdown");
+            shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
+            shareIntent.putExtra(Intent.EXTRA_TITLE, suggestedName);
+            shareIntent.putExtra(Intent.EXTRA_SUBJECT, suggestedName);
+            shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            shareIntent.setClipData(ClipData.newUri(getContext().getContentResolver(), suggestedName, uri));
+
+            Intent chooser = Intent.createChooser(shareIntent, "Share Markdown");
+            chooser.putExtra(
+                Intent.EXTRA_EXCLUDE_COMPONENTS,
+                new ComponentName[] { new ComponentName(getContext(), MainActivity.class) }
+            );
+            chooser.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            activity.startActivity(chooser);
+
+            JSObject result = new JSObject();
+            result.put("displayName", suggestedName);
+            result.put("mimeType", "text/markdown");
+            result.put("bytes", bytes.length);
+            Log.i(TAG, "Opened Android share sheet for Markdown document: " + safeForLog(suggestedName));
+            call.resolve(result);
+        } catch (ActivityNotFoundException ex) {
+            Log.w(TAG, "No Android share target is available", ex);
+            call.reject("No Android share target is available", "SHARE_TARGET_UNAVAILABLE", ex);
+        } catch (IOException | SecurityException ex) {
+            Log.e(TAG, "Failed to prepare Markdown document for sharing", ex);
+            call.reject("Could not prepare Markdown document for sharing", "SHARE_WRITE_FAILED", ex);
+        }
+    }
+
+    @PluginMethod
     public void readMarkdownDocument(PluginCall call) {
         String sourceUri = call.getString("sourceUri", "");
         Uri uri = parseContentUri(sourceUri);
@@ -173,6 +248,51 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
     }
 
+    private void handleIncomingIntent(Intent intent) {
+        if (intent == null) {
+            return;
+        }
+
+        String action = intent.getAction();
+        if (
+            !Intent.ACTION_VIEW.equals(action) &&
+            !Intent.ACTION_SEND.equals(action) &&
+            !Intent.ACTION_SEND_MULTIPLE.equals(action)
+        ) {
+            return;
+        }
+
+        if (!markIncomingIntentForHandling(intent)) {
+            return;
+        }
+
+        if (Intent.ACTION_VIEW.equals(action)) {
+            handleOpenWithIntent(intent);
+            return;
+        }
+
+        if (Intent.ACTION_SEND.equals(action)) {
+            handleShareIntent(intent);
+            return;
+        }
+
+        if (Intent.ACTION_SEND_MULTIPLE.equals(action)) {
+            Log.w(TAG, "Rejected Android multi-share intent");
+            notifyShareRejected("UNSUPPORTED_SHARE_DOCUMENT", "Share one Markdown file at a time");
+        }
+    }
+
+    private boolean markIncomingIntentForHandling(Intent intent) {
+        String intentId = intent.getAction() + ":" + System.identityHashCode(intent);
+        if (intentId.equals(lastHandledIncomingIntentId)) {
+            Log.d(TAG, "Ignored duplicate Android incoming intent: " + safeForLog(intent.getAction()));
+            return false;
+        }
+
+        lastHandledIncomingIntentId = intentId;
+        return true;
+    }
+
     private void handleOpenWithIntent(Intent intent) {
         if (intent == null || !Intent.ACTION_VIEW.equals(intent.getAction())) {
             return;
@@ -220,6 +340,119 @@ public class AndroidDocumentsPlugin extends Plugin {
         } catch (IOException ex) {
             Log.e(TAG, "Failed to open Android open-with document", ex);
             notifyOpenWithRejected("DOCUMENT_READ_FAILED", "Failed to read Android document");
+        }
+    }
+
+    private void handleShareIntent(Intent intent) {
+        if (intent == null || !Intent.ACTION_SEND.equals(intent.getAction())) {
+            return;
+        }
+
+        if (!hasOnlyAllowedShareCategories(intent)) {
+            Log.w(TAG, "Rejected Android share intent with unsupported categories");
+            notifyShareRejected("INVALID_SHARE_INTENT", "This Android share request is not supported");
+            return;
+        }
+
+        Uri streamUri;
+        try {
+            streamUri = getSharedStreamUri(intent);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android share stream extra rejected: " + ex.getMessage());
+            notifyShareRejected(ex.code, ex.getMessage());
+            return;
+        }
+
+        if (streamUri != null) {
+            handleSharedStream(streamUri, intent);
+            return;
+        }
+
+        CharSequence sharedText;
+        try {
+            sharedText = getSharedText(intent);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android share text extra rejected: " + ex.getMessage());
+            notifyShareRejected(ex.code, ex.getMessage());
+            return;
+        }
+
+        if (sharedText != null && sharedText.length() > 0) {
+            handleSharedText(sharedText.toString(), intent);
+            return;
+        }
+
+        notifyShareRejected("SHARE_CONTENT_MISSING", "This Android share did not include Markdown content");
+    }
+
+    private void handleSharedStream(Uri uri, Intent intent) {
+        if (!"content".equals(uri.getScheme())) {
+            Log.w(TAG, "Rejected Android shared URI with unsupported scheme: " + safeForLog(uri.getScheme()));
+            notifyShareRejected(
+                "INVALID_SHARE_SOURCE_URI",
+                "This Android share did not provide a supported file URI"
+            );
+            return;
+        }
+
+        try {
+            JSObject document = buildSharedStreamDocumentResult(uri, intent);
+            if ((intent.getFlags() & Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION) != 0) {
+                persistUriPermission(uri, intent);
+            }
+            document.put("persisted", hasPersistedReadPermission(uri));
+            document.put("canWrite", canWrite(uri, intent));
+            JSObject event = new JSObject();
+            event.put("document", document);
+            event.put("source", "share");
+            Log.i(TAG, "Received Android shared Markdown file: " + safeForLog(document.getString("displayName")));
+            notifyListeners(EVENT_SHARE_DOCUMENT, event, true);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android shared document rejected: " + ex.getMessage());
+            notifyShareRejected(ex.code, ex.getMessage());
+        } catch (FileNotFoundException ex) {
+            Log.w(TAG, "Android shared document no longer exists", ex);
+            notifyShareRejected("DOCUMENT_NOT_FOUND", "This Android document was moved or deleted");
+        } catch (SecurityException ex) {
+            Log.w(TAG, "Android shared document permission is not available", ex);
+            notifyShareRejected("DOCUMENT_PERMISSION_LOST", "Android document permission is no longer available");
+        } catch (IOException ex) {
+            Log.e(TAG, "Failed to open Android shared document", ex);
+            notifyShareRejected("DOCUMENT_READ_FAILED", "Failed to read Android document");
+        }
+    }
+
+    private void handleSharedText(String markdown, Intent intent) {
+        String mimeType = normalizeMimeType(intent.getType());
+        if (!isSharedTextMimeType(mimeType)) {
+            Log.w(TAG, "Rejected Android shared text with unsupported MIME type: " + safeForLog(mimeType));
+            notifyShareRejected("UNSUPPORTED_SHARE_DOCUMENT", "Share Markdown text or a Markdown file");
+            return;
+        }
+
+        try {
+            validateMarkdownBytes(markdown);
+            String displayName = getSharedTextDisplayName(intent);
+            JSObject document = new JSObject();
+            document.put("canceled", false);
+            document.put("sourceUri", JSObject.NULL);
+            document.put("displayName", displayName);
+            document.put("providerName", "Android share");
+            document.put("pathHint", displayName);
+            document.put("mimeType", mimeType.length() > 0 ? mimeType : "text/plain");
+            document.put("markdown", markdown);
+            document.put("canWrite", false);
+            document.put("persisted", false);
+            document.put("shareKind", "text");
+
+            JSObject event = new JSObject();
+            event.put("document", document);
+            event.put("source", "share");
+            Log.i(TAG, "Received Android shared Markdown text: " + safeForLog(displayName));
+            notifyListeners(EVENT_SHARE_DOCUMENT, event, true);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android shared text rejected: " + ex.getMessage());
+            notifyShareRejected(ex.code, ex.getMessage());
         }
     }
 
@@ -360,6 +593,31 @@ public class AndroidDocumentsPlugin extends Plugin {
         return result;
     }
 
+    private JSObject buildSharedStreamDocumentResult(Uri uri, Intent grantIntent) throws IOException, DocumentReadException {
+        String displayName = getDisplayName(uri);
+        String mimeType = getMimeType(uri, grantIntent);
+        if (!isSharedStreamMarkdownCandidate(uri, displayName, mimeType)) {
+            throw new DocumentReadException(
+                "UNSUPPORTED_SHARE_DOCUMENT",
+                "Share a Markdown file"
+            );
+        }
+
+        String markdown = readText(uri);
+        JSObject result = new JSObject();
+        result.put("canceled", false);
+        result.put("sourceUri", uri.toString());
+        result.put("displayName", displayName);
+        result.put("providerName", getProviderName(uri));
+        result.put("pathHint", displayName);
+        result.put("mimeType", mimeType);
+        result.put("markdown", markdown);
+        result.put("canWrite", canWrite(uri, grantIntent));
+        result.put("persisted", hasPersistedReadPermission(uri));
+        result.put("shareKind", "stream");
+        return result;
+    }
+
     private JSObject createDocumentResult(Uri uri, Intent grantIntent, String markdown) throws IOException, DocumentReadException {
         byte[] bytes = validateMarkdownBytes(markdown);
         writeText(uri, bytes);
@@ -444,6 +702,31 @@ public class AndroidDocumentsPlugin extends Plugin {
             return cleaned;
         }
         return cleaned + ".md";
+    }
+
+    private Uri writeShareCacheFile(String displayName, byte[] bytes) throws IOException {
+        File directory = new File(getContext().getCacheDir(), SHARE_CACHE_DIRECTORY);
+        if (!directory.exists() && !directory.mkdirs()) {
+            throw new IOException("Could not create share cache directory");
+        }
+
+        File outputFile = new File(directory, normalizeSuggestedMarkdownName(displayName));
+        String directoryPath = directory.getCanonicalPath();
+        String outputPath = outputFile.getCanonicalPath();
+        if (!outputPath.startsWith(directoryPath + File.separator)) {
+            throw new SecurityException("Share cache path escaped the expected directory");
+        }
+
+        try (OutputStream output = new FileOutputStream(outputFile, false)) {
+            output.write(bytes);
+            output.flush();
+        }
+
+        return FileProvider.getUriForFile(
+            getContext(),
+            getContext().getPackageName() + ".fileprovider",
+            outputFile
+        );
     }
 
     private void persistUriPermission(Uri uri, Intent data) {
@@ -539,7 +822,7 @@ public class AndroidDocumentsPlugin extends Plugin {
     private String getMimeType(Uri uri, Intent grantIntent) {
         String resolverType = getMimeType(uri);
         String intentType = grantIntent == null ? null : grantIntent.getType();
-        String normalizedIntentType = intentType == null ? "" : intentType.toLowerCase(Locale.US);
+        String normalizedIntentType = normalizeMimeType(intentType);
         if (isMarkdownMimeType(normalizedIntentType)) {
             return normalizedIntentType;
         }
@@ -549,6 +832,23 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
 
         return normalizedIntentType;
+    }
+
+    private String normalizeMimeType(String mimeType) {
+        return mimeType == null ? "" : mimeType.toLowerCase(Locale.US);
+    }
+
+    private String getSharedTextDisplayName(Intent intent) {
+        CharSequence titleValue = getOptionalCharSequenceExtra(intent, Intent.EXTRA_TITLE);
+        String title = titleValue == null ? "" : titleValue.toString();
+        CharSequence subjectValue = getOptionalCharSequenceExtra(intent, Intent.EXTRA_SUBJECT);
+        if (title.trim().length() == 0 && subjectValue != null) {
+            title = subjectValue.toString();
+        }
+        if (title == null || title.trim().length() == 0) {
+            title = "Shared Markdown";
+        }
+        return normalizeSuggestedMarkdownName(title);
     }
 
     private String getProviderName(Uri uri) {
@@ -587,6 +887,14 @@ public class AndroidDocumentsPlugin extends Plugin {
         );
     }
 
+    private boolean isSharedStreamMarkdownCandidate(Uri uri, String displayName, String mimeType) {
+        return (
+            hasMarkdownExtension(displayName) ||
+            hasMarkdownExtension(uri.getLastPathSegment()) ||
+            isMarkdownMimeType(mimeType)
+        );
+    }
+
     private boolean hasMarkdownExtension(String value) {
         String lowerName = value == null ? "" : value.toLowerCase(Locale.US);
         return (
@@ -604,6 +912,50 @@ public class AndroidDocumentsPlugin extends Plugin {
             "text/x-markdown".equals(mimeType) ||
             "text/vnd.daringfireball.markdown".equals(mimeType)
         );
+    }
+
+    private boolean isSharedTextMimeType(String mimeType) {
+        return (
+            mimeType.length() == 0 ||
+            "text/plain".equals(mimeType) ||
+            mimeType.startsWith("text/") ||
+            isMarkdownMimeType(mimeType)
+        );
+    }
+
+    @SuppressWarnings("deprecation")
+    private CharSequence getSharedText(Intent intent) throws DocumentReadException {
+        try {
+            return intent.getCharSequenceExtra(Intent.EXTRA_TEXT);
+        } catch (RuntimeException ex) {
+            throw new DocumentReadException(
+                "INVALID_SHARE_INTENT",
+                "This Android share request is not supported"
+            );
+        }
+    }
+
+    private CharSequence getOptionalCharSequenceExtra(Intent intent, String key) {
+        try {
+            return intent.getCharSequenceExtra(key);
+        } catch (RuntimeException ex) {
+            Log.w(TAG, "Ignored malformed Android share text metadata: " + safeForLog(key));
+            return null;
+        }
+    }
+
+    private Uri getSharedStreamUri(Intent intent) throws DocumentReadException {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                return intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri.class);
+            }
+            return intent.getParcelableExtra(Intent.EXTRA_STREAM);
+        } catch (RuntimeException ex) {
+            throw new DocumentReadException(
+                "INVALID_SHARE_INTENT",
+                "This Android share request is not supported"
+            );
+        }
     }
 
     private boolean hasOnlyAllowedViewCategories(Intent intent) {
@@ -624,12 +976,34 @@ public class AndroidDocumentsPlugin extends Plugin {
         return true;
     }
 
+    private boolean hasOnlyAllowedShareCategories(Intent intent) {
+        Set<String> categories = intent.getCategories();
+        if (categories == null) {
+            return true;
+        }
+
+        for (String category : categories) {
+            if (!Intent.CATEGORY_DEFAULT.equals(category)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private void notifyOpenWithRejected(String code, String message) {
         JSObject event = new JSObject();
         event.put("source", "open-with");
         event.put("errorCode", code);
         event.put("message", message);
         notifyListeners(EVENT_OPEN_WITH_DOCUMENT, event, true);
+    }
+
+    private void notifyShareRejected(String code, String message) {
+        JSObject event = new JSObject();
+        event.put("source", "share");
+        event.put("errorCode", code);
+        event.put("message", message);
+        notifyListeners(EVENT_SHARE_DOCUMENT, event, true);
     }
 
     private boolean canWrite(Uri uri, Intent grantIntent) {

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="my_images" path="." />
+    <cache-path name="shared_markdown" path="shared-markdown/" />
     <cache-path name="my_cache_images" path="." />
 </paths>

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,15 +5,19 @@ import type { PluginListenerHandle } from '@capacitor/core'
 import DocumentHome from './components/DocumentHome.vue'
 import {
   addAndroidOpenWithDocumentListener,
+  addAndroidShareDocumentListener,
   createAndroidMarkdownDocument,
   getAndroidDocumentErrorCode,
   getAndroidDocumentUserMessage,
   isAndroidDocumentAccessAvailable,
   openAndroidMarkdownDocument,
   readAndroidMarkdownDocument,
+  shareAndroidMarkdownDocument,
   writeAndroidMarkdownDocument,
   type AndroidOpenWithDocumentEvent,
+  type AndroidShareDocumentEvent,
   type OpenedAndroidDocument,
+  type SharedAndroidDocument,
 } from './lib/androidDocuments'
 import {
   createUntitledDocument,
@@ -53,6 +57,9 @@ const TRANSIENT_ANDROID_DOCUMENT_MESSAGE =
   'Saved to device. Kept local draft because Android did not grant long-term access.'
 const OPEN_WITH_TEMPORARY_ACCESS_MESSAGE =
   'Opened with temporary Android access. Save a copy to keep editing later.'
+const SHARE_TEMPORARY_ACCESS_MESSAGE =
+  'Opened from Android share with temporary access. Save a copy to keep editing later.'
+const SHARED_TEXT_IMPORTED_MESSAGE = 'Imported shared text as a local draft.'
 const ANDROID_RECOVERY_DRAFT_PREFIX = 'android-recovery:'
 const ANDROID_SAVE_RECOVERY_MESSAGE = 'Save failed. A local recovery draft was kept.'
 const ANDROID_EXIT_RECOVERY_MESSAGE = 'Unsaved changes were kept as a recovery draft.'
@@ -78,6 +85,7 @@ const editorMenuOpen = ref(false)
 const promptLocalDraftSaveOnExit = ref(false)
 const savingLocalDraftToAndroid = ref(false)
 const savingAndroidDocumentCopy = ref(false)
+const sharingCurrentDocument = ref(false)
 
 let editor: MuyaEditor | null = null
 let muyaCore: MuyaCoreModule | null = null
@@ -179,8 +187,12 @@ function canSaveAndroidDocumentCopy() {
   return documentState.value.autosaveTarget === 'android-document' && isAndroidDocumentAccessAvailable()
 }
 
+function canShareCurrentDocument() {
+  return isAndroidDocumentAccessAvailable()
+}
+
 function canShowEditorActions() {
-  return canSaveLocalDraftToAndroidDocument() || canSaveAndroidDocumentCopy()
+  return canShareCurrentDocument() || canSaveLocalDraftToAndroidDocument() || canSaveAndroidDocumentCopy()
 }
 
 function shouldPromptAndroidExitAfterSaveFailure() {
@@ -729,6 +741,45 @@ async function saveAndroidDocumentCopy(options: { returnHomeAfterSave?: boolean 
   }
 }
 
+async function shareCurrentMarkdownDocument() {
+  editorMenuOpen.value = false
+
+  if (!editor || !canShareCurrentDocument() || sharingCurrentDocument.value) {
+    return false
+  }
+
+  const currentDocument = syncDocumentFromEditor(documentState.value.isDirty)
+  if (currentDocument.autosaveTarget === 'local-draft') {
+    saveDraft()
+  }
+
+  const markdownForShare = prepareMarkdownForSave(currentDocument.markdown, currentDocument)
+  const suggestedName = getSuggestedMarkdownFileName(
+    currentDocument.markdown,
+    currentDocument.displayName,
+  )
+
+  sharingCurrentDocument.value = true
+  status.value = 'Sharing'
+
+  try {
+    const result = await shareAndroidMarkdownDocument(markdownForShare, suggestedName)
+    status.value = 'Share sheet opened'
+    androidDocumentLog.info('Android share sheet opened', {
+      displayName: result.displayName,
+      bytes: result.bytes,
+      autosaveTarget: currentDocument.autosaveTarget,
+    })
+    return true
+  } catch (error) {
+    status.value = getAndroidDocumentUserMessage(error)
+    androidDocumentLog.error('Android share failed', error)
+    return false
+  } finally {
+    sharingCurrentDocument.value = false
+  }
+}
+
 function saveDraft() {
   clearDraftSaveTimer()
 
@@ -882,12 +933,17 @@ function rememberAndroidDocument(document: OpenedAndroidDocument) {
 
 async function openAndroidDocumentResult(
   document: OpenedAndroidDocument,
-  options: { source?: 'picker' | 'recent' | 'open-with'; remember?: boolean } = {},
+  options: { source?: 'picker' | 'recent' | 'open-with' | 'share'; remember?: boolean } = {},
 ) {
   const source = options.source ?? 'picker'
   const shouldRemember = options.remember ?? true
-  homeNotice.value =
-    source === 'open-with' && !document.persisted ? OPEN_WITH_TEMPORARY_ACCESS_MESSAGE : null
+  const temporaryAccessMessage =
+    source === 'open-with'
+      ? OPEN_WITH_TEMPORARY_ACCESS_MESSAGE
+      : source === 'share'
+        ? SHARE_TEMPORARY_ACCESS_MESSAGE
+        : null
+  homeNotice.value = temporaryAccessMessage && !document.persisted ? temporaryAccessMessage : null
   if (shouldRemember) {
     rememberAndroidDocument(document)
   } else {
@@ -909,9 +965,38 @@ async function openAndroidDocumentResult(
     characters: document.markdown.length,
   })
   await openEditor(document.markdown)
-  status.value = source === 'open-with' && !document.persisted
+  status.value = temporaryAccessMessage && !document.persisted
     ? 'Opened temporarily'
     : getAndroidEditorStatus()
+  releaseEditorFocusAfterOpen()
+}
+
+async function openSharedTextDocument(document: SharedAndroidDocument) {
+  const draftDocument = createUntitledDocument({
+    markdown: document.markdown,
+    displayName: document.displayName,
+    autosaveTarget: 'local-draft',
+  })
+
+  persistLocalDrafts(
+    upsertLocalDraft(localDrafts.value, {
+      id: draftDocument.id,
+      markdown: draftDocument.markdown,
+      updatedAt: draftDocument.updatedAt,
+      lastSavedAt: draftDocument.lastSavedAt,
+    }),
+  )
+
+  homeNotice.value = null
+  promptLocalDraftSaveOnExit.value = true
+  currentAndroidDocumentCanWrite.value = false
+  documentState.value = draftDocument
+  androidDocumentLog.info('open Android shared text as local draft', {
+    displayName: document.displayName,
+    characters: document.markdown.length,
+  })
+  await openEditor(document.markdown)
+  status.value = SHARED_TEXT_IMPORTED_MESSAGE
   releaseEditorFocusAfterOpen()
 }
 
@@ -943,7 +1028,7 @@ async function preserveCurrentDocumentBeforeIncomingOpen() {
     return
   }
 
-  appLog.info('preserve current document before Android open-with')
+  appLog.info('preserve current document before incoming Android document')
 
   if (documentState.value.autosaveTarget === 'android-document') {
     syncDocumentFromEditor(documentState.value.isDirty)
@@ -975,6 +1060,37 @@ async function handleAndroidOpenWithDocumentEvent(event: AndroidOpenWithDocument
     source: 'open-with',
     remember: event.document.persisted,
   })
+}
+
+async function handleAndroidShareDocumentEvent(event: AndroidShareDocumentEvent) {
+  if (event.error) {
+    const message = getAndroidDocumentUserMessage(event.error)
+    homeNotice.value = message
+    status.value = message
+    androidDocumentLog.warn('Android shared document rejected', event.error)
+    return
+  }
+
+  await preserveCurrentDocumentBeforeIncomingOpen()
+  draftExitPromptOpen.value = false
+  androidExitPromptOpen.value = false
+  editorMenuOpen.value = false
+
+  if (event.document.sourceUri) {
+    await openAndroidDocumentResult(
+      {
+        ...event.document,
+        sourceUri: event.document.sourceUri,
+      },
+      {
+        source: 'share',
+        remember: event.document.persisted,
+      },
+    )
+    return
+  }
+
+  await openSharedTextDocument(event.document)
 }
 
 async function openDocument(id: string) {
@@ -1202,15 +1318,20 @@ function installAndroidDocumentIntentListeners() {
     return
   }
 
-  addAndroidOpenWithDocumentListener(event => {
-    void handleAndroidOpenWithDocumentEvent(event)
-  })
-    .then(handle => {
-      androidDocumentListenerHandles = [handle]
-      androidDocumentLog.info('Android open-with listener installed')
+  Promise.all([
+    addAndroidOpenWithDocumentListener(event => {
+      void handleAndroidOpenWithDocumentEvent(event)
+    }),
+    addAndroidShareDocumentListener(event => {
+      void handleAndroidShareDocumentEvent(event)
+    }),
+  ])
+    .then(handles => {
+      androidDocumentListenerHandles = handles
+      androidDocumentLog.info('Android document intent listeners installed')
     })
     .catch(error => {
-      androidDocumentLog.warn('Android open-with listener unavailable', error)
+      androidDocumentLog.warn('Android document intent listeners unavailable', error)
     })
 }
 
@@ -1342,6 +1463,16 @@ onBeforeUnmount(() => {
           ...
         </button>
         <div v-if="editorMenuOpen" class="editor-menu" role="menu">
+          <button
+            v-if="canShareCurrentDocument()"
+            type="button"
+            role="menuitem"
+            data-testid="share-document-button"
+            :disabled="sharingCurrentDocument || !editorReady"
+            @click="shareCurrentMarkdownDocument"
+          >
+            Share
+          </button>
           <button
             v-if="canSaveLocalDraftToAndroidDocument()"
             type="button"

--- a/src/lib/androidDocuments.ts
+++ b/src/lib/androidDocuments.ts
@@ -12,6 +12,19 @@ export interface OpenedAndroidDocument {
   persisted: boolean
 }
 
+export interface SharedAndroidDocument {
+  canceled?: false
+  sourceUri: string | null
+  displayName: string
+  providerName: string | null
+  pathHint: string | null
+  mimeType: string | null
+  markdown: string
+  canWrite: boolean
+  persisted: boolean
+  shareKind: 'text' | 'stream'
+}
+
 export interface SavedAndroidDocument {
   sourceUri: string
   displayName: string
@@ -32,6 +45,22 @@ export type AndroidOpenWithDocumentEvent =
       error: AndroidDocumentError
     }
 
+export type AndroidShareDocumentEvent =
+  | {
+      document: SharedAndroidDocument
+      error: null
+    }
+  | {
+      document: null
+      error: AndroidDocumentError
+    }
+
+export interface AndroidShareResult {
+  displayName: string
+  mimeType: string
+  bytes: number
+}
+
 interface CanceledAndroidDocumentOpen {
   canceled: true
 }
@@ -42,10 +71,20 @@ interface AndroidOpenWithDocumentPluginEvent {
   message?: string
 }
 
+interface AndroidShareDocumentPluginEvent {
+  document?: SharedAndroidDocument
+  errorCode?: string
+  message?: string
+}
+
 interface AndroidDocumentsPlugin {
   addListener(
     eventName: 'openWithDocument',
     listenerFunc: (event: AndroidOpenWithDocumentPluginEvent) => void,
+  ): Promise<PluginListenerHandle>
+  addListener(
+    eventName: 'shareDocument',
+    listenerFunc: (event: AndroidShareDocumentPluginEvent) => void,
   ): Promise<PluginListenerHandle>
   createMarkdownDocument(options: {
     markdown: string
@@ -53,6 +92,10 @@ interface AndroidDocumentsPlugin {
   }): Promise<OpenedAndroidDocument | CanceledAndroidDocumentOpen>
   openMarkdownDocument(): Promise<OpenedAndroidDocument | CanceledAndroidDocumentOpen>
   readMarkdownDocument(options: { sourceUri: string }): Promise<OpenedAndroidDocument>
+  shareMarkdownDocument(options: {
+    markdown: string
+    suggestedName: string
+  }): Promise<AndroidShareResult>
   writeMarkdownDocument(options: { sourceUri: string; markdown: string }): Promise<SavedAndroidDocument>
 }
 
@@ -110,12 +153,31 @@ export async function writeAndroidMarkdownDocument(sourceUri: string, markdown: 
   )
 }
 
+export async function shareAndroidMarkdownDocument(markdown: string, suggestedName: string) {
+  ensureAndroidDocumentsAvailable()
+  return normalizeShareResult(
+    await AndroidDocuments.shareMarkdownDocument({
+      markdown,
+      suggestedName,
+    }),
+  )
+}
+
 export async function addAndroidOpenWithDocumentListener(
   listener: (event: AndroidOpenWithDocumentEvent) => void,
 ) {
   ensureAndroidDocumentsAvailable()
   return AndroidDocuments.addListener('openWithDocument', event => {
     listener(normalizeOpenWithDocumentEvent(event))
+  })
+}
+
+export async function addAndroidShareDocumentListener(
+  listener: (event: AndroidShareDocumentEvent) => void,
+) {
+  ensureAndroidDocumentsAvailable()
+  return AndroidDocuments.addListener('shareDocument', event => {
+    listener(normalizeShareDocumentEvent(event))
   })
 }
 
@@ -148,6 +210,30 @@ export function getAndroidDocumentUserMessage(error: unknown) {
 
   if (code === 'INVALID_OPEN_WITH_INTENT') {
     return 'This Android open-with request is not supported.'
+  }
+
+  if (code === 'UNSUPPORTED_SHARE_DOCUMENT') {
+    return 'Share Markdown text or a Markdown file.'
+  }
+
+  if (code === 'INVALID_SHARE_INTENT') {
+    return 'This Android share request is not supported.'
+  }
+
+  if (code === 'INVALID_SHARE_SOURCE_URI') {
+    return 'This Android share did not provide a supported file URI.'
+  }
+
+  if (code === 'SHARE_CONTENT_MISSING') {
+    return 'This Android share did not include Markdown content.'
+  }
+
+  if (code === 'SHARE_TARGET_UNAVAILABLE') {
+    return 'No Android share target is available.'
+  }
+
+  if (code === 'SHARE_WRITE_FAILED') {
+    return 'Could not prepare this Markdown file for sharing.'
   }
 
   if (code === 'DOCUMENT_TOO_LARGE') {
@@ -209,6 +295,31 @@ function normalizeOpenedDocument(value: OpenedAndroidDocument): OpenedAndroidDoc
   }
 }
 
+function normalizeSharedDocument(value: SharedAndroidDocument): SharedAndroidDocument {
+  if (!value.displayName || typeof value.markdown !== 'string') {
+    throw new AndroidDocumentError('INVALID_DOCUMENT_RESULT', 'Android document plugin returned an invalid result')
+  }
+
+  const sourceUri = typeof value.sourceUri === 'string' && value.sourceUri ? value.sourceUri : null
+  const shareKind = value.shareKind === 'stream' ? 'stream' : 'text'
+  if (shareKind === 'stream' && !sourceUri) {
+    throw new AndroidDocumentError('INVALID_DOCUMENT_RESULT', 'Android document plugin returned an invalid result')
+  }
+
+  return {
+    canceled: false,
+    sourceUri,
+    displayName: value.displayName,
+    providerName: value.providerName ?? null,
+    pathHint: value.pathHint ?? null,
+    mimeType: value.mimeType ?? null,
+    markdown: value.markdown,
+    canWrite: Boolean(value.canWrite),
+    persisted: Boolean(value.persisted),
+    shareKind,
+  }
+}
+
 function normalizeSavedDocument(value: SavedAndroidDocument): SavedAndroidDocument {
   if (!value.sourceUri || !value.displayName) {
     throw new AndroidDocumentError('INVALID_DOCUMENT_RESULT', 'Android document plugin returned an invalid result')
@@ -225,6 +336,18 @@ function normalizeSavedDocument(value: SavedAndroidDocument): SavedAndroidDocume
   }
 }
 
+function normalizeShareResult(value: AndroidShareResult): AndroidShareResult {
+  if (!value.displayName || !value.mimeType || typeof value.bytes !== 'number') {
+    throw new AndroidDocumentError('INVALID_DOCUMENT_RESULT', 'Android document plugin returned an invalid result')
+  }
+
+  return {
+    displayName: value.displayName,
+    mimeType: value.mimeType,
+    bytes: value.bytes,
+  }
+}
+
 function normalizeOpenWithDocumentEvent(
   value: AndroidOpenWithDocumentPluginEvent,
 ): AndroidOpenWithDocumentEvent {
@@ -237,6 +360,23 @@ function normalizeOpenWithDocumentEvent(
 
   const code = typeof value.errorCode === 'string' ? value.errorCode : 'DOCUMENT_READ_FAILED'
   const message = typeof value.message === 'string' ? value.message : 'Could not open this Markdown file'
+
+  return {
+    document: null,
+    error: new AndroidDocumentError(code, message),
+  }
+}
+
+function normalizeShareDocumentEvent(value: AndroidShareDocumentPluginEvent): AndroidShareDocumentEvent {
+  if (value.document) {
+    return {
+      document: normalizeSharedDocument(value.document),
+      error: null,
+    }
+  }
+
+  const code = typeof value.errorCode === 'string' ? value.errorCode : 'DOCUMENT_READ_FAILED'
+  const message = typeof value.message === 'string' ? value.message : 'Could not import this Android share'
 
   return {
     document: null,

--- a/src/style.css
+++ b/src/style.css
@@ -296,7 +296,7 @@ body {
   right: 0;
   z-index: 30;
   min-width: 124px;
-  width: max-content;
+  width: 144px;
   max-width: calc(100vw - 32px);
   overflow: hidden;
   border: 1px solid var(--border);

--- a/tests/e2e/mobile-share-intent.spec.ts
+++ b/tests/e2e/mobile-share-intent.spec.ts
@@ -1,0 +1,332 @@
+import { expect, test, type Page } from '@playwright/test'
+
+test.describe.configure({ timeout: 60000 })
+
+interface MockCapacitorWindow {
+  androidBridge?: unknown
+  __emitAndroidShareDocument?: (event: MockAndroidShareEvent) => void
+  __androidDocumentListenerCount?: (eventName: string) => number
+  __lastAndroidShareOptions?: Record<string, unknown>
+  Capacitor?: {
+    PluginHeaders?: Array<{
+      name: string
+      methods: Array<{ name: string; rtype: string }>
+    }>
+    nativeCallback?: (
+      pluginName: string,
+      methodName: string,
+      options: Record<string, unknown>,
+      callback?: (data: unknown) => void,
+    ) => Promise<string>
+    nativePromise?: (
+      pluginName: string,
+      methodName: string,
+      options?: Record<string, unknown>,
+    ) => Promise<unknown>
+  }
+}
+
+interface MockAndroidShareEvent {
+  document?: {
+    sourceUri: string | null
+    displayName: string
+    providerName?: string
+    pathHint?: string
+    mimeType?: string
+    markdown: string
+    canWrite?: boolean
+    persisted?: boolean
+    shareKind?: 'text' | 'stream'
+  }
+  errorCode?: string
+  message?: string
+}
+
+interface MockAndroidShareOptions {
+  pendingShareEvent?: MockAndroidShareEvent
+}
+
+async function expectEditorReady(page: Page) {
+  await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
+}
+
+async function installAndroidShareAppMock(
+  page: Page,
+  options: MockAndroidShareOptions = {},
+) {
+  await page.addInitScript(({ mockOptions }) => {
+    const win = window as unknown as MockCapacitorWindow
+    const appListeners = new Map<string, Array<(data: unknown) => void>>()
+    const androidDocumentListeners = new Map<string, Array<(data: unknown) => void>>()
+    let pendingShareEvent = mockOptions.pendingShareEvent ?? null
+
+    const emitAndroidDocumentEvent = (eventName: string, data: unknown) => {
+      for (const listener of androidDocumentListeners.get(eventName) ?? []) {
+        listener(data)
+      }
+    }
+
+    win.androidBridge = {}
+    win.__emitAndroidShareDocument = (event: MockAndroidShareEvent) => {
+      emitAndroidDocumentEvent('shareDocument', event)
+    }
+    win.__androidDocumentListenerCount = (eventName: string) =>
+      androidDocumentListeners.get(eventName)?.length ?? 0
+    win.Capacitor = {
+      ...(win.Capacitor ?? {}),
+      PluginHeaders: [
+        ...((win.Capacitor?.PluginHeaders ?? []).filter(
+          header => header.name !== 'App' && header.name !== 'AndroidDocuments',
+        )),
+        {
+          name: 'App',
+          methods: [
+            { name: 'addListener', rtype: 'callback' },
+            { name: 'removeListener', rtype: 'promise' },
+            { name: 'exitApp', rtype: 'promise' },
+          ],
+        },
+        {
+          name: 'AndroidDocuments',
+          methods: [
+            { name: 'addListener', rtype: 'callback' },
+            { name: 'removeListener', rtype: 'promise' },
+            { name: 'createMarkdownDocument', rtype: 'promise' },
+            { name: 'openMarkdownDocument', rtype: 'promise' },
+            { name: 'readMarkdownDocument', rtype: 'promise' },
+            { name: 'shareMarkdownDocument', rtype: 'promise' },
+            { name: 'writeMarkdownDocument', rtype: 'promise' },
+          ],
+        },
+      ],
+      nativeCallback(pluginName, methodName, callbackOptions, callback) {
+        if (pluginName === 'App' && methodName === 'addListener') {
+          if (typeof callbackOptions.eventName === 'string' && callback) {
+            const listeners = appListeners.get(callbackOptions.eventName) ?? []
+            listeners.push(callback)
+            appListeners.set(callbackOptions.eventName, listeners)
+          }
+          return Promise.resolve(`app-listener-${String(callbackOptions.eventName)}`)
+        }
+
+        if (pluginName === 'AndroidDocuments' && methodName === 'addListener') {
+          if (typeof callbackOptions.eventName === 'string' && callback) {
+            const listeners = androidDocumentListeners.get(callbackOptions.eventName) ?? []
+            listeners.push(callback)
+            androidDocumentListeners.set(callbackOptions.eventName, listeners)
+            if (callbackOptions.eventName === 'shareDocument' && pendingShareEvent) {
+              window.setTimeout(() => {
+                if (pendingShareEvent) {
+                  callback(pendingShareEvent)
+                  pendingShareEvent = null
+                }
+              }, 0)
+            }
+          }
+          return Promise.resolve(`android-documents-listener-${String(callbackOptions.eventName)}`)
+        }
+
+        return Promise.reject({
+          code: 'UNIMPLEMENTED',
+          message: `${pluginName}.${methodName} is not mocked`,
+        })
+      },
+      nativePromise(pluginName, methodName, promiseOptions = {}) {
+        if (pluginName === 'App' && (methodName === 'removeListener' || methodName === 'exitApp')) {
+          return Promise.resolve()
+        }
+
+        if (pluginName === 'AndroidDocuments' && methodName === 'removeListener') {
+          return Promise.resolve()
+        }
+
+        if (pluginName === 'AndroidDocuments' && methodName === 'shareMarkdownDocument') {
+          win.__lastAndroidShareOptions = promiseOptions
+          const markdown = typeof promiseOptions.markdown === 'string' ? promiseOptions.markdown : ''
+          const displayName =
+            typeof promiseOptions.suggestedName === 'string'
+              ? promiseOptions.suggestedName
+              : 'Shared Markdown.md'
+          return Promise.resolve({
+            displayName,
+            mimeType: 'text/markdown',
+            bytes: new TextEncoder().encode(markdown).length,
+          })
+        }
+
+        return Promise.reject({
+          code: 'UNIMPLEMENTED',
+          message: `${pluginName}.${methodName} is not mocked`,
+        })
+      },
+    }
+  }, { mockOptions: options })
+}
+
+test('imports shared Android text as a local draft on app launch', async ({ page }) => {
+  await installAndroidShareAppMock(page, {
+    pendingShareEvent: {
+      document: {
+        sourceUri: null,
+        displayName: 'Shared From QQ.md',
+        providerName: 'Android share',
+        pathHint: 'Shared From QQ.md',
+        mimeType: 'text/plain',
+        markdown: '# Shared From QQ\n\nreceived as plain text',
+        canWrite: false,
+        persisted: false,
+        shareKind: 'text',
+      },
+    },
+  })
+  await page.addInitScript(() => localStorage.clear())
+  await page.goto('/')
+
+  await expectEditorReady(page)
+  await expect(page.getByTestId('editor-host')).toContainText('Shared From QQ')
+  await expect(page.getByText('Imported shared text as a local draft.')).toBeVisible()
+
+  const storage = await page.evaluate(() => ({
+    drafts: localStorage.getItem('marktext-for-android:drafts') ?? '',
+    recentDocuments: localStorage.getItem('marktext-for-android:recent-documents') ?? '',
+  }))
+  expect(storage.drafts).toContain('received as plain text')
+  expect(storage.recentDocuments).not.toContain('Shared From QQ')
+})
+
+test('opens a shared Markdown file with temporary Android access', async ({ page }) => {
+  await installAndroidShareAppMock(page, {
+    pendingShareEvent: {
+      document: {
+        sourceUri: 'content://test/share-stream',
+        displayName: 'Shared Stream.md',
+        providerName: 'Test Documents',
+        pathHint: 'Shared Stream.md',
+        mimeType: 'text/markdown',
+        markdown: '# Shared Stream\n\nreceived as a content URI',
+        canWrite: false,
+        persisted: false,
+        shareKind: 'stream',
+      },
+    },
+  })
+  await page.addInitScript(() => localStorage.clear())
+  await page.goto('/')
+
+  await expectEditorReady(page)
+  await expect(page.getByTestId('editor-host')).toContainText('Shared Stream')
+  await expect(page.getByText('Opened temporarily')).toBeVisible()
+
+  const recentDocuments = await page.evaluate(
+    () => localStorage.getItem('marktext-for-android:recent-documents') ?? '',
+  )
+  expect(recentDocuments).not.toContain('content://test/share-stream')
+})
+
+test('shares the current draft as a Markdown file through Android', async ({ page }) => {
+  await installAndroidShareAppMock(page)
+  await page.addInitScript(() => localStorage.clear())
+  await page.goto('/')
+  await page.waitForFunction(() => {
+    const win = window as unknown as MockCapacitorWindow
+    return (win.__androidDocumentListenerCount?.('shareDocument') ?? 0) > 0
+  })
+
+  await page.getByTestId('new-document-button').click()
+  await expectEditorReady(page)
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('# Share Out Note')
+  await page.keyboard.press('Enter')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('send to QQ or another Android target')
+  await expect(page.getByTestId('editor-host')).toContainText('send to QQ')
+  await expect
+    .poll(async () => page.evaluate(() => localStorage.getItem('marktext-for-android:drafts') ?? ''))
+    .toContain('Share Out Note')
+
+  await page.getByTestId('editor-menu-button').click()
+  await expect(page.getByTestId('share-document-button')).toBeVisible()
+  await page.getByTestId('share-document-button').click()
+
+  await expect(page.getByText('Share sheet opened')).toBeVisible()
+  const shareOptions = await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    return win.__lastAndroidShareOptions
+  })
+  expect(shareOptions?.suggestedName).toBe('Share Out Note.md')
+  expect(shareOptions?.markdown).toContain('send to QQ or another Android target')
+})
+
+test('preserves an active local draft before opening a warm Android share', async ({ page }) => {
+  await installAndroidShareAppMock(page)
+  await page.addInitScript(() => localStorage.clear())
+  await page.goto('/')
+  await page.waitForFunction(() => {
+    const win = window as unknown as MockCapacitorWindow
+    return (win.__androidDocumentListenerCount?.('shareDocument') ?? 0) > 0
+  })
+
+  await page.getByTestId('new-document-button').click()
+  await expectEditorReady(page)
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('# Draft Before Share')
+  await page.keyboard.press('Enter')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('preserve this draft')
+  await expect(page.getByTestId('editor-host')).toContainText('preserve this draft')
+  await expect
+    .poll(async () => page.evaluate(() => localStorage.getItem('marktext-for-android:drafts') ?? ''))
+    .toContain('Draft Before Share')
+
+  await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    win.__emitAndroidShareDocument?.({
+      document: {
+        sourceUri: null,
+        displayName: 'Warm Share.md',
+        providerName: 'Android share',
+        pathHint: 'Warm Share.md',
+        mimeType: 'text/plain',
+        markdown: '# Warm Share\n\nincoming while editing',
+        canWrite: false,
+        persisted: false,
+        shareKind: 'text',
+      },
+    })
+  })
+
+  await expect(page.getByTestId('editor-host')).toContainText('Warm Share')
+  const drafts = await page.evaluate(() => localStorage.getItem('marktext-for-android:drafts') ?? '')
+  expect(drafts).toContain('Draft Before Share')
+  expect(drafts).toContain('Warm Share')
+})
+
+test('shows a safe notice when an Android share is rejected', async ({ page }) => {
+  await installAndroidShareAppMock(page, {
+    pendingShareEvent: {
+      errorCode: 'UNSUPPORTED_SHARE_DOCUMENT',
+      message: 'Share a Markdown file',
+    },
+  })
+  await page.addInitScript(() => localStorage.clear())
+  await page.goto('/')
+
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  await expect(page.getByText('Share Markdown text or a Markdown file.')).toBeVisible()
+  await expect(page.getByTestId('editor-host')).toBeHidden()
+})
+
+test('uses share-specific copy for unsupported shared file URIs', async ({ page }) => {
+  await installAndroidShareAppMock(page, {
+    pendingShareEvent: {
+      errorCode: 'INVALID_SHARE_SOURCE_URI',
+      message: 'This Android share did not provide a supported file URI',
+    },
+  })
+  await page.addInitScript(() => localStorage.clear())
+  await page.goto('/')
+
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  await expect(page.getByText('This Android share did not provide a supported file URI.')).toBeVisible()
+  await expect(page.getByText('This recent file can no longer be opened.')).toBeHidden()
+})


### PR DESCRIPTION
Summary
- Add Android ACTION_SEND support for Markdown/text shares from other apps.
- Import shared text as a local draft and open shared content URIs as temporary Android documents unless a durable grant is available.
- Add an editor menu Share action that writes a Markdown file to app cache and opens the Android share sheet through FileProvider.
- Harden share intent handling: reject unsupported categories, file:// streams, malformed extras, oversized files, and unsupported MIME/extension combinations.
- Add Playwright coverage for inbound text/file shares, outbound sharing, warm share preservation, and rejected share messages.

Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:e2e
- pnpm android:sync
- .\android\gradlew.bat -p android assembleDebug --no-daemon
- ADB install and validation on emulator-5554

ADB evidence
- Inbound text share: logs/pr12-current-adb-share-text.png and logs/pr12-current-adb-share-text-logcat.log
- Inbound content URI file share: logs/pr12-current-adb-share-file.png and logs/pr12-current-adb-share-file-logcat.log
- Outbound Android share sheet: logs/pr12-current-adb-outbound-share-sheet.png and logs/pr12-current-adb-outbound-share-logcat.log
- Rejected file:// share URI: logs/pr12-current-adb-share-file-uri-rejected.png and logs/pr12-current-adb-share-file-uri-rejected-logcat.log

Notes
- Real QQ/provider behavior should still be checked on a device or emulator with QQ installed, because third-party providers may choose different MIME types or URI grant behavior.
- This PR intentionally focuses on Markdown/text share support. Broader reader formats such as txt/epub can be handled in later PRs.