### PR TITLE
Preserve Markdown source round trips

### DIFF
--- a/tests/e2e/mobile-recent-home.spec.ts
+++ b/tests/e2e/mobile-recent-home.spec.ts
@@ -374,6 +374,66 @@ test('creates a local draft from real editor input and returns it to the recent 
   await expect(page.getByTestId('new-document-button')).toBeVisible()
 })
 
+test('preserves repeated ordered-list markers when a draft is opened and saved', async ({ page }) => {
+  const now = '2026-07-01T08:00:00.000Z'
+  const markdown = '# List marker note\n\n1. one\n1. two\n1. three\n'
+
+  await page.goto('/')
+  await page.evaluate(({ markdown, now }) => {
+    localStorage.clear()
+    localStorage.setItem(
+      'marktext-for-android:drafts',
+      JSON.stringify([
+        {
+          id: 'doc-repeated-list-marker',
+          markdown,
+          updatedAt: now,
+          lastSavedAt: now,
+        },
+      ]),
+    )
+  }, { markdown, now })
+  await page.reload()
+
+  await page.getByRole('button', { name: /List marker note/ }).click()
+  await expectEditorReady(page)
+  await page.getByTestId('back-button').click()
+
+  const drafts = await page.evaluate(() => localStorage.getItem('marktext-for-android:drafts') ?? '')
+  expect(drafts).toContain('1. one\\n1. two\\n1. three')
+  expect(drafts).not.toContain('1. one\\n2. two\\n3. three')
+})
+
+test('preserves leading whitespace inside front matter when a draft is opened and saved', async ({ page }) => {
+  const now = '2026-07-01T08:00:00.000Z'
+  const markdown = '---\n  title: indented\n---\n\n# Front matter note\n'
+
+  await page.goto('/')
+  await page.evaluate(({ markdown, now }) => {
+    localStorage.clear()
+    localStorage.setItem(
+      'marktext-for-android:drafts',
+      JSON.stringify([
+        {
+          id: 'doc-indented-frontmatter',
+          markdown,
+          updatedAt: now,
+          lastSavedAt: now,
+        },
+      ]),
+    )
+  }, { markdown, now })
+  await page.reload()
+
+  await page.getByRole('button', { name: /Front matter note/ }).click()
+  await expectEditorReady(page)
+  await page.getByTestId('back-button').click()
+
+  const drafts = await page.evaluate(() => localStorage.getItem('marktext-for-android:drafts') ?? '')
+  expect(drafts).toContain('---\\n  title: indented\\n---')
+  expect(drafts).not.toContain('---\\ntitle: indented\\n---')
+})
+
 test('flushes local draft edits when the WebView becomes hidden', async ({ page }) => {
   await page.goto('/')
   await page.evaluate(() => localStorage.clear())

--- a/third_party/muya/src/block/commonMark/listItem/index.ts
+++ b/third_party/muya/src/block/commonMark/listItem/index.ts
@@ -10,11 +10,13 @@ import { ScrollPage } from '../../scrollPage';
 @mixins(IContainerQueryBlock)
 class ListItem extends Parent {
     public override children: LinkedList<Parent> = new LinkedList();
+    private meta: IListItemState['meta'] = undefined;
 
     static override blockName = 'list-item';
 
     static create(muya: Muya, state: IListItemState) {
         const listItem = new ListItem(muya);
+        listItem.meta = state.meta;
 
         listItem.append(
             ...state.children.map(child =>
@@ -42,6 +44,7 @@ class ListItem extends Parent {
     override getState(): IListItemState {
         const state: IListItemState = {
             name: 'list-item',
+            ...(this.meta ? { meta: this.meta } : {}),
             children: this.children.map(child => child.getState()),
         };
 

--- a/third_party/muya/src/state/__tests__/blockSerialization.spec.ts
+++ b/third_party/muya/src/state/__tests__/blockSerialization.spec.ts
@@ -104,6 +104,15 @@ after
     });
 });
 
+describe('Muya block tree — ordered list source markers', () => {
+    it('preserves repeated ordered-list markers after editor boot', () => {
+        const md = '1. one\n1. two\n1. three\n';
+        const muya = bootMuya(md);
+
+        expect(muya.getMarkdown()).toBe(md);
+    });
+});
+
 describe('stateToMarkdown — code block round-trip', () => {
     it('round-trips a fenced code block with a language tag', () => {
         const md = `\`\`\`js
@@ -318,6 +327,27 @@ describe('stateToMarkdown — frontmatter round-trip', () => {
         const md = `---
 title: hello
 author: world
+---
+
+# body
+`;
+        expect(roundTrip(md)).toBe(md);
+    });
+
+    it('preserves leading whitespace inside YAML frontmatter', () => {
+        const md = `---
+  title: indented
+---
+
+# body
+`;
+        expect(roundTrip(md)).toBe(md);
+    });
+
+    it('preserves a leading blank line inside YAML frontmatter', () => {
+        const md = `---
+
+title: after blank
 ---
 
 # body

--- a/third_party/muya/src/state/__tests__/listSerialization.spec.ts
+++ b/third_party/muya/src/state/__tests__/listSerialization.spec.ts
@@ -559,11 +559,9 @@ describe('stateToMarkdown — list looseness (preferLooseListItem)', () => {
     });
 });
 
-// Ordered-list start number is preserved through the markdown round-trip, and
-// the per-item number is computed by incrementing `meta.start` (see
-// stateToMarkdown.ts `serializeListItem`). The delimiter (`.` or `)`) likewise
-// comes from `meta.delimiter`, which a real boot seeds from
-// `muya.options.orderListDelimiter`.
+// Ordered-list source markers are preserved when parsed from Markdown. States
+// without item-level marker metadata still fall back to generated markers from
+// `meta.start` and `meta.delimiter`.
 describe('stateToMarkdown — ordered list start + delimiter', () => {
     function serialize(states: TState[]): string {
         return new ExportMarkdown({ listIndentation: 1 }).generate(states);
@@ -572,6 +570,21 @@ describe('stateToMarkdown — ordered list start + delimiter', () => {
     it('keeps a non-1 start number through the round-trip', () => {
         // The parser stores start=3; the serializer renders 3., 4. (start + i).
         expect(roundTrip('3. one\n4. two\n')).toBe('3. one\n4. two\n');
+    });
+
+    it('preserves repeated ordered-list source markers', () => {
+        const md = '1. one\n1. two\n1. three\n';
+        expect(roundTrip(md)).toBe(md);
+    });
+
+    it('preserves non-canonical ordered-list item markers', () => {
+        const md = '10) one\n20) two\n';
+        expect(roundTrip(md)).toBe(md);
+    });
+
+    it('preserves nested repeated ordered-list markers', () => {
+        const md = '1. one\n  1. nested one\n  1. nested two\n1. two\n';
+        expect(roundTrip(md)).toBe(md);
     });
 
     it('parses the start number into order-list meta.start', () => {
@@ -586,6 +599,8 @@ describe('stateToMarkdown — ordered list start + delimiter', () => {
         expect(list.name).toBe('order-list');
         expect(list.meta.start).toBe(3);
         expect(list.meta.delimiter).toBe('.');
+        expect(list.children[0].meta?.orderMarker).toBe('3.');
+        expect(list.children[1].meta?.orderMarker).toBe('4.');
     });
 
     it('emits the configured delimiter (")") for an ordered list', () => {

--- a/third_party/muya/src/state/markdownToState.ts
+++ b/third_party/muya/src/state/markdownToState.ts
@@ -20,6 +20,13 @@ function restoreTableEscapeCharacters(text: string) {
     return text.replace(/\|/g, '\\|');
 }
 
+function getOrderedListItemMarker(token: TBlockToken) {
+    if (token.type !== 'list_item')
+        return undefined;
+
+    return /^ {0,3}(\d+[.)])/.exec(token.raw)?.[1];
+}
+
 interface IMarkdownToStateOptions {
     footnote: boolean;
     math: boolean;
@@ -174,6 +181,7 @@ export class MarkdownToState {
 
             case 'list_item': {
                 const { listItemType, checked } = token;
+                const orderMarker = listItemType === 'order' ? getOrderedListItemMarker(token) : undefined;
                 let itemState: IListItemState | ITaskListItemState;
                 if (listItemType === 'task') {
                     itemState = {
@@ -185,6 +193,7 @@ export class MarkdownToState {
                 else {
                     itemState = {
                         name: 'list-item',
+                        ...(orderMarker ? { meta: { orderMarker } } : {}),
                         children: [],
                     };
                 }
@@ -228,7 +237,7 @@ export class MarkdownToState {
         switch (token.type) {
             case 'frontmatter': {
                 const { lang, style, text } = token;
-                value = text.replace(/^\s+/, '').replace(/\s$/, '');
+                value = text.replace(/\n$/, '');
 
                 state = {
                     name: 'frontmatter' as const,

--- a/third_party/muya/src/state/stateToMarkdown.ts
+++ b/third_party/muya/src/state/stateToMarkdown.ts
@@ -566,6 +566,7 @@ export default class ExportMarkdown {
             itemMarker = marker ? `${marker} ` : '- ';
         }
         else if ('start' in listInfo) {
+            const sourceMarker = state.name === 'list-item' ? state.meta?.orderMarker : undefined;
             // NOTE: GitHub and Bitbucket limit the list count to 99 but this is nowhere defined.
             //  We limit the number to 99 for Daring Fireball Markdown to prevent indentation issues.
             let n = listInfo.start;
@@ -574,7 +575,7 @@ export default class ExportMarkdown {
 
             listInfo.start++;
 
-            itemMarker = `${n}${delimiter || '.'} `;
+            itemMarker = sourceMarker ? `${sourceMarker} ` : `${n}${delimiter || '.'} `;
         }
         else {
             itemMarker = '- ';

--- a/third_party/muya/src/state/types.ts
+++ b/third_party/muya/src/state/types.ts
@@ -58,8 +58,13 @@ export interface IBlockQuoteState {
     children: TState[];
 }
 
+export interface IListItemMeta {
+    orderMarker?: string;
+}
+
 export interface IListItemState {
     name: 'list-item';
+    meta?: IListItemMeta;
     children: TState[];
 }
 


### PR DESCRIPTION
## Summary
- preserve original ordered-list item markers during Muya markdown round trips
- keep leading whitespace and leading blank lines inside YAML front matter
- add Muya-level and app-level regressions for open/save source preservation

## Review focus
This is PR19's review/fix pass for real reading and save scenarios. It targets silent Markdown source rewrites where opening a document and returning home could change user-authored source without an explicit edit.

## Validation
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm build
- pnpm android:sync
- pnpm exec playwright test tests/e2e/mobile-recent-home.spec.ts -g "preserves repeated ordered-list markers|preserves leading whitespace inside front matter" --workers=1
- pnpm exec playwright test --workers=1
- Gradle debug APK build via android/gradlew.bat assembleDebug
- Installed and launched on AVD MarkText_API_35 with adb; home and editor screenshots looked normal
- logcat filter found no FATAL EXCEPTION / AndroidRuntime crash stack

## Notes
- Build still reports the existing large chunk warning.
- Root Vitest config excludes third_party/**, so Muya-specific tests are included as source regressions but the runnable gate here is the app-level test/build/E2E path.