### PR TITLE
Refine mobile editor toolbar command config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,8 @@ export default [
       'dist/**',
       'logs/**',
       'node_modules/**',
+      'playwright-report/**',
+      'test-results/**',
       'third_party/**',
       'vite-dev.*.log',
     ],

--- a/src/App.vue
+++ b/src/App.vue
@@ -42,6 +42,10 @@ import {
   type MobileCommandId,
   type MobileEditorCommandTarget,
 } from './lib/mobileCommands'
+import {
+  DEFAULT_MOBILE_TOOLBAR_PANEL,
+  type MobileEditorToolbarPanel,
+} from './lib/mobileToolbarConfig'
 import { createMuyaMobileEditorCommandTarget } from './lib/muyaMobileAdapter'
 import {
   createRecentDocumentFromAndroidDocument,
@@ -76,7 +80,6 @@ const MARKDOWN_COPY_SUFFIX_REGEXP = /\s+copy(?:\s+(\d+))?$/
 
 type MuyaCoreModule = typeof import('@muyajs/core')
 type MuyaEditor = InstanceType<MuyaCoreModule['Muya']>
-type MobileEditorToolbarPanel = 'format' | 'block' | 'list'
 
 const editorElement = ref<HTMLElement | null>(null)
 const documentState = ref(createUntitledDocument())
@@ -91,7 +94,7 @@ const draftExitPromptOpen = ref(false)
 const androidExitPromptOpen = ref(false)
 const editorMenuOpen = ref(false)
 const editorToolbarExpanded = ref(false)
-const editorToolbarPanel = ref<MobileEditorToolbarPanel>('format')
+const editorToolbarPanel = ref<MobileEditorToolbarPanel>(DEFAULT_MOBILE_TOOLBAR_PANEL)
 const promptLocalDraftSaveOnExit = ref(false)
 const savingLocalDraftToAndroid = ref(false)
 const savingAndroidDocumentCopy = ref(false)

--- a/src/components/MobileEditorToolbar.vue
+++ b/src/components/MobileEditorToolbar.vue
@@ -1,19 +1,13 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { MOBILE_COMMANDS, type MobileCommandId } from '../lib/mobileCommands'
-
-type MobileEditorToolbarPanel = 'format' | 'block' | 'list'
-
-interface ToolbarCommandButton {
-  commandId: MobileCommandId
-  label: string
-  title: string
-}
-
-interface PanelTab {
-  id: MobileEditorToolbarPanel
-  label: string
-}
+import type { MobileCommandId } from '../lib/mobileCommands'
+import {
+  MOBILE_TOOLBAR_PANELS,
+  MOBILE_TOOLBAR_QUICK_GROUPS,
+  getMobileToolbarPanel,
+  getMobileToolbarPanelCommands,
+  type MobileEditorToolbarPanel,
+} from '../lib/mobileToolbarConfig'
 
 const props = defineProps<{
   expanded: boolean
@@ -30,48 +24,10 @@ const emit = defineEmits<{
   setPanel: [panel: MobileEditorToolbarPanel]
 }>()
 
-const quickCommands: ToolbarCommandButton[] = [
-  { commandId: MOBILE_COMMANDS.EDIT_UNDO, label: '↶', title: 'Undo' },
-  { commandId: MOBILE_COMMANDS.EDIT_REDO, label: '↷', title: 'Redo' },
-  { commandId: MOBILE_COMMANDS.FORMAT_STRONG, label: 'B', title: 'Bold' },
-  { commandId: MOBILE_COMMANDS.FORMAT_EMPHASIS, label: 'I', title: 'Italic' },
-  { commandId: MOBILE_COMMANDS.FORMAT_INLINE_CODE, label: '`', title: 'Inline code' },
-  { commandId: MOBILE_COMMANDS.FORMAT_HYPERLINK, label: '[]', title: 'Link' },
-  { commandId: MOBILE_COMMANDS.PARAGRAPH_BULLET_LIST, label: '•', title: 'Bullet list' },
-  { commandId: MOBILE_COMMANDS.PARAGRAPH_ORDERED_LIST, label: '1.', title: 'Ordered list' },
-  { commandId: MOBILE_COMMANDS.PARAGRAPH_TASK_LIST, label: '[ ]', title: 'Task list' },
-]
-
-const panelTabs: PanelTab[] = [
-  { id: 'format', label: 'Format' },
-  { id: 'block', label: 'Block' },
-  { id: 'list', label: 'List' },
-]
-
-const panelCommands: Record<MobileEditorToolbarPanel, ToolbarCommandButton[]> = {
-  format: [
-    { commandId: MOBILE_COMMANDS.FORMAT_STRONG, label: 'Bold', title: 'Bold' },
-    { commandId: MOBILE_COMMANDS.FORMAT_EMPHASIS, label: 'Italic', title: 'Italic' },
-    { commandId: MOBILE_COMMANDS.FORMAT_INLINE_CODE, label: 'Inline code', title: 'Inline code' },
-    { commandId: MOBILE_COMMANDS.FORMAT_HYPERLINK, label: 'Link', title: 'Link' },
-    { commandId: MOBILE_COMMANDS.FORMAT_CLEAR, label: 'Clear', title: 'Clear format' },
-  ],
-  block: [
-    { commandId: MOBILE_COMMANDS.PARAGRAPH_PARAGRAPH, label: 'Paragraph', title: 'Paragraph' },
-    { commandId: MOBILE_COMMANDS.PARAGRAPH_HEADING_1, label: 'Heading 1', title: 'Heading 1' },
-    { commandId: MOBILE_COMMANDS.PARAGRAPH_HEADING_2, label: 'Heading 2', title: 'Heading 2' },
-    { commandId: MOBILE_COMMANDS.PARAGRAPH_HEADING_3, label: 'Heading 3', title: 'Heading 3' },
-    { commandId: MOBILE_COMMANDS.PARAGRAPH_QUOTE_BLOCK, label: 'Quote', title: 'Quote block' },
-    { commandId: MOBILE_COMMANDS.PARAGRAPH_CODE_FENCE, label: 'Code block', title: 'Code block' },
-  ],
-  list: [
-    { commandId: MOBILE_COMMANDS.PARAGRAPH_BULLET_LIST, label: 'Bullet list', title: 'Bullet list' },
-    { commandId: MOBILE_COMMANDS.PARAGRAPH_ORDERED_LIST, label: 'Ordered list', title: 'Ordered list' },
-    { commandId: MOBILE_COMMANDS.PARAGRAPH_TASK_LIST, label: 'Task list', title: 'Task list' },
-  ],
-}
-
-const activePanelCommands = computed(() => panelCommands[props.activePanel])
+const quickCommandGroups = MOBILE_TOOLBAR_QUICK_GROUPS
+const panelTabs = MOBILE_TOOLBAR_PANELS
+const activePanel = computed(() => getMobileToolbarPanel(props.activePanel))
+const activePanelCommands = computed(() => getMobileToolbarPanelCommands(props.activePanel))
 const statsText = computed(
   () => `${props.wordCount} words - ${props.characterCount} chars - ${props.lineCount} lines`,
 )
@@ -94,26 +50,35 @@ function runCommand(commandId: MobileCommandId) {
   >
     <div class="toolbar-row">
       <div class="quick-command-strip" role="toolbar" aria-label="Quick Markdown commands">
-        <button
-          v-for="command in quickCommands"
-          :key="command.commandId"
-          class="toolbar-button"
-          type="button"
-          :aria-label="command.title"
-          :title="command.title"
-          :disabled="!editorReady"
-          :data-testid="`toolbar-command-${command.commandId}`"
-          @pointerdown.prevent
-          @mousedown.prevent
-          @click="runCommand(command.commandId)"
+        <div
+          v-for="group in quickCommandGroups"
+          :key="group.id"
+          class="quick-command-group"
+          role="group"
+          :aria-label="group.title"
         >
-          {{ command.label }}
-        </button>
+          <button
+            v-for="command in group.commands"
+            :key="command.commandId"
+            class="toolbar-button"
+            type="button"
+            :aria-label="command.title"
+            :title="command.title"
+            :disabled="!editorReady"
+            :data-testid="`toolbar-command-${command.commandId}`"
+            @pointerdown.prevent
+            @mousedown.prevent
+            @click="runCommand(command.commandId)"
+          >
+            <span class="toolbar-button-label">{{ command.label }}</span>
+          </button>
+        </div>
       </div>
 
       <button
         class="toolbar-expand-button"
         type="button"
+        :aria-label="expanded ? 'Collapse editing toolbar' : 'Expand editing toolbar'"
         :aria-expanded="expanded"
         aria-controls="mobile-editor-toolbar-panel"
         data-testid="toolbar-expand-button"
@@ -136,10 +101,10 @@ function runCommand(commandId: MobileCommandId) {
           v-for="tab in panelTabs"
           :key="tab.id"
           class="toolbar-tab"
-          :class="{ 'is-active': activePanel === tab.id }"
+          :class="{ 'is-active': activePanel.id === tab.id }"
           type="button"
           role="tab"
-          :aria-selected="activePanel === tab.id"
+          :aria-selected="activePanel.id === tab.id"
           :data-testid="`toolbar-panel-tab-${tab.id}`"
           @pointerdown.prevent
           @mousedown.prevent
@@ -149,7 +114,7 @@ function runCommand(commandId: MobileCommandId) {
         </button>
       </div>
 
-      <div class="panel-command-grid" role="toolbar" :aria-label="`${activePanel} commands`">
+      <div class="panel-command-grid" role="toolbar" :aria-label="activePanel.title">
         <button
           v-for="command in activePanelCommands"
           :key="command.commandId"
@@ -202,6 +167,10 @@ function runCommand(commandId: MobileCommandId) {
 
 .quick-command-strip::-webkit-scrollbar {
   display: none;
+}
+
+.quick-command-group {
+  display: contents;
 }
 
 .toolbar-button,

--- a/src/lib/mobileToolbarConfig.test.ts
+++ b/src/lib/mobileToolbarConfig.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { MOBILE_COMMANDS, getMobileCommandDefinition } from './mobileCommands'
+import {
+  DEFAULT_MOBILE_TOOLBAR_PANEL,
+  MOBILE_TOOLBAR_PANEL_COMMANDS,
+  MOBILE_TOOLBAR_PANELS,
+  MOBILE_TOOLBAR_QUICK_GROUPS,
+  getMobileToolbarPanel,
+  getMobileToolbarPanelCommands,
+} from './mobileToolbarConfig'
+
+function getQuickCommandIds() {
+  return MOBILE_TOOLBAR_QUICK_GROUPS.flatMap(group =>
+    group.commands.map(command => command.commandId),
+  )
+}
+
+function getPanelCommandIds() {
+  return MOBILE_TOOLBAR_PANELS.flatMap(panel => panel.commands.map(command => command.commandId))
+}
+
+describe('mobileToolbarConfig', () => {
+  it('keeps document-level actions out of the editor toolbar', () => {
+    const toolbarCommandIds = [...getQuickCommandIds(), ...getPanelCommandIds()]
+
+    expect(toolbarCommandIds).not.toContain(MOBILE_COMMANDS.FILE_NEW)
+    expect(toolbarCommandIds).not.toContain(MOBILE_COMMANDS.FILE_OPEN)
+    expect(toolbarCommandIds).not.toContain(MOBILE_COMMANDS.FILE_SAVE)
+    expect(toolbarCommandIds).not.toContain(MOBILE_COMMANDS.FILE_SAVE_AS)
+  })
+
+  it('exposes the frequent mobile editor commands in the quick row', () => {
+    expect(getQuickCommandIds()).toEqual([
+      MOBILE_COMMANDS.EDIT_UNDO,
+      MOBILE_COMMANDS.EDIT_REDO,
+      MOBILE_COMMANDS.FORMAT_STRONG,
+      MOBILE_COMMANDS.FORMAT_EMPHASIS,
+      MOBILE_COMMANDS.FORMAT_INLINE_CODE,
+      MOBILE_COMMANDS.FORMAT_HYPERLINK,
+      MOBILE_COMMANDS.PARAGRAPH_BULLET_LIST,
+      MOBILE_COMMANDS.PARAGRAPH_ORDERED_LIST,
+      MOBILE_COMMANDS.PARAGRAPH_TASK_LIST,
+    ])
+  })
+
+  it('keeps expanded panels focused on inline, block, and list editing', () => {
+    expect(MOBILE_TOOLBAR_PANEL_COMMANDS.format.map(command => command.commandId)).toContain(
+      MOBILE_COMMANDS.FORMAT_CLEAR,
+    )
+    expect(MOBILE_TOOLBAR_PANEL_COMMANDS.block.map(command => command.commandId)).toEqual([
+      MOBILE_COMMANDS.PARAGRAPH_PARAGRAPH,
+      MOBILE_COMMANDS.PARAGRAPH_HEADING_1,
+      MOBILE_COMMANDS.PARAGRAPH_HEADING_2,
+      MOBILE_COMMANDS.PARAGRAPH_HEADING_3,
+      MOBILE_COMMANDS.PARAGRAPH_QUOTE_BLOCK,
+      MOBILE_COMMANDS.PARAGRAPH_CODE_FENCE,
+    ])
+    expect(MOBILE_TOOLBAR_PANEL_COMMANDS.list.map(command => command.commandId)).toEqual([
+      MOBILE_COMMANDS.PARAGRAPH_BULLET_LIST,
+      MOBILE_COMMANDS.PARAGRAPH_ORDERED_LIST,
+      MOBILE_COMMANDS.PARAGRAPH_TASK_LIST,
+    ])
+  })
+
+  it('uses only command ids that have mobile command definitions', () => {
+    const toolbarCommandIds = new Set([...getQuickCommandIds(), ...getPanelCommandIds()])
+
+    for (const commandId of toolbarCommandIds) {
+      expect(getMobileCommandDefinition(commandId), commandId).not.toBeNull()
+    }
+  })
+
+  it('falls back to the default panel for an invalid panel id', () => {
+    const panel = getMobileToolbarPanel('missing' as typeof DEFAULT_MOBILE_TOOLBAR_PANEL)
+
+    expect(panel.id).toBe(DEFAULT_MOBILE_TOOLBAR_PANEL)
+    expect(getMobileToolbarPanelCommands(panel.id)).toBe(MOBILE_TOOLBAR_PANEL_COMMANDS.format)
+  })
+})

--- a/src/lib/mobileToolbarConfig.ts
+++ b/src/lib/mobileToolbarConfig.ts
@@ -1,0 +1,124 @@
+import { MOBILE_COMMANDS, type MobileCommandId } from './mobileCommands'
+
+export type MobileEditorToolbarPanel = 'format' | 'block' | 'list'
+
+export interface MobileToolbarCommandButton {
+  commandId: MobileCommandId
+  label: string
+  title: string
+}
+
+export interface MobileToolbarCommandGroup {
+  id: 'history' | 'inline' | 'structure'
+  title: string
+  commands: readonly MobileToolbarCommandButton[]
+}
+
+export interface MobileToolbarPanelDefinition {
+  id: MobileEditorToolbarPanel
+  label: string
+  title: string
+  commands: readonly MobileToolbarCommandButton[]
+}
+
+export const DEFAULT_MOBILE_TOOLBAR_PANEL: MobileEditorToolbarPanel = 'format'
+
+export const MOBILE_TOOLBAR_QUICK_GROUPS = [
+  {
+    id: 'history',
+    title: 'History',
+    commands: [
+      { commandId: MOBILE_COMMANDS.EDIT_UNDO, label: '↶', title: 'Undo' },
+      { commandId: MOBILE_COMMANDS.EDIT_REDO, label: '↷', title: 'Redo' },
+    ],
+  },
+  {
+    id: 'inline',
+    title: 'Inline formatting',
+    commands: [
+      { commandId: MOBILE_COMMANDS.FORMAT_STRONG, label: 'B', title: 'Bold' },
+      { commandId: MOBILE_COMMANDS.FORMAT_EMPHASIS, label: 'I', title: 'Italic' },
+      { commandId: MOBILE_COMMANDS.FORMAT_INLINE_CODE, label: '`', title: 'Inline code' },
+      { commandId: MOBILE_COMMANDS.FORMAT_HYPERLINK, label: '[]', title: 'Link' },
+    ],
+  },
+  {
+    id: 'structure',
+    title: 'Paragraph structure',
+    commands: [
+      {
+        commandId: MOBILE_COMMANDS.PARAGRAPH_BULLET_LIST,
+        label: '•',
+        title: 'Bullet list',
+      },
+      {
+        commandId: MOBILE_COMMANDS.PARAGRAPH_ORDERED_LIST,
+        label: '1.',
+        title: 'Ordered list',
+      },
+      {
+        commandId: MOBILE_COMMANDS.PARAGRAPH_TASK_LIST,
+        label: '[ ]',
+        title: 'Task list',
+      },
+    ],
+  },
+] as const satisfies readonly MobileToolbarCommandGroup[]
+
+export const MOBILE_TOOLBAR_PANEL_COMMANDS: Record<
+  MobileEditorToolbarPanel,
+  readonly MobileToolbarCommandButton[]
+> = {
+  format: [
+    { commandId: MOBILE_COMMANDS.FORMAT_STRONG, label: 'Bold', title: 'Bold' },
+    { commandId: MOBILE_COMMANDS.FORMAT_EMPHASIS, label: 'Italic', title: 'Italic' },
+    { commandId: MOBILE_COMMANDS.FORMAT_INLINE_CODE, label: 'Inline code', title: 'Inline code' },
+    { commandId: MOBILE_COMMANDS.FORMAT_HYPERLINK, label: 'Link', title: 'Link' },
+    { commandId: MOBILE_COMMANDS.FORMAT_CLEAR, label: 'Clear', title: 'Clear format' },
+  ],
+  block: [
+    { commandId: MOBILE_COMMANDS.PARAGRAPH_PARAGRAPH, label: 'Paragraph', title: 'Paragraph' },
+    { commandId: MOBILE_COMMANDS.PARAGRAPH_HEADING_1, label: 'Heading 1', title: 'Heading 1' },
+    { commandId: MOBILE_COMMANDS.PARAGRAPH_HEADING_2, label: 'Heading 2', title: 'Heading 2' },
+    { commandId: MOBILE_COMMANDS.PARAGRAPH_HEADING_3, label: 'Heading 3', title: 'Heading 3' },
+    { commandId: MOBILE_COMMANDS.PARAGRAPH_QUOTE_BLOCK, label: 'Quote', title: 'Quote block' },
+    { commandId: MOBILE_COMMANDS.PARAGRAPH_CODE_FENCE, label: 'Code block', title: 'Code block' },
+  ],
+  list: [
+    { commandId: MOBILE_COMMANDS.PARAGRAPH_BULLET_LIST, label: 'Bullet list', title: 'Bullet list' },
+    { commandId: MOBILE_COMMANDS.PARAGRAPH_ORDERED_LIST, label: 'Ordered list', title: 'Ordered list' },
+    { commandId: MOBILE_COMMANDS.PARAGRAPH_TASK_LIST, label: 'Task list', title: 'Task list' },
+  ],
+}
+
+export const MOBILE_TOOLBAR_PANELS = [
+  {
+    id: 'format',
+    label: 'Format',
+    title: 'Inline formatting',
+    commands: MOBILE_TOOLBAR_PANEL_COMMANDS.format,
+  },
+  {
+    id: 'block',
+    label: 'Block',
+    title: 'Block style',
+    commands: MOBILE_TOOLBAR_PANEL_COMMANDS.block,
+  },
+  {
+    id: 'list',
+    label: 'List',
+    title: 'List style',
+    commands: MOBILE_TOOLBAR_PANEL_COMMANDS.list,
+  },
+] as const satisfies readonly MobileToolbarPanelDefinition[]
+
+export function getMobileToolbarPanel(panelId: MobileEditorToolbarPanel) {
+  return (
+    MOBILE_TOOLBAR_PANELS.find(panel => panel.id === panelId) ??
+    MOBILE_TOOLBAR_PANELS.find(panel => panel.id === DEFAULT_MOBILE_TOOLBAR_PANEL)!
+  )
+}
+
+export function getMobileToolbarPanelCommands(panelId: MobileEditorToolbarPanel) {
+  return getMobileToolbarPanel(panelId).commands
+}


### PR DESCRIPTION
Summary
- Extract mobile editor toolbar command layout into a dedicated config module so the Vue component no longer owns the command matrix.
- Reuse the toolbar panel type/default from the shared config in App.vue.
- Add focused tests that keep document/file actions out of the editor toolbar and pin the quick row plus expanded panel command groups.
- Ignore Playwright generated output in ESLint so local/CI lint does not fail when test-results exists or disappears.

Validation
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm exec playwright test tests/e2e/mobile-editor-toolbar.spec.ts
- pnpm android:sync

Notes
- This intentionally avoids a visual redesign. The goal is to keep the current toolbar working after the Muya alignment while making the command layout easier to evolve in the next UI pass.