### PR TITLE
Fix Android diagram rendering compatibility

### DIFF
--- a/tests/e2e/mobile-markdown-rendering.spec.ts
+++ b/tests/e2e/mobile-markdown-rendering.spec.ts
@@ -2,6 +2,8 @@ import { expect, test, type Page } from '@playwright/test'
 
 test.describe.configure({ timeout: 60000 })
 
+const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
+
 async function expectEditorReady(page: Page) {
   await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
 }
@@ -30,6 +32,17 @@ async function openLocalDraft(page: Page, markdown: string, title: RegExp) {
 
   await page.getByRole('button', { name: title }).click()
   await expectEditorReady(page)
+}
+
+async function getStoredMarkdown(page: Page) {
+  return page.evaluate((key) => {
+    const raw = localStorage.getItem(key)
+    if (!raw) {
+      return ''
+    }
+    const [draft] = JSON.parse(raw) as Array<{ markdown: string }>
+    return draft?.markdown ?? ''
+  }, DRAFTS_STORAGE_KEY)
 }
 
 test('renders loaded CommonMark and GFM blocks as Muya editor structures', async ({ page }) => {
@@ -104,6 +117,64 @@ graph TD
   await expect
     .poll(() => editor.locator('.mu-diagram-preview svg').count(), { timeout: 30000 })
     .toBeGreaterThan(0)
+})
+
+test('renders all supported diagram previews without rewriting the Markdown source', async ({ page }) => {
+  await page.route('https://www.plantuml.com/plantuml/svg/**', route =>
+    route.fulfill({
+      contentType: 'image/svg+xml',
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="40"><text x="4" y="24">PlantUML</text></svg>',
+    }),
+  )
+
+  const markdown = `# Diagram Matrix
+
+\`\`\`mermaid
+graph TD
+  A[Start] --> B[Done]
+\`\`\`
+
+\`\`\`plantuml
+@startuml
+Alice -> Bob: Hello
+@enduml
+\`\`\`
+
+\`\`\`vega-lite
+{
+  "data": { "values": [{ "category": "A", "value": 1 }, { "category": "B", "value": 2 }] },
+  "mark": "bar",
+  "encoding": {
+    "x": { "field": "category", "type": "nominal" },
+    "y": { "field": "value", "type": "quantitative" }
+  }
+}
+\`\`\`
+
+\`\`\`flowchart
+st=>start: Start
+op=>operation: Process
+e=>end: End
+st->op->e
+\`\`\`
+
+\`\`\`sequence
+Alice->Bob: Hello Bob
+Bob-->Alice: Hello Alice
+\`\`\`
+`
+
+  await openLocalDraft(page, markdown, /Diagram Matrix/)
+
+  const editor = page.getByTestId('editor-host')
+  await expect(editor.locator('.mu-diagram-block')).toHaveCount(5)
+  await expect(editor.locator('.mu-code-block')).toHaveCount(0)
+  await expect(editor.locator('.mu-diagram-error')).toHaveCount(0)
+  await expect(editor.locator('.mu-diagram-preview img[src^="https://www.plantuml.com/plantuml/svg/"]')).toHaveCount(1)
+  await expect
+    .poll(() => editor.locator('.mu-diagram-preview svg').count(), { timeout: 45000 })
+    .toBeGreaterThanOrEqual(4)
+  await expect.poll(() => getStoredMarkdown(page)).toBe(markdown)
 })
 
 test('renders loaded front matter, footnotes, HTML blocks, and inline images', async ({ page }) => {

--- a/third_party/muya/src/block/extra/diagram/__tests__/diagramPreview.spec.ts
+++ b/third_party/muya/src/block/extra/diagram/__tests__/diagramPreview.spec.ts
@@ -57,6 +57,14 @@ function makePreview(text: string, type: IDiagramMeta['type'] = 'mermaid', local
     return { preview, muya, i18n };
 }
 
+function deferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => {
+        resolve = done;
+    });
+    return { promise, resolve };
+}
+
 describe('diagramPreview — empty state', () => {
     it('renders the empty-state class + localized "Empty Diagram" for empty code', async () => {
         const { preview } = makePreview('');
@@ -113,6 +121,48 @@ describe('diagramPreview — invalid / error state', () => {
         const html = preview.domNode!.innerHTML;
         expect(html).toContain('class="mu-diagram-error"');
         expect(html).toContain('图表渲染失败');
+    });
+});
+
+describe('diagramPreview — async update ordering', () => {
+    it('keeps the latest render when an older renderer finishes later', async () => {
+        const first = deferred();
+        const second = deferred();
+        const render = vi.fn(async (target: HTMLElement, spec: { mark: string }) => {
+            await (spec.mark === 'bar' ? first.promise : second.promise);
+            target.textContent = spec.mark;
+        });
+        loadRendererMock.mockResolvedValue(render);
+
+        const { preview } = makePreview('', 'vega-lite');
+        const firstUpdate = preview.update('{"mark":"bar"}');
+        const secondUpdate = preview.update('{"mark":"line"}');
+
+        second.resolve();
+        await secondUpdate;
+        expect(preview.domNode!.textContent).toBe('line');
+
+        first.resolve();
+        await firstUpdate;
+        expect(preview.domNode!.textContent).toBe('line');
+    });
+
+    it('does not replace an empty-state update with a late renderer error', async () => {
+        const first = deferred();
+        loadRendererMock.mockResolvedValue(async () => {
+            await first.promise;
+            throw new Error('late failure');
+        });
+
+        const { preview } = makePreview('', 'vega-lite');
+        const pendingUpdate = preview.update('{"mark":"bar"}');
+        await preview.update('');
+
+        first.resolve();
+        await pendingUpdate;
+
+        expect(preview.domNode!.innerHTML).toContain(`class="${CLASS_NAMES.MU_EMPTY}"`);
+        expect(preview.domNode!.innerHTML).not.toContain('late failure');
     });
 });
 

--- a/third_party/muya/src/block/extra/diagram/diagramPreview.ts
+++ b/third_party/muya/src/block/extra/diagram/diagramPreview.ts
@@ -116,6 +116,7 @@ async function renderDiagram({
 class DiagramPreview extends Parent {
     private _code: string;
     private _type: string;
+    private _renderId = 0;
     static override blockName = 'diagram-preview';
 
     static create(muya: Muya, state: IDiagramState) {
@@ -170,14 +171,19 @@ class DiagramPreview extends Parent {
         if (this._code !== code)
             this._code = code;
 
+        const renderId = ++this._renderId;
+
         if (code) {
-            this.domNode!.innerHTML = i18n.t('Loading...');
+            this.domNode!.innerHTML = '';
+            const renderTarget = document.createElement('div');
+            renderTarget.innerHTML = i18n.t('Loading...');
+            this.domNode!.appendChild(renderTarget);
             const { mermaidTheme, vegaTheme, plantumlServer, sequenceTheme } = this.muya.options;
             const { _type: type } = this;
 
             try {
                 await renderDiagram({
-                    target: this.domNode!,
+                    target: renderTarget,
                     code,
                     type,
                     mermaidTheme,
@@ -187,6 +193,8 @@ class DiagramPreview extends Parent {
                 });
             }
             catch (error) {
+                if (renderId !== this._renderId)
+                    return;
                 const detail
                     = error instanceof Error ? error.message : String(error);
                 debug.error(`render ${type} diagram failed: ${detail}`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,14 +27,20 @@ const optimizedMuyaDependencies = [
   'dayjs',
   ...optimizedDayjsPlugins,
   'fast-diff',
+  'flowchart.js',
   'mermaid',
   'ot-json1',
   'ot-text-unicode',
+  'plantuml-encoder',
   'prismjs',
   'prismjs/components.js',
   'prismjs/dependencies',
   'prismjs/plugins/keep-markup/prism-keep-markup',
+  'snapsvg-cjs',
   'snabbdom-to-html',
+  'underscore',
+  'vega-embed',
+  'webfontloader',
 ]
 
 // https://vite.dev/config/
@@ -46,6 +52,30 @@ export default defineConfig({
       {
         find: /^mermaid$/,
         replacement: resolve(mermaidPackagePath, 'dist', 'mermaid.core.mjs'),
+      },
+      {
+        find: /^flowchart\.js$/,
+        replacement: resolveMuyaDependency('flowchart.js', 'index.js'),
+      },
+      {
+        find: /^plantuml-encoder$/,
+        replacement: resolveMuyaDependency('plantuml-encoder', 'browser-index.js'),
+      },
+      {
+        find: /^snapsvg-cjs$/,
+        replacement: resolveMuyaDependency('snapsvg-cjs', 'dist', 'snap.svg-cjs.js'),
+      },
+      {
+        find: /^underscore$/,
+        replacement: resolveMuyaDependency('underscore', 'underscore-esm.js'),
+      },
+      {
+        find: /^vega-embed$/,
+        replacement: resolveMuyaDependency('vega-embed', 'build', 'embed.js'),
+      },
+      {
+        find: /^webfontloader$/,
+        replacement: resolveMuyaDependency('webfontloader', 'webfontloader.js'),
       },
       {
         find: /^dayjs$/,


### PR DESCRIPTION
## Summary

- keep all five Muya diagram engines enabled on Android: Mermaid, PlantUML, Vega-Lite, flowchart, and sequence
- fix Vite/WebView loading for Muya-owned legacy diagram dependencies without moving them into startup code
- guard async diagram preview updates so stale renders cannot overwrite newer content
- add mobile E2E coverage that verifies all diagram previews render and the stored Markdown source is not rewritten

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm exec playwright test tests/e2e/mobile-markdown-rendering.spec.ts --project=mobile-chromium`
- `pnpm test:e2e`
- `pnpm android:sync`
- `JAVA_HOME=E:\Java\jdk-22 ANDROID_HOME=E:\Android\Sdk .\android\gradlew.bat -p android assembleDebug --no-daemon`
- ADB emulator/WebView smoke on `emulator-5554`: 5 diagram blocks, 0 diagram errors, 4 SVG previews, 1 PlantUML image preview, PlantUML image loaded, Markdown unchanged

## Notes

- Production build still warns about large chunks. That is expected while preserving full Muya/MarkText capability; heavy diagram renderers remain lazy-loaded chunks.
- PlantUML still depends on the configured remote PlantUML server for live image generation.