### PR TITLE
Add Android image import and sharing support

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -30,19 +30,32 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @CapacitorPlugin(name = "AndroidDocuments")
 public class AndroidDocumentsPlugin extends Plugin {
 
     private static final String TAG = "MarkTextAndroid";
     private static final int MAX_MARKDOWN_BYTES = 5 * 1024 * 1024;
+    private static final int MAX_IMAGE_BYTES = 15 * 1024 * 1024;
     private static final String CALLBACK_OPEN_MARKDOWN_DOCUMENT = "openMarkdownDocumentResult";
     private static final String CALLBACK_CREATE_MARKDOWN_DOCUMENT = "createMarkdownDocumentResult";
+    private static final String CALLBACK_PICK_IMAGE_DOCUMENT = "pickImageDocumentResult";
     private static final String EVENT_OPEN_WITH_DOCUMENT = "openWithDocument";
     private static final String EVENT_SHARE_DOCUMENT = "shareDocument";
+    private static final String IMPORTED_IMAGE_DIRECTORY = "images";
     private static final String SHARE_CACHE_DIRECTORY = "shared-markdown";
+    private static final Pattern MARKTEXT_IMAGE_SOURCE_PATTERN = Pattern.compile(
+        "marktext-image://local/([^\\s)]+)",
+        Pattern.CASE_INSENSITIVE
+    );
     private String lastHandledIncomingIntentId = "";
 
     @Override
@@ -145,9 +158,10 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
 
         String suggestedName = normalizeSuggestedMarkdownName(call.getString("suggestedName", ""));
+        ShareMarkdownPayload sharePayload = buildShareMarkdownPayload(markdown);
         byte[] bytes;
         try {
-            bytes = validateMarkdownBytes(markdown);
+            bytes = validateMarkdownBytes(sharePayload.markdown);
         } catch (DocumentReadException ex) {
             Log.w(TAG, "Android share rejected: " + ex.getMessage());
             call.reject(ex.getMessage(), ex.code, ex);
@@ -155,14 +169,34 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
 
         try {
-            Uri uri = writeShareCacheFile(suggestedName, bytes);
-            Intent shareIntent = new Intent(Intent.ACTION_SEND);
-            shareIntent.setType("text/markdown");
-            shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
+            File shareDirectory = getShareCacheDirectory();
+            Uri markdownUri = writeShareCacheFile(shareDirectory, suggestedName, bytes);
+            ArrayList<Uri> streamUris = new ArrayList<>();
+            streamUris.add(markdownUri);
+
+            for (Map.Entry<String, File> imageEntry : sharePayload.images.entrySet()) {
+                File sharedImage = copyShareImageFile(shareDirectory, imageEntry.getKey(), imageEntry.getValue());
+                streamUris.add(
+                    FileProvider.getUriForFile(
+                        getContext(),
+                        getContext().getPackageName() + ".fileprovider",
+                        sharedImage
+                    )
+                );
+            }
+
+            boolean sharesImages = streamUris.size() > 1;
+            Intent shareIntent = new Intent(sharesImages ? Intent.ACTION_SEND_MULTIPLE : Intent.ACTION_SEND);
+            shareIntent.setType(sharesImages ? "*/*" : "text/markdown");
+            if (sharesImages) {
+                shareIntent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, streamUris);
+            } else {
+                shareIntent.putExtra(Intent.EXTRA_STREAM, markdownUri);
+            }
             shareIntent.putExtra(Intent.EXTRA_TITLE, suggestedName);
             shareIntent.putExtra(Intent.EXTRA_SUBJECT, suggestedName);
             shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            shareIntent.setClipData(ClipData.newUri(getContext().getContentResolver(), suggestedName, uri));
+            shareIntent.setClipData(buildShareClipData(suggestedName, streamUris));
 
             Intent chooser = Intent.createChooser(shareIntent, "Share Markdown");
             chooser.putExtra(
@@ -176,7 +210,15 @@ public class AndroidDocumentsPlugin extends Plugin {
             result.put("displayName", suggestedName);
             result.put("mimeType", "text/markdown");
             result.put("bytes", bytes.length);
-            Log.i(TAG, "Opened Android share sheet for Markdown document: " + safeForLog(suggestedName));
+            result.put("imageCount", sharePayload.images.size());
+            result.put("sharedFileCount", streamUris.size());
+            Log.i(
+                TAG,
+                "Opened Android share sheet for Markdown document: " +
+                safeForLog(suggestedName) +
+                ", images=" +
+                sharePayload.images.size()
+            );
             call.resolve(result);
         } catch (ActivityNotFoundException ex) {
             Log.w(TAG, "No Android share target is available", ex);
@@ -184,6 +226,38 @@ public class AndroidDocumentsPlugin extends Plugin {
         } catch (IOException | SecurityException ex) {
             Log.e(TAG, "Failed to prepare Markdown document for sharing", ex);
             call.reject("Could not prepare Markdown document for sharing", "SHARE_WRITE_FAILED", ex);
+        }
+    }
+
+    @PluginMethod
+    public void getImportedImageDirectory(PluginCall call) {
+        JSObject result = new JSObject();
+        result.put("fileUri", getFileUri(getImportedImageDirectoryFile()));
+        call.resolve(result);
+    }
+
+    @PluginMethod
+    public void pickImageDocument(PluginCall call) {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("image/*");
+        intent.putExtra(
+            Intent.EXTRA_MIME_TYPES,
+            new String[] {
+                "image/jpeg",
+                "image/png",
+                "image/gif",
+                "image/webp",
+                "image/svg+xml"
+            }
+        );
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+        try {
+            startActivityForResult(call, intent, CALLBACK_PICK_IMAGE_DOCUMENT);
+        } catch (ActivityNotFoundException ex) {
+            Log.e(TAG, "No Android image picker is available", ex);
+            call.reject("No Android image picker is available", "IMAGE_PICKER_UNAVAILABLE", ex);
         }
     }
 
@@ -545,6 +619,46 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
     }
 
+    @ActivityCallback
+    private void pickImageDocumentResult(PluginCall call, ActivityResult result) {
+        if (call == null) {
+            Log.w(TAG, "Missing plugin call for Android image picker result");
+            return;
+        }
+
+        if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
+            JSObject canceled = new JSObject();
+            canceled.put("canceled", true);
+            call.resolve(canceled);
+            return;
+        }
+
+        Intent data = result.getData();
+        Uri uri = data.getData();
+        if (uri == null) {
+            call.reject("Android image picker returned no URI", "IMAGE_URI_MISSING");
+            return;
+        }
+
+        try {
+            JSObject importedImage = importImageResult(uri, data);
+            Log.i(TAG, "Imported Android image: " + safeForLog(importedImage.getString("displayName")));
+            call.resolve(importedImage);
+        } catch (DocumentReadException ex) {
+            Log.w(TAG, "Android image import rejected: " + ex.getMessage());
+            call.reject(ex.getMessage(), ex.code, ex);
+        } catch (FileNotFoundException ex) {
+            Log.w(TAG, "Android image no longer exists", ex);
+            call.reject("This Android image was moved or deleted", "IMAGE_NOT_FOUND", ex);
+        } catch (SecurityException ex) {
+            Log.w(TAG, "Android image read permission is no longer available", ex);
+            call.reject("Android image permission is no longer available", "IMAGE_PERMISSION_LOST", ex);
+        } catch (IOException ex) {
+            Log.e(TAG, "Failed to import Android image", ex);
+            call.reject("Failed to import Android image", "IMAGE_IMPORT_FAILED", ex);
+        }
+    }
+
     private JSObject buildDocumentResult(Uri uri, Intent grantIntent) throws IOException, DocumentReadException {
         String displayName = getDisplayName(uri);
         String mimeType = getMimeType(uri);
@@ -566,6 +680,34 @@ public class AndroidDocumentsPlugin extends Plugin {
         result.put("markdown", markdown);
         result.put("canWrite", canWrite(uri, grantIntent));
         result.put("persisted", hasPersistedReadPermission(uri));
+        return result;
+    }
+
+    private JSObject importImageResult(Uri uri, Intent grantIntent) throws IOException, DocumentReadException {
+        String mimeType = getMimeType(uri, grantIntent);
+        String displayName = normalizeImageDisplayName(getDisplayName(uri), mimeType);
+        if (!isSupportedImage(displayName, mimeType)) {
+            throw new DocumentReadException(
+                "UNSUPPORTED_IMAGE",
+                "Choose a JPEG, PNG, GIF, WebP, or SVG image"
+            );
+        }
+
+        File outputDirectory = getImportedImageDirectoryFile();
+        if (!outputDirectory.exists() && !outputDirectory.mkdirs()) {
+            throw new IOException("Could not create image import directory");
+        }
+
+        File outputFile = new File(outputDirectory, createStoredImageName(displayName, mimeType));
+        int bytes = copyImage(uri, outputFile);
+        JSObject result = new JSObject();
+        result.put("canceled", false);
+        result.put("sourceUri", uri.toString());
+        result.put("displayName", displayName);
+        result.put("mimeType", mimeType);
+        result.put("markdownSrc", "marktext-image://local/" + Uri.encode(outputFile.getName()));
+        result.put("fileUri", getFileUri(outputFile));
+        result.put("bytes", bytes);
         return result;
     }
 
@@ -704,16 +846,50 @@ public class AndroidDocumentsPlugin extends Plugin {
         return cleaned + ".md";
     }
 
-    private Uri writeShareCacheFile(String displayName, byte[] bytes) throws IOException {
+    private ShareMarkdownPayload buildShareMarkdownPayload(String markdown) {
+        Map<String, File> images = new LinkedHashMap<>();
+        Matcher matcher = MARKTEXT_IMAGE_SOURCE_PATTERN.matcher(markdown);
+        StringBuffer rewrittenMarkdown = new StringBuffer();
+
+        while (matcher.find()) {
+            String fileName = normalizeImportedImageFileName(Uri.decode(matcher.group(1)));
+            if (fileName.length() == 0) {
+                continue;
+            }
+
+            File importedImage = new File(getImportedImageDirectoryFile(), fileName);
+            if (!isFileInDirectory(importedImage, getImportedImageDirectoryFile()) || !importedImage.isFile()) {
+                Log.w(TAG, "Skipping missing Android image during share: " + safeForLog(fileName));
+                continue;
+            }
+
+            images.put(fileName, importedImage);
+            matcher.appendReplacement(rewrittenMarkdown, Matcher.quoteReplacement(fileName));
+        }
+        matcher.appendTail(rewrittenMarkdown);
+
+        return new ShareMarkdownPayload(rewrittenMarkdown.toString(), images);
+    }
+
+    private ClipData buildShareClipData(String suggestedName, ArrayList<Uri> streamUris) {
+        ClipData clipData = ClipData.newUri(getContext().getContentResolver(), suggestedName, streamUris.get(0));
+        for (int index = 1; index < streamUris.size(); index++) {
+            clipData.addItem(new ClipData.Item(streamUris.get(index)));
+        }
+        return clipData;
+    }
+
+    private File getShareCacheDirectory() throws IOException {
         File directory = new File(getContext().getCacheDir(), SHARE_CACHE_DIRECTORY);
         if (!directory.exists() && !directory.mkdirs()) {
             throw new IOException("Could not create share cache directory");
         }
+        return directory;
+    }
 
+    private Uri writeShareCacheFile(File directory, String displayName, byte[] bytes) throws IOException {
         File outputFile = new File(directory, normalizeSuggestedMarkdownName(displayName));
-        String directoryPath = directory.getCanonicalPath();
-        String outputPath = outputFile.getCanonicalPath();
-        if (!outputPath.startsWith(directoryPath + File.separator)) {
+        if (!isFileInDirectory(outputFile, directory)) {
             throw new SecurityException("Share cache path escaped the expected directory");
         }
 
@@ -727,6 +903,87 @@ public class AndroidDocumentsPlugin extends Plugin {
             getContext().getPackageName() + ".fileprovider",
             outputFile
         );
+    }
+
+    private File copyShareImageFile(File directory, String displayName, File sourceFile) throws IOException {
+        String normalizedName = normalizeImportedImageFileName(displayName);
+        if (normalizedName.length() == 0) {
+            throw new SecurityException("Invalid shared image file name");
+        }
+
+        File outputFile = new File(directory, normalizedName);
+        if (!isFileInDirectory(outputFile, directory)) {
+            throw new SecurityException("Shared image path escaped the expected directory");
+        }
+
+        try (
+            InputStream input = new java.io.FileInputStream(sourceFile);
+            OutputStream output = new FileOutputStream(outputFile, false)
+        ) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                output.write(buffer, 0, read);
+            }
+            output.flush();
+        }
+
+        return outputFile;
+    }
+
+    private boolean isFileInDirectory(File file, File directory) {
+        try {
+            String directoryPath = directory.getCanonicalPath();
+            String filePath = file.getCanonicalPath();
+            return filePath.startsWith(directoryPath + File.separator);
+        } catch (IOException ex) {
+            Log.w(TAG, "Could not validate file path", ex);
+            return false;
+        }
+    }
+
+    private File getImportedImageDirectoryFile() {
+        return new File(getContext().getFilesDir(), IMPORTED_IMAGE_DIRECTORY);
+    }
+
+    private String getFileUri(File file) {
+        return "file://" + file.getAbsolutePath();
+    }
+
+    private int copyImage(Uri uri, File outputFile) throws IOException, DocumentReadException {
+        ContentResolver resolver = getContext().getContentResolver();
+        boolean copied = false;
+        try {
+            try (
+                InputStream input = resolver.openInputStream(uri);
+                OutputStream output = new FileOutputStream(outputFile)
+            ) {
+                if (input == null) {
+                    throw new IOException("Content resolver returned no image stream");
+                }
+
+                byte[] buffer = new byte[8192];
+                int totalBytes = 0;
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    totalBytes += read;
+                    if (totalBytes > MAX_IMAGE_BYTES) {
+                        throw new DocumentReadException(
+                            "IMAGE_TOO_LARGE",
+                            "Image is larger than the current 15 MB limit"
+                        );
+                    }
+                    output.write(buffer, 0, read);
+                }
+                output.flush();
+                copied = true;
+                return totalBytes;
+            }
+        } finally {
+            if (!copied && outputFile.exists() && !outputFile.delete()) {
+                Log.w(TAG, "Could not delete incomplete imported image: " + safeForLog(outputFile.getName()));
+            }
+        }
     }
 
     private void persistUriPermission(Uri uri, Intent data) {
@@ -906,6 +1163,125 @@ public class AndroidDocumentsPlugin extends Plugin {
         );
     }
 
+    private boolean isSupportedImage(String displayName, String mimeType) {
+        if (isSupportedImageMimeType(mimeType)) {
+            return true;
+        }
+
+        return (
+            mimeType.length() == 0 ||
+            "application/octet-stream".equals(mimeType)
+        ) && hasSupportedImageExtension(displayName);
+    }
+
+    private boolean isSupportedImageMimeType(String mimeType) {
+        return (
+            "image/*".equals(mimeType) ||
+            "image/jpeg".equals(mimeType) ||
+            "image/png".equals(mimeType) ||
+            "image/gif".equals(mimeType) ||
+            "image/webp".equals(mimeType) ||
+            "image/svg+xml".equals(mimeType)
+        );
+    }
+
+    private boolean hasSupportedImageExtension(String value) {
+        String lowerName = value == null ? "" : value.toLowerCase(Locale.US);
+        return (
+            lowerName.endsWith(".jpg") ||
+            lowerName.endsWith(".jpeg") ||
+            lowerName.endsWith(".png") ||
+            lowerName.endsWith(".gif") ||
+            lowerName.endsWith(".webp") ||
+            lowerName.endsWith(".svg")
+        );
+    }
+
+    private String normalizeImageDisplayName(String displayName, String mimeType) {
+        String cleaned = displayName == null ? "" : displayName.trim();
+        cleaned = cleaned.replaceAll("[\\\\/:*?\"<>|\\r\\n]+", " ");
+        cleaned = cleaned.replaceAll("\\s+", " ").trim();
+        if (cleaned.length() == 0) {
+            cleaned = "Image";
+        }
+
+        if (hasSupportedImageExtension(cleaned)) {
+            return cleaned;
+        }
+        return cleaned + extensionForImageMimeType(mimeType);
+    }
+
+    private String createStoredImageName(String displayName, String mimeType) {
+        String normalized = normalizeImageDisplayName(displayName, mimeType);
+        String extension = extensionFromImageName(normalized);
+        String baseName = extension.length() == 0
+            ? normalized
+            : normalized.substring(0, normalized.length() - extension.length());
+        baseName = baseName.replaceAll("[^A-Za-z0-9._-]+", "-");
+        baseName = baseName.replaceAll("-+", "-").replaceAll("^-|-$", "");
+        if (baseName.length() == 0) {
+            baseName = "image";
+        }
+        if (baseName.length() > 48) {
+            baseName = baseName.substring(0, 48);
+        }
+
+        String unique = UUID.randomUUID().toString().substring(0, 8);
+        return System.currentTimeMillis() + "-" + unique + "-" + baseName + extension;
+    }
+
+    private String normalizeImportedImageFileName(String fileName) {
+        String normalized = fileName == null ? "" : fileName.trim();
+        if (
+            normalized.length() == 0 ||
+            normalized.contains("/") ||
+            normalized.contains("\\") ||
+            !hasSupportedImageExtension(normalized)
+        ) {
+            return "";
+        }
+        return normalized;
+    }
+
+    private String extensionFromImageName(String displayName) {
+        String lowerName = displayName == null ? "" : displayName.toLowerCase(Locale.US);
+        if (lowerName.endsWith(".jpeg")) {
+            return ".jpeg";
+        }
+        if (lowerName.endsWith(".jpg")) {
+            return ".jpg";
+        }
+        if (lowerName.endsWith(".png")) {
+            return ".png";
+        }
+        if (lowerName.endsWith(".gif")) {
+            return ".gif";
+        }
+        if (lowerName.endsWith(".webp")) {
+            return ".webp";
+        }
+        if (lowerName.endsWith(".svg")) {
+            return ".svg";
+        }
+        return "";
+    }
+
+    private String extensionForImageMimeType(String mimeType) {
+        if ("image/jpeg".equals(mimeType)) {
+            return ".jpg";
+        }
+        if ("image/gif".equals(mimeType)) {
+            return ".gif";
+        }
+        if ("image/webp".equals(mimeType)) {
+            return ".webp";
+        }
+        if ("image/svg+xml".equals(mimeType)) {
+            return ".svg";
+        }
+        return ".png";
+    }
+
     private boolean isMarkdownMimeType(String mimeType) {
         return (
             "text/markdown".equals(mimeType) ||
@@ -1042,6 +1418,17 @@ public class AndroidDocumentsPlugin extends Plugin {
         DocumentReadException(String code, String message) {
             super(message);
             this.code = code;
+        }
+    }
+
+    private static class ShareMarkdownPayload {
+
+        final String markdown;
+        final Map<String, File> images;
+
+        ShareMarkdownPayload(String markdown, Map<String, File> images) {
+            this.markdown = markdown;
+            this.images = images;
         }
     }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,6 +21,12 @@ import {
   type SharedAndroidDocument,
 } from './lib/androidDocuments'
 import {
+  ensureAndroidImageResolver,
+  getAndroidImageUserMessage,
+  isAndroidImageImportAvailable,
+  pickAndroidImageDocument,
+} from './lib/androidImages'
+import {
   createUntitledDocument,
   getSuggestedMarkdownFileName,
   markDocumentSaved,
@@ -104,6 +110,7 @@ const promptLocalDraftSaveOnExit = ref(false)
 const savingLocalDraftToAndroid = ref(false)
 const savingAndroidDocumentCopy = ref(false)
 const sharingCurrentDocument = ref(false)
+const importingAndroidImage = ref(false)
 
 let editor: MuyaEditor | null = null
 let muyaCore: MuyaCoreModule | null = null
@@ -116,7 +123,7 @@ let androidSaveRequestedAfterCurrent = false
 let appLifecycleListenerHandles: PluginListenerHandle[] = []
 let androidDocumentListenerHandles: PluginListenerHandle[] = []
 let browserLifecycleListenersInstalled = false
-let pendingLinkRange: Range | null = null
+let pendingInlineInsertRange: Range | null = null
 
 const appLog = createLogger('app')
 const editorLog = createLogger('editor')
@@ -397,12 +404,12 @@ function buildMarkdownLink(text: string, url: string) {
 
 function restorePendingLinkRange() {
   const selection = window.getSelection()
-  if (!selection || !pendingLinkRange) {
+  if (!selection || !pendingInlineInsertRange) {
     return false
   }
 
   selection.removeAllRanges()
-  selection.addRange(pendingLinkRange)
+  selection.addRange(pendingInlineInsertRange)
   return true
 }
 
@@ -417,8 +424,8 @@ function openLinkSheet() {
     return
   }
 
-  pendingLinkRange = captureEditorSelection()
-  linkText.value = normalizeLinkField(pendingLinkRange?.toString() ?? '')
+  pendingInlineInsertRange = captureEditorSelection()
+  linkText.value = normalizeLinkField(pendingInlineInsertRange?.toString() ?? '')
   linkUrl.value = ''
   editorMenuOpen.value = false
   closeEditorToolbar()
@@ -433,7 +440,7 @@ function closeLinkSheet() {
   linkSheetOpen.value = false
   linkText.value = ''
   linkUrl.value = ''
-  pendingLinkRange = null
+  pendingInlineInsertRange = null
 }
 
 function insertLinkFromSheet() {
@@ -451,6 +458,65 @@ function insertLinkFromSheet() {
 
   closeLinkSheet()
   syncAfterToolbarCommand(beforeMarkdown)
+}
+
+function escapeMarkdownImageAlt(value: string) {
+  return value.replace(/[\r\n]+/g, ' ').replace(/]/g, '\\]').trim()
+}
+
+function buildMarkdownImage(alt: string, source: string) {
+  return `![${escapeMarkdownImageAlt(alt)}](${source})`
+}
+
+async function insertImageFromAndroidPicker() {
+  if (!editorReady.value || !editor || importingAndroidImage.value) {
+    return
+  }
+
+  if (!isAndroidImageImportAvailable()) {
+    status.value = getAndroidImageUserMessage({ code: 'UNAVAILABLE' })
+    editorLog.warn('mobile image insert skipped because Android image import is unavailable')
+    return
+  }
+
+  const beforeMarkdown = editor.getMarkdown()
+  pendingInlineInsertRange = captureEditorSelection()
+  const selectedText = normalizeLinkField(pendingInlineInsertRange?.toString() ?? '')
+  editorMenuOpen.value = false
+  closeEditorToolbar()
+  importingAndroidImage.value = true
+  status.value = 'Choose an image'
+
+  try {
+    await ensureAndroidImageResolver()
+    const image = await pickAndroidImageDocument()
+    if (image.canceled) {
+      status.value = 'Ready'
+      return
+    }
+
+    const alt = selectedText || image.displayName
+    const markdownImage = buildMarkdownImage(alt, image.markdownSrc)
+    if (!insertMarkdownAtPendingSelection(markdownImage)) {
+      status.value = 'Image insert failed'
+      editorLog.warn('mobile image insert failed because text insertion was not handled')
+      return
+    }
+
+    status.value = 'Image inserted'
+    editorLog.info('mobile image inserted', {
+      displayName: image.displayName,
+      mimeType: image.mimeType,
+      bytes: image.bytes,
+    })
+    syncAfterToolbarCommand(beforeMarkdown)
+  } catch (error) {
+    status.value = getAndroidImageUserMessage(error)
+    editorLog.error('mobile image insert failed', error)
+  } finally {
+    importingAndroidImage.value = false
+    pendingInlineInsertRange = null
+  }
 }
 
 function syncAfterToolbarCommand(beforeMarkdown: string) {
@@ -477,6 +543,11 @@ function runEditorToolbarCommand(commandId: MobileCommandId) {
 
   if (commandId === MOBILE_COMMANDS.FORMAT_HYPERLINK) {
     openLinkSheet()
+    return
+  }
+
+  if (commandId === MOBILE_COMMANDS.FORMAT_IMAGE) {
+    void insertImageFromAndroidPicker()
     return
   }
 
@@ -936,6 +1007,8 @@ async function shareCurrentMarkdownDocument() {
     androidDocumentLog.info('Android share sheet opened', {
       displayName: result.displayName,
       bytes: result.bytes,
+      imageCount: result.imageCount,
+      sharedFileCount: result.sharedFileCount,
       autosaveTarget: currentDocument.autosaveTarget,
     })
     return true
@@ -1010,6 +1083,11 @@ async function initEditor(initialMarkdown: string) {
 
   try {
     const token = ++editorInitToken
+    try {
+      await ensureAndroidImageResolver()
+    } catch (error) {
+      editorLog.warn('Android image resolver unavailable during editor init', error)
+    }
     const { Muya, en } = await registerMuyaPlugins()
     if (token !== editorInitToken || !editorElement.value) {
       return

--- a/src/lib/androidDocuments.ts
+++ b/src/lib/androidDocuments.ts
@@ -59,6 +59,8 @@ export interface AndroidShareResult {
   displayName: string
   mimeType: string
   bytes: number
+  imageCount: number
+  sharedFileCount: number
 }
 
 interface CanceledAndroidDocumentOpen {
@@ -77,7 +79,7 @@ interface AndroidShareDocumentPluginEvent {
   message?: string
 }
 
-interface AndroidDocumentsPlugin {
+export interface AndroidDocumentsPlugin {
   addListener(
     eventName: 'openWithDocument',
     listenerFunc: (event: AndroidOpenWithDocumentPluginEvent) => void,
@@ -97,6 +99,16 @@ interface AndroidDocumentsPlugin {
     suggestedName: string
   }): Promise<AndroidShareResult>
   writeMarkdownDocument(options: { sourceUri: string; markdown: string }): Promise<SavedAndroidDocument>
+  getImportedImageDirectory(): Promise<{ fileUri: string; webBaseUri?: string }>
+  pickImageDocument(): Promise<{
+    canceled?: false
+    sourceUri: string
+    displayName: string
+    mimeType: string | null
+    markdownSrc: string
+    fileUri: string
+    bytes: number
+  } | { canceled: true }>
 }
 
 export class AndroidDocumentError extends Error {
@@ -109,7 +121,7 @@ export class AndroidDocumentError extends Error {
   }
 }
 
-const AndroidDocuments = registerPlugin<AndroidDocumentsPlugin>('AndroidDocuments')
+export const AndroidDocuments = registerPlugin<AndroidDocumentsPlugin>('AndroidDocuments')
 
 export function isAndroidDocumentAccessAvailable() {
   return Capacitor.getPlatform() === 'android' && Capacitor.isNativePlatform()
@@ -345,6 +357,8 @@ function normalizeShareResult(value: AndroidShareResult): AndroidShareResult {
     displayName: value.displayName,
     mimeType: value.mimeType,
     bytes: value.bytes,
+    imageCount: typeof value.imageCount === 'number' ? value.imageCount : 0,
+    sharedFileCount: typeof value.sharedFileCount === 'number' ? value.sharedFileCount : 1,
   }
 }
 

--- a/src/lib/androidImages.test.ts
+++ b/src/lib/androidImages.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AndroidImageError,
+  buildMarkTextImageSource,
+  resolveMarkTextImageSource,
+} from './androidImages'
+
+describe('androidImages', () => {
+  it('builds and resolves app-local Markdown image sources', () => {
+    const source = buildMarkTextImageSource('picked image.png')
+
+    expect(source).toBe('marktext-image://local/picked%20image.png')
+    expect(
+      resolveMarkTextImageSource(source, {
+        fileUri: 'file:///data/user/0/io.github.renakoni.marktextandroid/files/images',
+        webBaseUri: 'http://localhost/images',
+      }),
+    ).toBe('http://localhost/images/picked%20image.png')
+  })
+
+  it('rejects image source filenames that escape the image directory', () => {
+    expect(() => buildMarkTextImageSource('../secret.png')).toThrow(AndroidImageError)
+    expect(() =>
+      resolveMarkTextImageSource('marktext-image://local/..%2Fsecret.png', {
+        fileUri: 'file:///data/user/0/io.github.renakoni.marktextandroid/files/images',
+      }),
+    ).toThrow(AndroidImageError)
+  })
+
+  it('ignores app-local image sources until the native directory is available', () => {
+    expect(resolveMarkTextImageSource('marktext-image://local/picked.png', null)).toBeNull()
+    expect(resolveMarkTextImageSource('marktext-image://local/..%2Fsecret.png', null)).toBeNull()
+  })
+
+  it('normalizes invalid percent-encoded image filenames into Android image errors', () => {
+    expect(() =>
+      resolveMarkTextImageSource('marktext-image://local/%E0%A4%A.png', {
+        fileUri: 'file:///data/user/0/io.github.renakoni.marktextandroid/files/images',
+      }),
+    ).toThrow(AndroidImageError)
+  })
+})

--- a/src/lib/androidImages.ts
+++ b/src/lib/androidImages.ts
@@ -1,0 +1,192 @@
+import { Capacitor } from '@capacitor/core'
+import { AndroidDocuments } from './androidDocuments'
+
+export interface ImportedAndroidImage {
+  canceled?: false
+  sourceUri: string
+  displayName: string
+  mimeType: string | null
+  markdownSrc: string
+  fileUri: string
+  bytes: number
+}
+
+interface ImportedAndroidImageDirectory {
+  fileUri: string
+  webBaseUri?: string
+}
+
+interface AndroidImageResolverWindow extends Window {
+  MarkTextAndroidImageResolver?: (source: string) => string | null
+}
+
+export class AndroidImageError extends Error {
+  code: string
+
+  constructor(code: string, message: string) {
+    super(message)
+    this.name = 'AndroidImageError'
+    this.code = code
+  }
+}
+
+const MARKTEXT_IMAGE_SOURCE_REGEXP = /^marktext-image:\/\/local\/([^/?#]+)$/i
+
+let imageDirectory: ImportedAndroidImageDirectory | null = null
+
+export function isAndroidImageImportAvailable() {
+  return Capacitor.getPlatform() === 'android' && Capacitor.isNativePlatform()
+}
+
+export function buildMarkTextImageSource(fileName: string) {
+  const normalized = normalizeImageFileName(fileName)
+  return `marktext-image://local/${encodeURIComponent(normalized)}`
+}
+
+export function resolveMarkTextImageSource(
+  source: string,
+  directory: ImportedAndroidImageDirectory | null,
+) {
+  if (!directory) {
+    return null
+  }
+
+  const fileName = getMarkTextImageFileName(source)
+  if (!fileName) {
+    return null
+  }
+
+  const baseUri = directory.webBaseUri?.replace(/\/+$/, '')
+  if (baseUri) {
+    return `${baseUri}/${encodeURIComponent(fileName)}`
+  }
+
+  return Capacitor.convertFileSrc(`${directory.fileUri.replace(/\/+$/, '')}/${encodeURIComponent(fileName)}`)
+}
+
+export async function ensureAndroidImageResolver() {
+  const win = window as AndroidImageResolverWindow
+  if (!isAndroidImageImportAvailable()) {
+    win.MarkTextAndroidImageResolver = source => resolveMarkTextImageSource(source, imageDirectory)
+    return
+  }
+
+  if (!imageDirectory) {
+    imageDirectory = normalizeImageDirectory(await AndroidDocuments.getImportedImageDirectory())
+  }
+
+  win.MarkTextAndroidImageResolver = source => resolveMarkTextImageSource(source, imageDirectory)
+}
+
+export async function pickAndroidImageDocument() {
+  ensureAndroidImagesAvailable()
+  const result = await AndroidDocuments.pickImageDocument()
+  if (result.canceled) {
+    return result
+  }
+
+  return normalizeImportedImage(result)
+}
+
+export function getAndroidImageErrorCode(error: unknown) {
+  if (error instanceof AndroidImageError) {
+    return error.code
+  }
+
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = (error as { code?: unknown }).code
+    return typeof code === 'string' ? code : 'UNKNOWN'
+  }
+
+  return 'UNKNOWN'
+}
+
+export function getAndroidImageUserMessage(error: unknown) {
+  const code = getAndroidImageErrorCode(error)
+  if (code === 'UNAVAILABLE') {
+    return 'Insert images from the Android app build.'
+  }
+
+  if (code === 'IMAGE_PICKER_UNAVAILABLE') {
+    return 'No Android image picker is available.'
+  }
+
+  if (code === 'UNSUPPORTED_IMAGE') {
+    return 'Choose a JPEG, PNG, GIF, WebP, or SVG image.'
+  }
+
+  if (code === 'IMAGE_TOO_LARGE') {
+    return 'This image is larger than the current 15 MB limit.'
+  }
+
+  if (code === 'IMAGE_NOT_FOUND') {
+    return 'This image was moved or deleted.'
+  }
+
+  if (code === 'IMAGE_PERMISSION_LOST') {
+    return 'Choose this image again from Android.'
+  }
+
+  if (code === 'IMAGE_IMPORT_FAILED') {
+    return 'Could not import this image.'
+  }
+
+  return 'Could not insert this image.'
+}
+
+function ensureAndroidImagesAvailable() {
+  if (!isAndroidImageImportAvailable()) {
+    throw new AndroidImageError('UNAVAILABLE', 'Android image import is only available in Android builds')
+  }
+}
+
+function normalizeImageDirectory(value: ImportedAndroidImageDirectory): ImportedAndroidImageDirectory {
+  if (!value.fileUri) {
+    throw new AndroidImageError('INVALID_IMAGE_RESULT', 'Android image plugin returned an invalid directory')
+  }
+
+  return {
+    fileUri: value.fileUri,
+    webBaseUri: typeof value.webBaseUri === 'string' ? value.webBaseUri : undefined,
+  }
+}
+
+function normalizeImportedImage(value: ImportedAndroidImage): ImportedAndroidImage {
+  if (!value.sourceUri || !value.displayName || !value.markdownSrc || !value.fileUri) {
+    throw new AndroidImageError('INVALID_IMAGE_RESULT', 'Android image plugin returned an invalid image')
+  }
+
+  return {
+    canceled: false,
+    sourceUri: value.sourceUri,
+    displayName: value.displayName,
+    mimeType: value.mimeType ?? null,
+    markdownSrc: value.markdownSrc,
+    fileUri: value.fileUri,
+    bytes: typeof value.bytes === 'number' ? value.bytes : 0,
+  }
+}
+
+function getMarkTextImageFileName(source: string) {
+  const match = MARKTEXT_IMAGE_SOURCE_REGEXP.exec(source)
+  if (!match) {
+    return null
+  }
+
+  try {
+    return normalizeImageFileName(decodeURIComponent(match[1]))
+  } catch (error) {
+    if (error instanceof AndroidImageError) {
+      throw error
+    }
+    throw new AndroidImageError('INVALID_IMAGE_RESULT', 'Android image plugin returned an invalid file name')
+  }
+}
+
+function normalizeImageFileName(fileName: string) {
+  const normalized = fileName.trim()
+  if (!normalized || normalized.includes('/') || normalized.includes('\\')) {
+    throw new AndroidImageError('INVALID_IMAGE_RESULT', 'Android image plugin returned an invalid file name')
+  }
+  return normalized
+}

--- a/src/lib/mobileToolbarConfig.ts
+++ b/src/lib/mobileToolbarConfig.ts
@@ -74,6 +74,7 @@ export const MOBILE_TOOLBAR_PANEL_COMMANDS: Record<
     { commandId: MOBILE_COMMANDS.FORMAT_EMPHASIS, label: 'Italic', title: 'Italic' },
     { commandId: MOBILE_COMMANDS.FORMAT_INLINE_CODE, label: 'Inline code', title: 'Inline code' },
     { commandId: MOBILE_COMMANDS.FORMAT_HYPERLINK, label: 'Link', title: 'Link' },
+    { commandId: MOBILE_COMMANDS.FORMAT_IMAGE, label: 'Image', title: 'Image' },
     { commandId: MOBILE_COMMANDS.FORMAT_CLEAR, label: 'Clear', title: 'Clear format' },
   ],
   block: [

--- a/tests/e2e/mobile-editor-toolbar.spec.ts
+++ b/tests/e2e/mobile-editor-toolbar.spec.ts
@@ -2,6 +2,27 @@ import { expect, test, type Page } from '@playwright/test'
 
 test.describe.configure({ timeout: 60000 })
 
+interface MockCapacitorWindow {
+  androidBridge?: unknown
+  Capacitor?: {
+    PluginHeaders?: Array<{
+      name: string
+      methods: Array<{ name: string; rtype: string }>
+    }>
+    nativePromise?: (
+      pluginName: string,
+      methodName: string,
+      options?: Record<string, unknown>,
+    ) => Promise<unknown>
+    nativeCallback?: (
+      pluginName: string,
+      methodName: string,
+      options: Record<string, unknown>,
+      callback?: (data: unknown) => void,
+    ) => Promise<string>
+  }
+}
+
 async function expectEditorReady(page: Page) {
   await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
 }
@@ -16,6 +37,86 @@ async function newBlankDocument(page: Page) {
 
 async function getDraftStorage(page: Page) {
   return page.evaluate(() => localStorage.getItem('marktext-for-android:drafts') ?? '')
+}
+
+async function installAndroidImagePickerMock(page: Page) {
+  await page.addInitScript(() => {
+    const win = window as unknown as MockCapacitorWindow
+
+    win.androidBridge = {}
+    win.Capacitor = {
+      ...(win.Capacitor ?? {}),
+      PluginHeaders: [
+        ...((win.Capacitor?.PluginHeaders ?? []).filter(
+          header => header.name !== 'App' && header.name !== 'AndroidDocuments',
+        )),
+        {
+          name: 'App',
+          methods: [
+            { name: 'addListener', rtype: 'callback' },
+            { name: 'removeListener', rtype: 'promise' },
+            { name: 'exitApp', rtype: 'promise' },
+          ],
+        },
+        {
+          name: 'AndroidDocuments',
+          methods: [
+            { name: 'addListener', rtype: 'callback' },
+            { name: 'removeListener', rtype: 'promise' },
+            { name: 'getImportedImageDirectory', rtype: 'promise' },
+            { name: 'pickImageDocument', rtype: 'promise' },
+          ],
+        },
+      ],
+      nativeCallback(pluginName, methodName, options) {
+        if (pluginName === 'App' && methodName === 'addListener') {
+          return Promise.resolve(`app-listener-${String(options.eventName)}`)
+        }
+
+        if (pluginName === 'AndroidDocuments' && methodName === 'addListener') {
+          return Promise.resolve(`android-documents-listener-${String(options.eventName)}`)
+        }
+
+        return Promise.reject({
+          code: 'UNIMPLEMENTED',
+          message: `${pluginName}.${methodName} is not mocked`,
+        })
+      },
+      nativePromise(pluginName, methodName) {
+        if (pluginName === 'App' && methodName === 'exitApp') {
+          return Promise.resolve()
+        }
+
+        if (methodName === 'removeListener') {
+          return Promise.resolve()
+        }
+
+        if (pluginName === 'AndroidDocuments' && methodName === 'getImportedImageDirectory') {
+          return Promise.resolve({
+            fileUri: 'file:///mock/images',
+            webBaseUri: location.origin,
+          })
+        }
+
+        if (pluginName === 'AndroidDocuments' && methodName === 'pickImageDocument') {
+          return Promise.resolve({
+            canceled: false,
+            sourceUri: 'content://test/picked-image',
+            displayName: 'favicon.svg',
+            mimeType: 'image/svg+xml',
+            markdownSrc: 'marktext-image://local/favicon.svg',
+            fileUri: 'file:///mock/images/favicon.svg',
+            bytes: 512,
+          })
+        }
+
+        return Promise.reject({
+          code: 'UNIMPLEMENTED',
+          message: `${pluginName}.${methodName} is not mocked`,
+        })
+      },
+    }
+  })
 }
 
 test('applies quick toolbar inline formatting to selected editor text', async ({ page }) => {
@@ -62,6 +163,25 @@ test('inserts a link at a collapsed cursor through the mobile link sheet', async
 
   await expect(page.getByTestId('link-insert-sheet')).toBeHidden()
   await expect.poll(() => getDraftStorage(page)).toContain('[Project repo](example.com)')
+})
+
+test('inserts an Android-picked image from selected text through the format panel', async ({ page }) => {
+  await installAndroidImagePickerMock(page)
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('Picked icon')
+  await page.keyboard.press('Control+A')
+  await page.getByTestId('toolbar-expand-button').click()
+  await page.getByTestId('toolbar-panel-command-format.image').click()
+
+  await expect.poll(() => getDraftStorage(page)).toContain(
+    '![Picked icon](marktext-image://local/favicon.svg)',
+  )
+
+  const editor = page.getByTestId('editor-host')
+  await expect(editor.locator('.mu-inline-image img[alt="Picked icon"]')).toHaveCount(1)
+  await expect.poll(() => editor.locator('.mu-inline-image.mu-image-success').count()).toBeGreaterThan(0)
 })
 
 test('applies expanded toolbar block and list commands to the current paragraph', async ({ page }) => {

--- a/tests/e2e/mobile-share-intent.spec.ts
+++ b/tests/e2e/mobile-share-intent.spec.ts
@@ -151,6 +151,8 @@ async function installAndroidShareAppMock(
             displayName,
             mimeType: 'text/markdown',
             bytes: new TextEncoder().encode(markdown).length,
+            imageCount: 0,
+            sharedFileCount: 1,
           })
         }
 

--- a/third_party/muya/src/utils/image.ts
+++ b/third_party/muya/src/utils/image.ts
@@ -8,6 +8,12 @@ export interface IImageInfo {
     imageId: string;
 }
 
+declare global {
+    interface Window {
+        MarkTextAndroidImageResolver?: (source: string) => string | null;
+    }
+}
+
 export function getImageInfo(image: HTMLElement): IImageInfo {
     const paragraph = findContentDOM(image)!;
     const raw = image.getAttribute('data-raw')!;
@@ -68,6 +74,24 @@ function resolveRelativePath(base: string, relative: string): string {
 }
 
 export function getImageSrc(src: string) {
+    try {
+        const resolvedSrc = typeof window === 'undefined'
+            ? null
+            : window.MarkTextAndroidImageResolver?.(src);
+        if (resolvedSrc) {
+            return {
+                isUnknownType: false,
+                src: resolvedSrc,
+            };
+        }
+    }
+    catch {
+        return {
+            isUnknownType: false,
+            src: '',
+        };
+    }
+
     const EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i;
     // http[s] (domain or IPv4 or localhost or IPv6) [port] /not-white-space
     const URL_REG


### PR DESCRIPTION
## Summary
- Add Android image picking from the mobile Format panel and import selected images into app-private storage.
- Store stable Markdown image sources as `marktext-image://local/...` and resolve them through Capacitor for WebView rendering.
- Share Markdown documents with imported local images as multi-file Android shares, rewriting exported Markdown image links to same-directory image filenames.
- Add focused unit and Playwright coverage for Android image source resolution and mobile image insertion.

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm android:sync`
- `pnpm exec playwright test --workers=1` passed earlier after image insertion work: 43 passed
- `pnpm exec playwright test tests/e2e/mobile-share-intent.spec.ts -g "shares the current draft" --workers=1`
- `cd android; .\gradlew.bat assembleDebug`
- `git diff --check`

## Real Android smoke test
- Installed debug APK on `emulator-5554`.
- Pushed `C:\Users\25799\Desktop\test.png` to `/sdcard/Download/marktext-test.png`.
- Inserted the image through Android DocumentsUI; confirmed it rendered in the WebView and remained rendered after returning home and reopening the local draft.
- Triggered Android share for the image draft; confirmed share cache contains both `Untitled-1.md` and the imported PNG, with exported Markdown rewritten to the image filename.
- Checked logcat for fatal/image-import errors; no relevant crash or image import failure found.

## Notes
- Android share targets differ in how they preserve multiple attachments. This PR sends the Markdown and image files together and rewrites Markdown links to same-directory filenames; receivers still decide how to save or display the attachments.