### PR TITLE
Add home settings shell

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { App } from '@capacitor/app'
 import type { PluginListenerHandle } from '@capacitor/core'
-import DocumentHome from './components/DocumentHome.vue'
+import HomeShell from './components/HomeShell.vue'
 import MobileEditorToolbar from './components/MobileEditorToolbar.vue'
 import {
   addAndroidOpenWithDocumentListener,
@@ -53,6 +53,13 @@ import {
   DEFAULT_MOBILE_TOOLBAR_PANEL,
   type MobileEditorToolbarPanel,
 } from './lib/mobileToolbarConfig'
+import { DEFAULT_HOME_TAB, HOME_TABS, type HomeTab } from './lib/homeNavigation'
+import type { HomeDocumentItem } from './lib/homeDocuments'
+import {
+  DEFAULT_SETTINGS_PAGE,
+  SETTINGS_PAGES,
+  type SettingsPage,
+} from './lib/settingsNavigation'
 import { createMuyaMobileEditorCommandTarget } from './lib/muyaMobileAdapter'
 import {
   createRecentDocumentFromAndroidDocument,
@@ -96,6 +103,8 @@ const currentAndroidDocumentCanWrite = ref(false)
 const status = ref('Ready')
 const homeNotice = ref<string | null>(null)
 const currentScreen = ref<'home' | 'editor'>('home')
+const homeTab = ref<HomeTab>(DEFAULT_HOME_TAB)
+const settingsPage = ref<SettingsPage>(DEFAULT_SETTINGS_PAGE)
 const editorReady = ref(false)
 const draftExitPromptOpen = ref(false)
 const androidExitPromptOpen = ref(false)
@@ -149,7 +158,7 @@ const continueDocument = computed(() =>
 )
 const earlierDocuments = computed(() => earlierDocumentItems.value.map(toHomeDocumentItem))
 
-function toHomeDocumentItem(item: RecentDocumentListItem) {
+function toHomeDocumentItem(item: RecentDocumentListItem): HomeDocumentItem {
   const savedAt = formatSavedTime(item.lastSavedAt ?? item.updatedAt)
   const count = item.stats ? `${item.stats.words} ${item.stats.words === 1 ? 'word' : 'words'}` : ''
   const source = item.providerName ?? 'Markdown document'
@@ -1438,7 +1447,18 @@ function closeEditorToHome() {
   closeLinkSheet()
   closeEditorToolbar()
   destroyEditor()
+  homeTab.value = HOME_TABS.DOCUMENTS
+  settingsPage.value = DEFAULT_SETTINGS_PAGE
   currentScreen.value = 'home'
+}
+
+function setHomeTab(tab: HomeTab) {
+  homeTab.value = tab
+  settingsPage.value = DEFAULT_SETTINGS_PAGE
+}
+
+function setSettingsPage(page: SettingsPage) {
+  settingsPage.value = page
 }
 
 async function showHome() {
@@ -1520,6 +1540,8 @@ function handlePageHide() {
 async function handleAppBackButton() {
   appLog.info('Android back button pressed', {
     screen: currentScreen.value,
+    homeTab: homeTab.value,
+    settingsPage: settingsPage.value,
     promptOpen: draftExitPromptOpen.value,
     androidExitPromptOpen: androidExitPromptOpen.value,
     menuOpen: editorMenuOpen.value,
@@ -1555,6 +1577,21 @@ async function handleAppBackButton() {
 
   if (currentScreen.value === 'editor') {
     await showHome()
+    return
+  }
+
+  if (
+    currentScreen.value === 'home' &&
+    homeTab.value === HOME_TABS.SETTINGS &&
+    settingsPage.value !== SETTINGS_PAGES.INDEX
+  ) {
+    settingsPage.value = SETTINGS_PAGES.INDEX
+    return
+  }
+
+  if (currentScreen.value === 'home' && homeTab.value !== HOME_TABS.DOCUMENTS) {
+    homeTab.value = HOME_TABS.DOCUMENTS
+    settingsPage.value = DEFAULT_SETTINGS_PAGE
     return
   }
 
@@ -1713,16 +1750,19 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <main v-if="currentScreen === 'home'" class="app-shell is-home">
-    <DocumentHome
-      :continue-document="continueDocument"
-      :earlier-documents="earlierDocuments"
-      :notice="homeNotice"
-      @new-document="newDocument"
-      @open-document="openDocument"
-      @open-file="openFileFromAndroid"
-    />
-  </main>
+  <HomeShell
+    v-if="currentScreen === 'home'"
+    :active-tab="homeTab"
+    :settings-page="settingsPage"
+    :continue-document="continueDocument"
+    :earlier-documents="earlierDocuments"
+    :notice="homeNotice"
+    @new-document="newDocument"
+    @open-document="openDocument"
+    @open-file="openFileFromAndroid"
+    @set-tab="setHomeTab"
+    @set-settings-page="setSettingsPage"
+  />
 
   <main v-else class="app-shell">
     <header class="top-bar">

--- a/src/components/AppBottomNavigation.vue
+++ b/src/components/AppBottomNavigation.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import AppBottomNavigationIcon from './AppBottomNavigationIcon.vue'
+import { HOME_TAB_ITEMS, type HomeTab } from '../lib/homeNavigation'
+
+defineProps<{
+  activeTab: HomeTab
+}>()
+
+const emit = defineEmits<{
+  setTab: [tab: HomeTab]
+}>()
+
+const tabs = HOME_TAB_ITEMS
+
+function selectTab(tab: HomeTab) {
+  emit('setTab', tab)
+}
+</script>
+
+<template>
+  <nav class="app-bottom-navigation" aria-label="Primary" data-testid="app-bottom-navigation">
+    <button
+      v-for="tab in tabs"
+      :key="tab.id"
+      class="bottom-nav-button"
+      :class="{ 'is-active': activeTab === tab.id }"
+      type="button"
+      :aria-label="tab.label"
+      :aria-current="activeTab === tab.id ? 'page' : undefined"
+      :data-testid="`bottom-nav-${tab.id}`"
+      @click="selectTab(tab.id)"
+    >
+      <AppBottomNavigationIcon :name="tab.icon" />
+    </button>
+  </nav>
+</template>
+
+<style scoped>
+.app-bottom-navigation {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  padding: 8px 20px calc(env(safe-area-inset-bottom, 0px) + 8px);
+  border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface-muted) 82%, var(--surface) 18%);
+}
+
+.bottom-nav-button {
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  min-height: 48px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  touch-action: manipulation;
+}
+
+.bottom-nav-button.is-active {
+  background: var(--surface);
+  color: var(--accent-strong);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.bottom-nav-button:active {
+  transform: translateY(1px);
+}
+
+@media (min-width: 720px) {
+  .app-bottom-navigation {
+    padding-right: max(24px, calc((100vw - 760px) / 2));
+    padding-left: max(24px, calc((100vw - 760px) / 2));
+  }
+}
+</style>

--- a/src/components/AppBottomNavigationIcon.vue
+++ b/src/components/AppBottomNavigationIcon.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import type { HomeTabIcon } from '../lib/homeNavigation'
+
+defineProps<{
+  name: HomeTabIcon
+}>()
+</script>
+
+<template>
+  <svg
+    v-if="name === 'document'"
+    class="bottom-nav-icon"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path d="M7 3h7l4 4v14H7z" />
+    <path d="M14 3v5h5" />
+    <path d="M9.5 12h5" />
+    <path d="M9.5 16h5" />
+  </svg>
+  <svg
+    v-else
+    class="bottom-nav-icon"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path d="M12 8.5a3.5 3.5 0 1 1 0 7a3.5 3.5 0 0 1 0-7z" />
+    <path
+      d="M19 13.5v-3l-2.1-.4a5.9 5.9 0 0 0-.7-1.6l1.2-1.8l-2.1-2.1l-1.8 1.2a5.9 5.9 0 0 0-1.6-.7L11.5 3h-3l-.4 2.1a5.9 5.9 0 0 0-1.6.7L4.7 4.6L2.6 6.7l1.2 1.8a5.9 5.9 0 0 0-.7 1.6L1 10.5v3l2.1.4a5.9 5.9 0 0 0 .7 1.6l-1.2 1.8l2.1 2.1l1.8-1.2a5.9 5.9 0 0 0 1.6.7l.4 2.1h3l.4-2.1a5.9 5.9 0 0 0 1.6-.7l1.8 1.2l2.1-2.1l-1.2-1.8a5.9 5.9 0 0 0 .7-1.6z"
+    />
+  </svg>
+</template>
+
+<style scoped>
+.bottom-nav-icon {
+  width: 25px;
+  height: 25px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.9;
+}
+</style>

--- a/src/components/DocumentHome.vue
+++ b/src/components/DocumentHome.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
-interface DocumentListItem {
-  id: string
-  title: string
-  details: string
-}
+import type { HomeDocumentItem } from '../lib/homeDocuments'
 
 interface Props {
-  continueDocument: DocumentListItem | null
-  earlierDocuments: DocumentListItem[]
+  continueDocument: HomeDocumentItem | null
+  earlierDocuments: HomeDocumentItem[]
   notice: string | null
 }
 
@@ -21,7 +17,7 @@ defineEmits<{
 </script>
 
 <template>
-  <section class="home-screen" aria-label="Recent documents">
+  <section class="home-screen" aria-label="Recent documents" data-testid="documents-screen">
     <header class="home-top">
       <div>
         <h1>MarkText</h1>

--- a/src/components/HomeShell.vue
+++ b/src/components/HomeShell.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import AppBottomNavigation from './AppBottomNavigation.vue'
+import DocumentHome from './DocumentHome.vue'
+import SettingsHome from './SettingsHome.vue'
+import type { HomeDocumentItem } from '../lib/homeDocuments'
+import { HOME_TABS, type HomeTab } from '../lib/homeNavigation'
+import type { SettingsPage } from '../lib/settingsNavigation'
+
+interface Props {
+  activeTab: HomeTab
+  settingsPage: SettingsPage
+  continueDocument: HomeDocumentItem | null
+  earlierDocuments: HomeDocumentItem[]
+  notice: string | null
+}
+
+defineProps<Props>()
+
+const emit = defineEmits<{
+  setTab: [tab: HomeTab]
+  openDocument: [id: string]
+  openFile: []
+  newDocument: []
+  setSettingsPage: [page: SettingsPage]
+}>()
+</script>
+
+<template>
+  <main class="app-shell is-home">
+    <div class="home-main">
+      <DocumentHome
+        v-if="activeTab === HOME_TABS.DOCUMENTS"
+        :continue-document="continueDocument"
+        :earlier-documents="earlierDocuments"
+        :notice="notice"
+        @new-document="emit('newDocument')"
+        @open-document="id => emit('openDocument', id)"
+        @open-file="emit('openFile')"
+      />
+      <SettingsHome
+        v-else
+        :active-page="settingsPage"
+        @set-page="page => emit('setSettingsPage', page)"
+      />
+    </div>
+    <AppBottomNavigation :active-tab="activeTab" @set-tab="tab => emit('setTab', tab)" />
+  </main>
+</template>
+
+<style scoped>
+.home-main {
+  min-height: 0;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+</style>

--- a/src/components/SettingsHome.vue
+++ b/src/components/SettingsHome.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import AboutSettings from './settings/AboutSettings.vue'
+import ReferenceSettings from './settings/ReferenceSettings.vue'
+import SettingsRow from './settings/SettingsRow.vue'
+import SettingsSection from './settings/SettingsSection.vue'
+import {
+  SETTINGS_HOME_ITEMS,
+  SETTINGS_PAGES,
+  type SettingsPage,
+} from '../lib/settingsNavigation'
+
+defineProps<{
+  activePage: SettingsPage
+}>()
+
+const emit = defineEmits<{
+  setPage: [page: SettingsPage]
+}>()
+
+function getPageTitle(page: SettingsPage) {
+  if (page === SETTINGS_PAGES.ABOUT) {
+    return 'About MarkText'
+  }
+
+  if (page === SETTINGS_PAGES.REFERENCES) {
+    return 'References'
+  }
+
+  return 'Settings'
+}
+</script>
+
+<template>
+  <section class="settings-screen" aria-label="Settings" data-testid="settings-screen">
+    <header class="settings-top" :class="{ 'is-detail': activePage !== SETTINGS_PAGES.INDEX }">
+      <button
+        v-if="activePage !== SETTINGS_PAGES.INDEX"
+        class="settings-back-button"
+        type="button"
+        aria-label="Back to settings"
+        data-testid="settings-detail-back"
+        @click="emit('setPage', SETTINGS_PAGES.INDEX)"
+      />
+      <h1 data-testid="settings-title">{{ getPageTitle(activePage) }}</h1>
+    </header>
+    <div class="settings-content">
+      <template v-if="activePage === SETTINGS_PAGES.INDEX">
+        <div class="settings-index" data-testid="settings-index">
+          <SettingsSection title="App">
+            <SettingsRow
+              v-for="item in SETTINGS_HOME_ITEMS"
+              :key="item.id"
+              :label="item.label"
+              :value="item.value"
+              button
+              :test-id="item.testId"
+              @activate="emit('setPage', item.id)"
+            />
+          </SettingsSection>
+        </div>
+      </template>
+      <AboutSettings v-else-if="activePage === SETTINGS_PAGES.ABOUT" />
+      <ReferenceSettings v-else />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.settings-screen {
+  min-height: 100%;
+  padding: calc(env(safe-area-inset-top, 0px) + 18px) 0 28px;
+  background: var(--surface);
+}
+
+.settings-top {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: center;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.settings-top.is-detail {
+  grid-template-columns: 44px minmax(0, 1fr) 44px;
+}
+
+.settings-back-button {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  margin-left: -10px;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+}
+
+.settings-back-button::before {
+  position: absolute;
+  top: 50%;
+  left: 16px;
+  width: 13px;
+  height: 13px;
+  border-bottom: 2.5px solid currentColor;
+  border-left: 2.5px solid currentColor;
+  content: '';
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.settings-back-button:active {
+  transform: translateY(1px);
+}
+
+.settings-top h1 {
+  margin: 0;
+  color: var(--text);
+  font-size: 28px;
+  line-height: 1.08;
+  font-weight: 760;
+}
+
+.settings-top.is-detail h1 {
+  text-align: center;
+}
+
+.settings-content {
+  display: grid;
+  max-width: 760px;
+  margin: 30px auto 0;
+  gap: 24px;
+}
+
+.settings-index {
+  display: grid;
+  gap: 24px;
+}
+</style>

--- a/src/components/settings/AboutSettings.vue
+++ b/src/components/settings/AboutSettings.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import SettingsRow from './SettingsRow.vue'
+import SettingsSection from './SettingsSection.vue'
+import { APP_INFO } from '../../lib/appInfo'
+import { checkForAppUpdates, type AppUpdateCheckResult } from '../../lib/appUpdates'
+
+const checkingUpdates = ref(false)
+const updateResult = ref<AppUpdateCheckResult | null>(null)
+
+const updateStatus = computed(() => {
+  if (checkingUpdates.value) {
+    return 'Checking'
+  }
+
+  return updateResult.value?.message
+})
+
+const releaseLinkLabel = computed(() =>
+  updateResult.value?.status === 'unavailable' ? 'All releases' : 'Latest release',
+)
+
+const releaseLinkValue = computed(() =>
+  updateResult.value?.latestVersion ? `v${updateResult.value.latestVersion}` : 'GitHub releases',
+)
+
+async function checkUpdates() {
+  if (checkingUpdates.value) {
+    return
+  }
+
+  checkingUpdates.value = true
+  try {
+    updateResult.value = await checkForAppUpdates()
+  } finally {
+    checkingUpdates.value = false
+  }
+}
+</script>
+
+<template>
+  <SettingsSection title="App">
+    <SettingsRow label="App" :value="APP_INFO.name" test-id="settings-about-app" />
+    <SettingsRow label="Version" :value="APP_INFO.version" test-id="settings-about-version" />
+  </SettingsSection>
+
+  <SettingsSection title="Updates">
+    <SettingsRow
+      label="Check for updates"
+      :value="updateStatus"
+      button
+      :busy="checkingUpdates"
+      :disabled="checkingUpdates"
+      test-id="settings-check-updates"
+      @activate="checkUpdates"
+    />
+    <SettingsRow
+      v-if="updateResult?.releaseUrl"
+      :label="releaseLinkLabel"
+      :value="releaseLinkValue"
+      :href="updateResult.releaseUrl"
+      test-id="settings-latest-release"
+    />
+  </SettingsSection>
+</template>

--- a/src/components/settings/ReferenceSettings.vue
+++ b/src/components/settings/ReferenceSettings.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import SettingsRow from './SettingsRow.vue'
+import SettingsSection from './SettingsSection.vue'
+import { APP_REFERENCE_SECTIONS } from '../../lib/appInfo'
+</script>
+
+<template>
+  <SettingsSection
+    v-for="section in APP_REFERENCE_SECTIONS"
+    :key="section.title"
+    :title="section.title"
+  >
+    <SettingsRow
+      v-for="link in section.links"
+      :key="link.href"
+      :label="link.label"
+      :value="link.value"
+      :href="link.href"
+      :test-id="link.testId"
+    />
+  </SettingsSection>
+</template>

--- a/src/components/settings/SettingsRow.vue
+++ b/src/components/settings/SettingsRow.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+defineProps<{
+  label: string
+  value?: string
+  href?: string
+  button?: boolean
+  disabled?: boolean
+  busy?: boolean
+  testId?: string
+}>()
+
+defineEmits<{
+  activate: []
+}>()
+</script>
+
+<template>
+  <button
+    v-if="button"
+    class="settings-row is-action"
+    type="button"
+    :disabled="disabled"
+    :aria-busy="busy ? 'true' : undefined"
+    :data-testid="testId"
+    @click="$emit('activate')"
+  >
+    <span class="settings-row-label">{{ label }}</span>
+    <span v-if="value" class="settings-row-value">{{ value }}</span>
+  </button>
+  <a
+    v-else-if="href"
+    class="settings-row is-link"
+    :href="href"
+    target="_blank"
+    rel="noreferrer"
+    :data-testid="testId"
+  >
+    <span class="settings-row-label">{{ label }}</span>
+    <span v-if="value" class="settings-row-value">{{ value }}</span>
+  </a>
+  <div v-else class="settings-row" :data-testid="testId">
+    <span class="settings-row-label">{{ label }}</span>
+    <span v-if="value" class="settings-row-value">{{ value }}</span>
+  </div>
+</template>
+
+<style scoped>
+.settings-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  width: min(100%, 760px);
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  text-decoration: none;
+}
+
+.settings-row:last-child {
+  border-bottom: 0;
+}
+
+.settings-row.is-link,
+.settings-row.is-action {
+  padding-right: 48px;
+}
+
+.settings-row.is-link::after,
+.settings-row.is-action::after {
+  position: absolute;
+  top: 50%;
+  right: 24px;
+  width: 8px;
+  height: 8px;
+  border-top: 2px solid currentColor;
+  border-right: 2px solid currentColor;
+  color: var(--text-muted);
+  content: '';
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.settings-row.is-link:active,
+.settings-row.is-action:active {
+  background: var(--surface-muted);
+}
+
+.settings-row.is-action {
+  width: 100%;
+  max-width: 760px;
+  border-top: 0;
+  border-right: 0;
+  border-left: 0;
+  text-align: left;
+}
+
+.settings-row.is-action:disabled {
+  color: var(--text-muted);
+}
+
+.settings-row-label,
+.settings-row-value {
+  min-width: 0;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.settings-row-label {
+  font-size: 16px;
+  font-weight: 720;
+}
+
+.settings-row-value {
+  max-width: 42vw;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 620;
+  text-align: right;
+}
+</style>

--- a/src/components/settings/SettingsSection.vue
+++ b/src/components/settings/SettingsSection.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+}>()
+</script>
+
+<template>
+  <section class="settings-section">
+    <h2>{{ title }}</h2>
+    <div class="settings-section-body">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.settings-section {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-section h2 {
+  max-width: 760px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 20px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.2;
+  font-weight: 760;
+}
+
+.settings-section-body {
+  overflow: hidden;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+</style>

--- a/src/lib/appInfo.ts
+++ b/src/lib/appInfo.ts
@@ -1,0 +1,71 @@
+export const APP_INFO = Object.freeze({
+  name: 'MarkText for Android',
+  version: '0.0.0',
+  repositoryOwner: 'Renakoni',
+  repositoryName: 'marktext-android',
+  repositoryUrl: 'https://github.com/Renakoni/marktext-android',
+  issuesUrl: 'https://github.com/Renakoni/marktext-android/issues',
+  releasesUrl: 'https://github.com/Renakoni/marktext-android/releases',
+  latestReleaseApiUrl: 'https://api.github.com/repos/Renakoni/marktext-android/releases/latest',
+  upstreamMarkTextUrl: 'https://github.com/marktext/marktext',
+  upstreamMuyaUrl: 'https://github.com/marktext/muya',
+} as const)
+
+export interface AppReferenceLink {
+  label: string
+  value: string
+  href: string
+  testId: string
+}
+
+export interface AppReferenceSection {
+  title: string
+  links: readonly AppReferenceLink[]
+}
+
+export const APP_REFERENCE_SECTIONS = [
+  {
+    title: 'Project',
+    links: [
+      {
+        label: 'GitHub repository',
+        value: 'Renakoni/marktext-android',
+        href: APP_INFO.repositoryUrl,
+        testId: 'settings-reference-repository',
+      },
+      {
+        label: 'Report an issue',
+        value: 'GitHub issues',
+        href: APP_INFO.issuesUrl,
+        testId: 'settings-reference-issues',
+      },
+      {
+        label: 'All releases',
+        value: 'GitHub releases',
+        href: APP_INFO.releasesUrl,
+        testId: 'settings-reference-releases',
+      },
+    ],
+  },
+  {
+    title: 'Upstream',
+    links: [
+      {
+        label: 'MarkText desktop',
+        value: 'marktext/marktext',
+        href: APP_INFO.upstreamMarkTextUrl,
+        testId: 'settings-reference-upstream-marktext',
+      },
+      {
+        label: 'Editor core',
+        value: 'marktext/muya',
+        href: APP_INFO.upstreamMuyaUrl,
+        testId: 'settings-reference-muya',
+      },
+    ],
+  },
+] as const satisfies readonly AppReferenceSection[]
+
+export const APP_REFERENCE_LINKS: readonly AppReferenceLink[] = APP_REFERENCE_SECTIONS.flatMap(section =>
+  [...section.links],
+)

--- a/src/lib/appUpdates.test.ts
+++ b/src/lib/appUpdates.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest'
+import { APP_INFO } from './appInfo'
+import { checkForAppUpdates, compareVersionTags } from './appUpdates'
+
+describe('compareVersionTags', () => {
+  test('compares semver-like release tags', () => {
+    expect(compareVersionTags('v1.2.0', '1.1.9')).toBe(1)
+    expect(compareVersionTags('1.0.0', '1.0')).toBe(0)
+    expect(compareVersionTags('0.9.0', '1.0.0')).toBe(-1)
+  })
+})
+
+describe('checkForAppUpdates', () => {
+  test('reports a newer GitHub release as available', async () => {
+    const result = await checkForAppUpdates(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            tag_name: 'v0.1.0',
+            html_url: 'https://github.com/Renakoni/marktext-android/releases/tag/v0.1.0',
+          }),
+          { status: 200 },
+        ),
+      ),
+    )
+
+    expect(result).toMatchObject({
+      status: 'available',
+      latestVersion: '0.1.0',
+      releaseUrl: 'https://github.com/Renakoni/marktext-android/releases/tag/v0.1.0',
+    })
+  })
+
+  test('handles repositories without published releases', async () => {
+    const result = await checkForAppUpdates(() => Promise.resolve(new Response('', { status: 404 })))
+
+    expect(result).toEqual({
+      status: 'unavailable',
+      message: 'No published releases yet',
+      latestVersion: null,
+      releaseUrl: APP_INFO.releasesUrl,
+    })
+  })
+})

--- a/src/lib/appUpdates.ts
+++ b/src/lib/appUpdates.ts
@@ -1,0 +1,130 @@
+import { APP_INFO } from './appInfo'
+
+interface GitHubReleaseResponse {
+  tag_name?: unknown
+  html_url?: unknown
+}
+
+export type AppUpdateCheckResult =
+  | {
+      status: 'available'
+      message: string
+      latestVersion: string
+      releaseUrl: string | null
+    }
+  | {
+      status: 'current' | 'unavailable'
+      message: string
+      latestVersion: string | null
+      releaseUrl: string | null
+    }
+
+type ReleaseFetch = typeof fetch
+
+function normalizeVersionTag(value: unknown) {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().replace(/^v/i, '')
+  return normalized || null
+}
+
+function parseVersionParts(value: string) {
+  const version = normalizeVersionTag(value)?.split(/[+-]/, 1)[0]
+  if (!version) {
+    return null
+  }
+
+  const parts = version.split('.').map(part => Number.parseInt(part, 10))
+  if (parts.some(part => Number.isNaN(part))) {
+    return null
+  }
+
+  return parts
+}
+
+export function compareVersionTags(left: string, right: string) {
+  const leftParts = parseVersionParts(left)
+  const rightParts = parseVersionParts(right)
+
+  if (!leftParts || !rightParts) {
+    return normalizeVersionTag(left) === normalizeVersionTag(right) ? 0 : 1
+  }
+
+  const length = Math.max(leftParts.length, rightParts.length)
+  for (let index = 0; index < length; index += 1) {
+    const leftValue = leftParts[index] ?? 0
+    const rightValue = rightParts[index] ?? 0
+    if (leftValue !== rightValue) {
+      return leftValue > rightValue ? 1 : -1
+    }
+  }
+
+  return 0
+}
+
+export async function checkForAppUpdates(fetchRelease: ReleaseFetch = fetch) {
+  try {
+    const response = await fetchRelease(APP_INFO.latestReleaseApiUrl, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2026-03-10',
+      },
+    })
+
+    if (response.status === 404) {
+      return {
+        status: 'unavailable',
+        message: 'No published releases yet',
+        latestVersion: null,
+        releaseUrl: APP_INFO.releasesUrl,
+      } satisfies AppUpdateCheckResult
+    }
+
+    if (!response.ok) {
+      return {
+        status: 'unavailable',
+        message: `Could not check updates (${response.status})`,
+        latestVersion: null,
+        releaseUrl: APP_INFO.releasesUrl,
+      } satisfies AppUpdateCheckResult
+    }
+
+    const release = (await response.json()) as GitHubReleaseResponse
+    const latestVersion = normalizeVersionTag(release.tag_name)
+    const releaseUrl = typeof release.html_url === 'string' ? release.html_url : APP_INFO.releasesUrl
+
+    if (!latestVersion) {
+      return {
+        status: 'unavailable',
+        message: 'Latest release did not include a version',
+        latestVersion: null,
+        releaseUrl,
+      } satisfies AppUpdateCheckResult
+    }
+
+    if (compareVersionTags(latestVersion, APP_INFO.version) > 0) {
+      return {
+        status: 'available',
+        message: `Update available: v${latestVersion}`,
+        latestVersion,
+        releaseUrl,
+      } satisfies AppUpdateCheckResult
+    }
+
+    return {
+      status: 'current',
+      message: 'You are on the latest version',
+      latestVersion,
+      releaseUrl,
+    } satisfies AppUpdateCheckResult
+  } catch {
+    return {
+      status: 'unavailable',
+      message: 'Could not reach GitHub releases',
+      latestVersion: null,
+      releaseUrl: APP_INFO.releasesUrl,
+    } satisfies AppUpdateCheckResult
+  }
+}

--- a/src/lib/homeDocuments.ts
+++ b/src/lib/homeDocuments.ts
@@ -1,0 +1,5 @@
+export interface HomeDocumentItem {
+  id: string
+  title: string
+  details: string
+}

--- a/src/lib/homeNavigation.ts
+++ b/src/lib/homeNavigation.ts
@@ -1,0 +1,28 @@
+export const HOME_TABS = Object.freeze({
+  DOCUMENTS: 'documents',
+  SETTINGS: 'settings',
+} as const)
+
+export type HomeTab = (typeof HOME_TABS)[keyof typeof HOME_TABS]
+export type HomeTabIcon = 'document' | 'settings'
+
+export interface HomeTabItem {
+  id: HomeTab
+  label: string
+  icon: HomeTabIcon
+}
+
+export const HOME_TAB_ITEMS = [
+  {
+    id: HOME_TABS.DOCUMENTS,
+    label: 'Documents',
+    icon: 'document',
+  },
+  {
+    id: HOME_TABS.SETTINGS,
+    label: 'Settings',
+    icon: 'settings',
+  },
+] as const satisfies readonly HomeTabItem[]
+
+export const DEFAULT_HOME_TAB: HomeTab = HOME_TABS.DOCUMENTS

--- a/src/lib/settingsNavigation.ts
+++ b/src/lib/settingsNavigation.ts
@@ -1,0 +1,31 @@
+export const SETTINGS_PAGES = Object.freeze({
+  INDEX: 'index',
+  ABOUT: 'about',
+  REFERENCES: 'references',
+} as const)
+
+export type SettingsPage = (typeof SETTINGS_PAGES)[keyof typeof SETTINGS_PAGES]
+
+export interface SettingsHomeItem {
+  id: Exclude<SettingsPage, typeof SETTINGS_PAGES.INDEX>
+  label: string
+  value: string
+  testId: string
+}
+
+export const SETTINGS_HOME_ITEMS = [
+  {
+    id: SETTINGS_PAGES.ABOUT,
+    label: 'About MarkText',
+    value: 'Version and updates',
+    testId: 'settings-entry-about',
+  },
+  {
+    id: SETTINGS_PAGES.REFERENCES,
+    label: 'References',
+    value: 'Repository and upstream',
+    testId: 'settings-entry-references',
+  },
+] as const satisfies readonly SettingsHomeItem[]
+
+export const DEFAULT_SETTINGS_PAGE: SettingsPage = SETTINGS_PAGES.INDEX

--- a/src/style.css
+++ b/src/style.css
@@ -43,16 +43,15 @@ body {
 }
 
 .app-shell.is-home {
-  display: block;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  overflow: hidden;
+  background: var(--surface);
 }
 
 .home-screen {
-  min-height: 100vh;
-  min-height: 100dvh;
-  padding: calc(env(safe-area-inset-top, 0px) + 18px) 18px
-    calc(env(safe-area-inset-bottom, 0px) + 28px);
+  min-height: 100%;
+  padding: calc(env(safe-area-inset-top, 0px) + 18px) 18px 28px;
   background: var(--surface);
 }
 

--- a/tests/e2e/mobile-home-navigation.spec.ts
+++ b/tests/e2e/mobile-home-navigation.spec.ts
@@ -1,0 +1,196 @@
+import { expect, test, type Page } from '@playwright/test'
+
+interface MockCapacitorWindow {
+  __emitCapacitorAppBackButton?: () => void
+  __appExitCount?: () => number
+  __appListenerCount?: (eventName: string) => number
+  Capacitor?: {
+    PluginHeaders?: Array<{
+      name: string
+      methods: Array<{ name: string; rtype: string }>
+    }>
+    nativeCallback?: (
+      pluginName: string,
+      methodName: string,
+      options: Record<string, unknown>,
+      callback?: (data: unknown) => void,
+    ) => Promise<string>
+    nativePromise?: (
+      pluginName: string,
+      methodName: string,
+      options?: Record<string, unknown>,
+    ) => Promise<unknown>
+  }
+}
+
+async function installAndroidBackButtonMock(page: Page) {
+  await page.addInitScript(() => {
+    const win = window as unknown as MockCapacitorWindow
+    const appListeners = new Map<string, Array<(data: unknown) => void>>()
+    let appExitCount = 0
+
+    win.__emitCapacitorAppBackButton = () => {
+      for (const listener of appListeners.get('backButton') ?? []) {
+        listener({ canGoBack: false })
+      }
+    }
+    win.__appExitCount = () => appExitCount
+    win.__appListenerCount = (eventName: string) => appListeners.get(eventName)?.length ?? 0
+    win.Capacitor = {
+      ...(win.Capacitor ?? {}),
+      PluginHeaders: [
+        ...((win.Capacitor?.PluginHeaders ?? []).filter(header => header.name !== 'App')),
+        {
+          name: 'App',
+          methods: [
+            { name: 'addListener', rtype: 'callback' },
+            { name: 'removeListener', rtype: 'promise' },
+            { name: 'exitApp', rtype: 'promise' },
+          ],
+        },
+      ],
+      nativeCallback(pluginName, methodName, options, callback) {
+        if (pluginName === 'App' && methodName === 'addListener') {
+          if (typeof options.eventName === 'string' && callback) {
+            const listeners = appListeners.get(options.eventName) ?? []
+            listeners.push(callback)
+            appListeners.set(options.eventName, listeners)
+          }
+          return Promise.resolve(`app-listener-${String(options.eventName)}`)
+        }
+
+        return Promise.reject({
+          code: 'UNIMPLEMENTED',
+          message: `${pluginName}.${methodName} is not mocked`,
+        })
+      },
+      nativePromise(pluginName, methodName) {
+        if (pluginName === 'App' && methodName === 'exitApp') {
+          appExitCount += 1
+          return Promise.resolve()
+        }
+
+        if (pluginName === 'App' && methodName === 'removeListener') {
+          return Promise.resolve()
+        }
+
+        return Promise.reject({
+          code: 'UNIMPLEMENTED',
+          message: `${pluginName}.${methodName} is not mocked`,
+        })
+      },
+    }
+  })
+}
+
+test('switches between document home and the settings about screen', async ({ page }) => {
+  await page.route('https://api.github.com/repos/Renakoni/marktext-android/releases/latest', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        tag_name: 'v0.1.0',
+        html_url: 'https://github.com/Renakoni/marktext-android/releases/tag/v0.1.0',
+      }),
+    }),
+  )
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+
+  await expect(page.getByTestId('documents-screen')).toBeVisible()
+  await expect(page.getByTestId('new-document-button')).toBeVisible()
+  await expect(page.getByTestId('bottom-nav-documents')).toHaveAttribute('aria-current', 'page')
+
+  await page.getByTestId('bottom-nav-settings').click()
+
+  await expect(page.getByTestId('settings-screen')).toBeVisible()
+  await expect(page.getByTestId('settings-index')).toBeVisible()
+  await expect(page.getByTestId('new-document-button')).toBeHidden()
+  await expect(page.getByTestId('bottom-nav-settings')).toHaveAttribute('aria-current', 'page')
+
+  await page.getByTestId('settings-entry-about').click()
+  await expect(page.getByTestId('settings-title')).toContainText('About MarkText')
+  await expect(page.getByTestId('settings-about-app')).toBeVisible()
+  await expect(page.getByTestId('settings-about-version')).toBeVisible()
+
+  await page.getByTestId('settings-check-updates').click()
+  await expect(page.getByTestId('settings-check-updates')).toContainText(
+    'Update available: v0.1.0',
+  )
+  await expect(page.getByTestId('settings-latest-release')).toHaveAttribute(
+    'href',
+    'https://github.com/Renakoni/marktext-android/releases/tag/v0.1.0',
+  )
+
+  await page.getByTestId('settings-detail-back').click()
+  await expect(page.getByTestId('settings-index')).toBeVisible()
+
+  await page.getByTestId('settings-entry-references').click()
+  await expect(page.getByTestId('settings-title')).toContainText('References')
+  await expect(page.getByTestId('settings-reference-repository')).toHaveAttribute(
+    'href',
+    'https://github.com/Renakoni/marktext-android',
+  )
+  await expect(page.getByTestId('settings-reference-issues')).toHaveAttribute(
+    'href',
+    'https://github.com/Renakoni/marktext-android/issues',
+  )
+
+  await page.getByTestId('bottom-nav-documents').click()
+
+  await expect(page.getByTestId('documents-screen')).toBeVisible()
+  await expect(page.getByTestId('new-document-button')).toBeVisible()
+})
+
+test('uses Android back to return from settings to documents before exiting', async ({ page }) => {
+  await installAndroidBackButtonMock(page)
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+  await page.waitForFunction(() => {
+    const win = window as unknown as MockCapacitorWindow
+    return (win.__appListenerCount?.('backButton') ?? 0) > 0
+  })
+
+  await page.getByTestId('bottom-nav-settings').click()
+  await expect(page.getByTestId('settings-screen')).toBeVisible()
+  await page.getByTestId('settings-entry-about').click()
+  await expect(page.getByTestId('settings-title')).toContainText('About MarkText')
+
+  await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    win.__emitCapacitorAppBackButton?.()
+  })
+
+  await expect(page.getByTestId('settings-index')).toBeVisible()
+  const exitCountAfterDetailBack = await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    return win.__appExitCount?.() ?? 0
+  })
+  expect(exitCountAfterDetailBack).toBe(0)
+
+  await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    win.__emitCapacitorAppBackButton?.()
+  })
+
+  await expect(page.getByTestId('documents-screen')).toBeVisible()
+  const exitCountAfterSettingsBack = await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    return win.__appExitCount?.() ?? 0
+  })
+  expect(exitCountAfterSettingsBack).toBe(0)
+
+  await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    win.__emitCapacitorAppBackButton?.()
+  })
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const win = window as unknown as MockCapacitorWindow
+      return win.__appExitCount?.() ?? 0
+    })
+  }).toBe(1)
+})


### PR DESCRIPTION
## Summary

- Add a home shell with icon-only Documents and Settings bottom navigation.
- Add a mobile settings index with tappable About MarkText and References entries.
- Add About detail content for app/version/update checks and References detail content for repository/upstream links.
- Keep settings UI split into small shell, section, row, about, reference, and navigation modules.
- Cover Android Back behavior from settings detail to settings index, then back to Documents.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm exec playwright test tests/e2e/mobile-home-navigation.spec.ts --project=mobile-chromium`
- Full Playwright E2E with a temporary config on port 5175, 49 passed
- `pnpm android:sync`
- `./android/gradlew.bat -p android assembleDebug`
- Installed debug APK on `emulator-5554` with ADB
- MCP screenshot review for Documents, Settings index, About MarkText, References, and update-check failure state

## Notes

- The local default Playwright port 5174 was bound by another local process, so the full E2E run used a temporary config on port 5175 without changing repository files.
- Update checking uses the GitHub latest release API and falls back to the releases page when a release check is unavailable.