### PR TITLE
Cover common Markdown editing and rendering behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lerna-debug.log*
 HANDOFF.md
 todolist.md
 AGENTS.md
+refs/
 
 # Environment
 .env

--- a/tests/e2e/mobile-markdown-editing.spec.ts
+++ b/tests/e2e/mobile-markdown-editing.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, type Page } from '@playwright/test'
+
+test.describe.configure({ timeout: 60000 })
+
+const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
+
+async function expectEditorReady(page: Page) {
+  await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
+}
+
+async function newBlankDocument(page: Page) {
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+  await page.getByTestId('new-document-button').click()
+  await expectEditorReady(page)
+}
+
+async function openLocalDraft(page: Page, markdown: string, title: RegExp) {
+  const now = '2026-07-01T09:00:00.000Z'
+  await page.goto('/')
+  await page.evaluate(
+    ({ markdown, now }) => {
+      localStorage.clear()
+      localStorage.setItem(
+        'marktext-for-android:drafts',
+        JSON.stringify([
+          {
+            id: 'markdown-editing-draft',
+            markdown,
+            updatedAt: now,
+            lastSavedAt: now,
+          },
+        ]),
+      )
+    },
+    { markdown, now },
+  )
+  await page.reload()
+
+  await page.getByRole('button', { name: title }).click()
+  await expectEditorReady(page)
+}
+
+async function getDraftStorage(page: Page) {
+  return page.evaluate(key => localStorage.getItem(key) ?? '', DRAFTS_STORAGE_KEY)
+}
+
+test('toggles a task list checkbox and persists the checked markdown state', async ({ page }) => {
+  await openLocalDraft(
+    page,
+    `# Task Probe
+
+- [ ] Tap this task
+`,
+    /Task Probe/,
+  )
+
+  const checkbox = page.locator('.mu-task-list-checkbox').first()
+  await expect(checkbox).toBeVisible()
+  await checkbox.click()
+
+  await expect.poll(() => getDraftStorage(page)).toContain('- [x] Tap this task')
+})
+
+test('continues unordered and ordered lists from mobile keyboard input', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('- first bullet')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('second bullet')
+  await page.keyboard.press('Enter')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('1. first step')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('second step')
+
+  await expect(page.locator('ul').filter({ hasText: 'second bullet' })).toHaveCount(1)
+  await expect(page.locator('ol').filter({ hasText: 'second step' })).toHaveCount(1)
+  await expect.poll(() => getDraftStorage(page)).toContain('- first bullet')
+  await expect.poll(() => getDraftStorage(page)).toContain('- second bullet')
+  await expect.poll(() => getDraftStorage(page)).toContain('1. first step')
+  await expect.poll(() => getDraftStorage(page)).toContain('2. second step')
+})
+
+test('converts a typed pipe row into a persisted Markdown table', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('| A | B |')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('alpha')
+
+  const table = page.locator('figure.mu-table')
+  await expect(table).toHaveCount(1)
+  await expect(table).toContainText('A')
+  await expect(table).toContainText('B')
+  await expect(table).toContainText('alpha')
+  await expect.poll(() => getDraftStorage(page)).toContain('| A')
+  await expect.poll(() => getDraftStorage(page)).toContain('| B')
+  await expect.poll(() => getDraftStorage(page)).toContain('| ----- | --- |')
+  await expect.poll(() => getDraftStorage(page)).toContain('| alpha')
+})

--- a/tests/e2e/mobile-markdown-rendering.spec.ts
+++ b/tests/e2e/mobile-markdown-rendering.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test, type Page } from '@playwright/test'
+
+test.describe.configure({ timeout: 60000 })
+
+async function expectEditorReady(page: Page) {
+  await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
+}
+
+async function openLocalDraft(page: Page, markdown: string, title: RegExp) {
+  const now = '2026-07-01T10:00:00.000Z'
+  await page.goto('/')
+  await page.evaluate(
+    ({ markdown, now }) => {
+      localStorage.clear()
+      localStorage.setItem(
+        'marktext-for-android:drafts',
+        JSON.stringify([
+          {
+            id: 'markdown-rendering-draft',
+            markdown,
+            updatedAt: now,
+            lastSavedAt: now,
+          },
+        ]),
+      )
+    },
+    { markdown, now },
+  )
+  await page.reload()
+
+  await page.getByRole('button', { name: title }).click()
+  await expectEditorReady(page)
+}
+
+test('renders loaded CommonMark and GFM blocks as Muya editor structures', async ({ page }) => {
+  await openLocalDraft(
+    page,
+    `# Rendering Matrix
+
+> Quoted **strong** and *emphasized* text with \`inline code\`.
+
+---
+
+- Bullet item
+- [x] Checked item
+- [ ] Unchecked item
+
+1. First item
+2. Second item
+
+[MarkText](https://github.com/marktext/marktext)
+
+| Feature | State |
+| --- | --- |
+| Table | Ready |
+`,
+    /Rendering Matrix/,
+  )
+
+  const editor = page.getByTestId('editor-host')
+  await expect(editor.locator('h1.mu-atx-heading')).toContainText('Rendering Matrix')
+  await expect(editor.locator('.mu-block-quote')).toContainText('Quoted')
+  await expect(editor.locator('.mu-thematic-break')).toHaveCount(1)
+  await expect(editor.locator('ul').filter({ hasText: 'Bullet item' })).toHaveCount(1)
+  await expect(editor.locator('ol').filter({ hasText: 'Second item' })).toHaveCount(1)
+  await expect(editor.locator('.mu-task-list-checkbox')).toHaveCount(2)
+  await expect(editor.locator('.mu-task-list-checkbox.mu-checkbox-checked')).toHaveCount(1)
+  await expect(editor.locator('.mu-link').filter({ hasText: 'MarkText' })).toBeVisible()
+  await expect(editor.locator('figure.mu-table')).toHaveCount(1)
+  await expect(editor.locator('figure.mu-table')).toContainText('Ready')
+})
+
+test('renders loaded math, fenced code, and Mermaid previews', async ({ page }) => {
+  await openLocalDraft(
+    page,
+    `# Preview Matrix
+
+Inline math $x^2 + y^2$.
+
+$$
+E = mc^2
+$$
+
+\`\`\`ts
+const ready: boolean = true
+\`\`\`
+
+\`\`\`mermaid
+graph TD
+  A[Start] --> B[Done]
+\`\`\`
+`,
+    /Preview Matrix/,
+  )
+
+  const editor = page.getByTestId('editor-host')
+  await expect.poll(() => editor.locator('.katex').count()).toBeGreaterThan(0)
+  await expect(editor.locator('.mu-math-block')).toHaveCount(1)
+  await expect(editor.locator('.mu-math-error')).toHaveCount(0)
+  await expect(editor.locator('.mu-code-block')).toHaveCount(1)
+  await expect(editor.locator('.mu-code-block .token.keyword').first()).toBeVisible()
+  await expect(editor.locator('.mu-diagram-block')).toHaveCount(1)
+  await expect(editor.locator('.mu-diagram-error')).toHaveCount(0)
+  await expect
+    .poll(() => editor.locator('.mu-diagram-preview svg').count(), { timeout: 30000 })
+    .toBeGreaterThan(0)
+})
+
+test('renders loaded front matter, footnotes, HTML blocks, and inline images', async ({ page }) => {
+  await page.goto('/')
+  const appIconUrl = await page.evaluate(() => new URL('/favicon.svg', location.href).href)
+
+  await openLocalDraft(
+    page,
+    `---
+title: Mobile Render Probe
+---
+
+# Extended Matrix
+
+Reference with footnote.[^note]
+
+Inline image: ![App icon](${appIconUrl})
+
+<div class="html-probe"><strong>HTML Rendered</strong></div>
+
+[^note]: Footnote body text.
+`,
+    /Extended Matrix/,
+  )
+
+  const editor = page.getByTestId('editor-host')
+  await expect(editor.locator('pre.mu-frontmatter')).toHaveCount(1)
+  await expect(editor.locator('pre.mu-frontmatter')).toContainText('Mobile Render Probe')
+  await expect(editor.locator('.mu-footnote')).toHaveCount(1)
+  await expect(editor.locator('.mu-footnote')).toContainText('Footnote body text')
+  await expect(editor.locator('.mu-html-block')).toHaveCount(1)
+  await expect(editor.locator('.mu-html-preview')).toContainText('HTML Rendered')
+  await expect(editor.locator('.mu-inline-image img[alt="App icon"]')).toHaveCount(1)
+  await expect.poll(() => editor.locator('.mu-inline-image.mu-image-success').count()).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Summary

- Add a focused mobile Markdown editing E2E spec for task checkbox toggles, list continuation, and pipe-table conversion.
- Add a render-only mobile Markdown E2E spec for loaded documents covering CommonMark/GFM structures, math, code highlighting, Mermaid, front matter, footnotes, HTML preview, and URL image rendering.
- Ignore the local `refs/` research folder so Markdown capability notes stay out of the repository.

## Validation

- `pnpm exec playwright test tests/e2e/mobile-markdown-editing.spec.ts`
- `pnpm exec playwright test tests/e2e/mobile-markdown-rendering.spec.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`
- Official Emulator WebView render probe via ADB/devtools passed
- logcat fatal/error scan found no matching app/runtime errors

## Notes

Loaded URL images render in the Android shell. Root-relative/local image paths still need the future Android-safe image/document URI model, so this PR does not claim local image path support.