### PR TITLE
Expand settings content placeholders

### DIFF
--- a/src/components/AppBottomNavigation.vue
+++ b/src/components/AppBottomNavigation.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import AppBottomNavigationIcon from './AppBottomNavigationIcon.vue'
 import { HOME_TAB_ITEMS, type HomeTab } from '../lib/homeNavigation'
+import { useI18n } from '../lib/i18n'
 
 defineProps<{
   activeTab: HomeTab
@@ -10,6 +11,7 @@ const emit = defineEmits<{
   setTab: [tab: HomeTab]
 }>()
 
+const { t } = useI18n()
 const tabs = HOME_TAB_ITEMS
 
 function selectTab(tab: HomeTab) {
@@ -25,7 +27,7 @@ function selectTab(tab: HomeTab) {
       class="bottom-nav-button"
       :class="{ 'is-active': activeTab === tab.id }"
       type="button"
-      :aria-label="tab.label"
+      :aria-label="t(tab.labelKey)"
       :aria-current="activeTab === tab.id ? 'page' : undefined"
       :data-testid="`bottom-nav-${tab.id}`"
       @click="selectTab(tab.id)"

--- a/src/components/DocumentHome.vue
+++ b/src/components/DocumentHome.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { HomeDocumentItem } from '../lib/homeDocuments'
+import { useI18n } from '../lib/i18n'
 
 interface Props {
   continueDocument: HomeDocumentItem | null
@@ -14,10 +15,12 @@ defineEmits<{
   openFile: []
   newDocument: []
 }>()
+
+const { t } = useI18n()
 </script>
 
 <template>
-  <section class="home-screen" aria-label="Recent documents" data-testid="documents-screen">
+  <section class="home-screen" :aria-label="t('home.documents.aria')" data-testid="documents-screen">
     <header class="home-top">
       <div>
         <h1>MarkText</h1>
@@ -29,14 +32,14 @@ defineEmits<{
           data-testid="open-file-button"
           @click="$emit('openFile')"
         >
-          Open
+          {{ t('home.open') }}
         </button>
         <button
           class="home-new-button"
           type="button"
-          aria-label="New document"
+          :aria-label="t('home.newDocument')"
           data-testid="new-document-button"
-          title="New document"
+          :title="t('home.newDocument')"
           @click="$emit('newDocument')"
         >
           +
@@ -46,13 +49,13 @@ defineEmits<{
 
     <p v-if="notice" class="home-notice" role="status">{{ notice }}</p>
 
-    <nav class="home-tabs" aria-label="Document sections">
-      <button class="home-tab is-active" type="button">Recent</button>
+    <nav class="home-tabs" :aria-label="t('home.documentSections')">
+      <button class="home-tab is-active" type="button">{{ t('home.recent') }}</button>
     </nav>
 
     <div class="home-content">
       <section v-if="continueDocument" class="document-group" aria-labelledby="continue-title">
-        <h2 id="continue-title">Continue writing</h2>
+        <h2 id="continue-title">{{ t('home.continueWriting') }}</h2>
         <button class="document-row" type="button" @click="$emit('openDocument', continueDocument.id)">
           <span class="document-icon" aria-hidden="true">M</span>
           <span class="document-text">
@@ -63,7 +66,7 @@ defineEmits<{
       </section>
 
       <section v-if="earlierDocuments.length > 0" class="document-group" aria-labelledby="earlier-title">
-        <h2 id="earlier-title">Earlier</h2>
+        <h2 id="earlier-title">{{ t('home.earlier') }}</h2>
         <button
           v-for="document in earlierDocuments"
           :key="document.id"
@@ -85,8 +88,8 @@ defineEmits<{
         aria-labelledby="recent-title"
       >
         <div class="empty-recent">
-          <h2 id="recent-title">No recent Markdown files</h2>
-          <p>Start a local draft or open a Markdown file from this device.</p>
+          <h2 id="recent-title">{{ t('home.emptyTitle') }}</h2>
+          <p>{{ t('home.emptyBody') }}</p>
         </div>
       </section>
     </div>

--- a/src/components/SettingsHome.vue
+++ b/src/components/SettingsHome.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import AboutSettings from './settings/AboutSettings.vue'
-import ReferenceSettings from './settings/ReferenceSettings.vue'
+import SettingsDetailPage from './settings/SettingsDetailPage.vue'
 import SettingsRow from './settings/SettingsRow.vue'
 import SettingsSection from './settings/SettingsSection.vue'
+import { useI18n } from '../lib/i18n'
+import { SETTINGS_PAGE_TITLE_KEYS } from '../lib/settingsContent'
 import {
-  SETTINGS_HOME_ITEMS,
+  SETTINGS_HOME_SECTIONS,
   SETTINGS_PAGES,
   type SettingsPage,
 } from '../lib/settingsNavigation'
@@ -17,42 +19,37 @@ const emit = defineEmits<{
   setPage: [page: SettingsPage]
 }>()
 
-function getPageTitle(page: SettingsPage) {
-  if (page === SETTINGS_PAGES.ABOUT) {
-    return 'About MarkText'
-  }
-
-  if (page === SETTINGS_PAGES.REFERENCES) {
-    return 'References'
-  }
-
-  return 'Settings'
-}
+const { t } = useI18n()
 </script>
 
 <template>
-  <section class="settings-screen" aria-label="Settings" data-testid="settings-screen">
+  <section class="settings-screen" :aria-label="t('settings.title')" data-testid="settings-screen">
     <header class="settings-top" :class="{ 'is-detail': activePage !== SETTINGS_PAGES.INDEX }">
       <button
         v-if="activePage !== SETTINGS_PAGES.INDEX"
         class="settings-back-button"
         type="button"
-        aria-label="Back to settings"
+        :aria-label="t('settings.back')"
         data-testid="settings-detail-back"
         @click="emit('setPage', SETTINGS_PAGES.INDEX)"
       />
-      <h1 data-testid="settings-title">{{ getPageTitle(activePage) }}</h1>
+      <h1 data-testid="settings-title">{{ t(SETTINGS_PAGE_TITLE_KEYS[activePage]) }}</h1>
     </header>
     <div class="settings-content">
       <template v-if="activePage === SETTINGS_PAGES.INDEX">
         <div class="settings-index" data-testid="settings-index">
-          <SettingsSection title="App">
+          <SettingsSection
+            v-for="section in SETTINGS_HOME_SECTIONS"
+            :key="section.titleKey"
+            :title="t(section.titleKey)"
+          >
             <SettingsRow
-              v-for="item in SETTINGS_HOME_ITEMS"
+              v-for="item in section.items"
               :key="item.id"
-              :label="item.label"
-              :value="item.value"
+              :label="t(item.labelKey)"
+              :value="t(item.valueKey)"
               button
+              chevron
               :test-id="item.testId"
               @activate="emit('setPage', item.id)"
             />
@@ -60,7 +57,7 @@ function getPageTitle(page: SettingsPage) {
         </div>
       </template>
       <AboutSettings v-else-if="activePage === SETTINGS_PAGES.ABOUT" />
-      <ReferenceSettings v-else />
+      <SettingsDetailPage v-else :page="activePage" />
     </div>
   </section>
 </template>

--- a/src/components/settings/AboutSettings.vue
+++ b/src/components/settings/AboutSettings.vue
@@ -1,28 +1,53 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import ReferenceSettings from './ReferenceSettings.vue'
 import SettingsRow from './SettingsRow.vue'
 import SettingsSection from './SettingsSection.vue'
 import { APP_INFO } from '../../lib/appInfo'
 import { checkForAppUpdates, type AppUpdateCheckResult } from '../../lib/appUpdates'
+import { useI18n } from '../../lib/i18n'
 
 const checkingUpdates = ref(false)
 const updateResult = ref<AppUpdateCheckResult | null>(null)
+const { t } = useI18n()
 
 const updateStatus = computed(() => {
   if (checkingUpdates.value) {
-    return 'Checking'
+    return t('about.update.checking')
   }
 
-  return updateResult.value?.message
+  return updateResult.value ? getUpdateStatus(updateResult.value) : undefined
 })
 
 const releaseLinkLabel = computed(() =>
-  updateResult.value?.status === 'unavailable' ? 'All releases' : 'Latest release',
+  updateResult.value?.status === 'unavailable' ? t('about.allReleases') : t('about.latestRelease'),
 )
 
 const releaseLinkValue = computed(() =>
-  updateResult.value?.latestVersion ? `v${updateResult.value.latestVersion}` : 'GitHub releases',
+  updateResult.value?.latestVersion ? `v${updateResult.value.latestVersion}` : t('about.githubReleases'),
 )
+
+function getUpdateStatus(result: AppUpdateCheckResult) {
+  if (result.status === 'available' && result.latestVersion) {
+    return t('about.update.available', { version: result.latestVersion })
+  }
+
+  if (result.status === 'current') {
+    return t('about.update.current')
+  }
+
+  if (result.message === 'No published releases yet') {
+    return t('about.update.noReleases')
+  }
+
+  if (result.message === 'Latest release did not include a version') {
+    return t('about.update.badRelease')
+  }
+
+  return result.message.startsWith('Could not check updates')
+    ? result.message
+    : t('about.update.unavailable')
+}
 
 async function checkUpdates() {
   if (checkingUpdates.value) {
@@ -39,14 +64,16 @@ async function checkUpdates() {
 </script>
 
 <template>
-  <SettingsSection title="App">
-    <SettingsRow label="App" :value="APP_INFO.name" test-id="settings-about-app" />
-    <SettingsRow label="Version" :value="APP_INFO.version" test-id="settings-about-version" />
+  <SettingsSection :title="t('about.section.app')">
+    <SettingsRow :label="t('about.app')" :value="APP_INFO.name" test-id="settings-about-app" />
+    <SettingsRow :label="t('about.version')" :value="APP_INFO.version" test-id="settings-about-version" />
   </SettingsSection>
 
-  <SettingsSection title="Updates">
+  <ReferenceSettings />
+
+  <SettingsSection :title="t('about.section.updates')">
     <SettingsRow
-      label="Check for updates"
+      :label="t('about.checkUpdates')"
       :value="updateStatus"
       button
       :busy="checkingUpdates"
@@ -60,6 +87,14 @@ async function checkUpdates() {
       :value="releaseLinkValue"
       :href="updateResult.releaseUrl"
       test-id="settings-latest-release"
+    />
+  </SettingsSection>
+
+  <SettingsSection :title="t('about.section.legal')">
+    <SettingsRow
+      :label="t('about.licenseNotices')"
+      :value="t('about.thirdPartyNotices')"
+      test-id="settings-about-notices"
     />
   </SettingsSection>
 </template>

--- a/src/components/settings/ReferenceSettings.vue
+++ b/src/components/settings/ReferenceSettings.vue
@@ -2,19 +2,22 @@
 import SettingsRow from './SettingsRow.vue'
 import SettingsSection from './SettingsSection.vue'
 import { APP_REFERENCE_SECTIONS } from '../../lib/appInfo'
+import { useI18n } from '../../lib/i18n'
+
+const { t } = useI18n()
 </script>
 
 <template>
   <SettingsSection
     v-for="section in APP_REFERENCE_SECTIONS"
-    :key="section.title"
-    :title="section.title"
+    :key="section.titleKey"
+    :title="t(section.titleKey)"
   >
     <SettingsRow
       v-for="link in section.links"
       :key="link.href"
-      :label="link.label"
-      :value="link.value"
+      :label="t(link.labelKey)"
+      :value="link.valueKey ? t(link.valueKey) : link.value"
       :href="link.href"
       :test-id="link.testId"
     />

--- a/src/components/settings/SettingsChoiceRow.vue
+++ b/src/components/settings/SettingsChoiceRow.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+interface SettingsChoiceOption {
+  id: string
+  label: string
+  testId: string
+}
+
+defineProps<{
+  label?: string
+  ariaLabel?: string
+  modelValue: string
+  options: readonly SettingsChoiceOption[]
+  testId?: string
+}>()
+
+defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+</script>
+
+<template>
+  <div class="settings-choice-row" :class="{ 'is-label-hidden': !label }" :data-testid="testId">
+    <span v-if="label" class="settings-choice-label">{{ label }}</span>
+    <div class="settings-choice-options" role="group" :aria-label="ariaLabel ?? label">
+      <button
+        v-for="option in options"
+        :key="option.id"
+        class="settings-choice-option"
+        :class="{ 'is-active': modelValue === option.id }"
+        type="button"
+        :aria-pressed="modelValue === option.id"
+        :data-testid="option.testId"
+        @click="$emit('update:modelValue', option.id)"
+      >
+        {{ option.label }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.settings-choice-row {
+  display: grid;
+  gap: 10px;
+  width: min(100%, 760px);
+  min-height: 72px;
+  margin: 0 auto;
+  padding: 12px 20px 14px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+}
+
+.settings-choice-row:last-child {
+  border-bottom: 0;
+}
+
+.settings-choice-row.is-label-hidden {
+  min-height: 64px;
+  align-content: center;
+}
+
+.settings-choice-label {
+  min-width: 0;
+  font-size: 16px;
+  font-weight: 720;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.settings-choice-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  width: 100%;
+}
+
+.settings-choice-option {
+  min-width: 0;
+  min-height: 38px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 86%, var(--surface-muted) 14%);
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 720;
+  letter-spacing: 0;
+  touch-action: manipulation;
+}
+
+.settings-choice-option.is-active {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface));
+  color: var(--accent-strong);
+}
+
+.settings-choice-option:active {
+  transform: translateY(1px);
+}
+</style>

--- a/src/components/settings/SettingsDetailPage.vue
+++ b/src/components/settings/SettingsDetailPage.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import SettingsChoiceRow from './SettingsChoiceRow.vue'
+import SettingsRow from './SettingsRow.vue'
+import SettingsSection from './SettingsSection.vue'
+import { SETTINGS_DETAIL_SECTIONS } from '../../lib/settingsContent'
+import { APP_LANGUAGE_OPTIONS, useI18n } from '../../lib/i18n'
+import { SETTINGS_PAGES, type SettingsPage } from '../../lib/settingsNavigation'
+
+const props = defineProps<{
+  page: SettingsPage
+}>()
+
+const { locale, setLocale, t } = useI18n()
+const sections = computed(() => SETTINGS_DETAIL_SECTIONS[props.page] ?? [])
+const languageOptions = computed(() =>
+  APP_LANGUAGE_OPTIONS.map(option => ({
+    id: option.id,
+    label: t(option.labelKey),
+    testId: option.testId,
+  })),
+)
+
+function setLanguage(value: string) {
+  const nextLocale = APP_LANGUAGE_OPTIONS.find(option => option.id === value)?.id
+  if (nextLocale) {
+    setLocale(nextLocale)
+  }
+}
+</script>
+
+<template>
+  <SettingsSection
+    v-if="page === SETTINGS_PAGES.APPEARANCE"
+    :title="t('settings.section.language')"
+  >
+    <SettingsChoiceRow
+      :aria-label="t('settings.language.app')"
+      :model-value="locale"
+      :options="languageOptions"
+      test-id="settings-language-app"
+      @update:model-value="setLanguage"
+    />
+  </SettingsSection>
+
+  <SettingsSection v-for="section in sections" :key="section.titleKey" :title="t(section.titleKey)">
+    <SettingsRow
+      v-for="row in section.rows"
+      :key="row.testId"
+      :label="t(row.labelKey)"
+      :value="t(row.valueKey)"
+      :test-id="row.testId"
+    />
+  </SettingsSection>
+</template>

--- a/src/components/settings/SettingsRow.vue
+++ b/src/components/settings/SettingsRow.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-defineProps<{
+import { computed } from 'vue'
+
+const props = defineProps<{
   label: string
   value?: string
   href?: string
   button?: boolean
+  chevron?: boolean
   disabled?: boolean
   busy?: boolean
   testId?: string
@@ -12,12 +15,15 @@ defineProps<{
 defineEmits<{
   activate: []
 }>()
+
+const hasChevron = computed(() => Boolean(props.chevron || props.href))
 </script>
 
 <template>
   <button
     v-if="button"
     class="settings-row is-action"
+    :class="{ 'has-chevron': hasChevron }"
     type="button"
     :disabled="disabled"
     :aria-busy="busy ? 'true' : undefined"
@@ -29,7 +35,7 @@ defineEmits<{
   </button>
   <a
     v-else-if="href"
-    class="settings-row is-link"
+    class="settings-row is-link has-chevron"
     :href="href"
     target="_blank"
     rel="noreferrer"
@@ -66,13 +72,11 @@ defineEmits<{
   border-bottom: 0;
 }
 
-.settings-row.is-link,
-.settings-row.is-action {
+.settings-row.has-chevron {
   padding-right: 48px;
 }
 
-.settings-row.is-link::after,
-.settings-row.is-action::after {
+.settings-row.has-chevron::after {
   position: absolute;
   top: 50%;
   right: 24px;
@@ -101,6 +105,17 @@ defineEmits<{
 
 .settings-row.is-action:disabled {
   color: var(--text-muted);
+}
+
+.settings-row.has-chevron {
+  grid-template-columns: minmax(0, 1fr);
+  align-content: center;
+  gap: 3px;
+}
+
+.settings-row.has-chevron .settings-row-value {
+  max-width: none;
+  text-align: left;
 }
 
 .settings-row-label,

--- a/src/lib/appInfo.ts
+++ b/src/lib/appInfo.ts
@@ -1,3 +1,5 @@
+import type { I18nKey } from './i18n'
+
 export const APP_INFO = Object.freeze({
   name: 'MarkText for Android',
   version: '0.0.0',
@@ -12,59 +14,67 @@ export const APP_INFO = Object.freeze({
 } as const)
 
 export interface AppReferenceLink {
-  label: string
+  labelKey: I18nKey
   value: string
+  valueKey?: I18nKey
   href: string
   testId: string
 }
 
 export interface AppReferenceSection {
-  title: string
+  titleKey: I18nKey
   links: readonly AppReferenceLink[]
 }
 
-export const APP_REFERENCE_SECTIONS = [
+export const APP_REFERENCE_SECTIONS: readonly AppReferenceSection[] = [
   {
-    title: 'Project',
+    titleKey: 'about.section.project',
     links: [
       {
-        label: 'GitHub repository',
+        labelKey: 'about.githubRepository',
         value: 'Renakoni/marktext-android',
         href: APP_INFO.repositoryUrl,
         testId: 'settings-reference-repository',
       },
       {
-        label: 'Report an issue',
-        value: 'GitHub issues',
-        href: APP_INFO.issuesUrl,
-        testId: 'settings-reference-issues',
-      },
-      {
-        label: 'All releases',
+        labelKey: 'about.allReleases',
         value: 'GitHub releases',
+        valueKey: 'about.githubReleases',
         href: APP_INFO.releasesUrl,
         testId: 'settings-reference-releases',
       },
     ],
   },
   {
-    title: 'Upstream',
+    titleKey: 'about.section.upstream',
     links: [
       {
-        label: 'MarkText desktop',
+        labelKey: 'about.upstreamMarkText',
         value: 'marktext/marktext',
         href: APP_INFO.upstreamMarkTextUrl,
         testId: 'settings-reference-upstream-marktext',
       },
       {
-        label: 'Editor core',
+        labelKey: 'about.muyaAttribution',
         value: 'marktext/muya',
         href: APP_INFO.upstreamMuyaUrl,
         testId: 'settings-reference-muya',
       },
     ],
   },
-] as const satisfies readonly AppReferenceSection[]
+  {
+    titleKey: 'about.section.support',
+    links: [
+      {
+        labelKey: 'about.reportIssue',
+        value: 'GitHub issues',
+        valueKey: 'about.githubIssues',
+        href: APP_INFO.issuesUrl,
+        testId: 'settings-reference-issues',
+      },
+    ],
+  },
+]
 
 export const APP_REFERENCE_LINKS: readonly AppReferenceLink[] = APP_REFERENCE_SECTIONS.flatMap(section =>
   [...section.links],

--- a/src/lib/homeNavigation.ts
+++ b/src/lib/homeNavigation.ts
@@ -1,3 +1,5 @@
+import type { I18nKey } from './i18n'
+
 export const HOME_TABS = Object.freeze({
   DOCUMENTS: 'documents',
   SETTINGS: 'settings',
@@ -8,19 +10,19 @@ export type HomeTabIcon = 'document' | 'settings'
 
 export interface HomeTabItem {
   id: HomeTab
-  label: string
+  labelKey: I18nKey
   icon: HomeTabIcon
 }
 
 export const HOME_TAB_ITEMS = [
   {
     id: HOME_TABS.DOCUMENTS,
-    label: 'Documents',
+    labelKey: 'nav.documents',
     icon: 'document',
   },
   {
     id: HOME_TABS.SETTINGS,
-    label: 'Settings',
+    labelKey: 'nav.settings',
     icon: 'settings',
   },
 ] as const satisfies readonly HomeTabItem[]

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,360 @@
+import { readonly, ref } from 'vue'
+
+export const APP_LOCALES = Object.freeze({
+  EN: 'en',
+  ZH_CN: 'zh-CN',
+} as const)
+
+export type AppLocale = (typeof APP_LOCALES)[keyof typeof APP_LOCALES]
+
+const DEFAULT_APP_LOCALE: AppLocale = APP_LOCALES.EN
+const APP_LOCALE_STORAGE_KEY = 'marktext-for-android:locale'
+
+const MESSAGES = {
+  [APP_LOCALES.EN]: {
+    'app.name': 'MarkText for Android',
+
+    'home.documents.aria': 'Recent documents',
+    'home.open': 'Open',
+    'home.newDocument': 'New document',
+    'home.documentSections': 'Document sections',
+    'home.recent': 'Recent',
+    'home.continueWriting': 'Continue writing',
+    'home.earlier': 'Earlier',
+    'home.emptyTitle': 'No recent Markdown files',
+    'home.emptyBody': 'Start a local draft or open a Markdown file from this device.',
+
+    'nav.documents': 'Documents',
+    'nav.settings': 'Settings',
+
+    'settings.title': 'Settings',
+    'settings.display': 'Display',
+    'settings.editor': 'Editor',
+    'settings.files': 'Files',
+    'settings.more': 'More',
+    'settings.appearance': 'Appearance',
+    'settings.editing': 'Editing',
+    'settings.markdown': 'Markdown',
+    'settings.filesMedia': 'Files & Media',
+    'settings.advanced': 'Advanced',
+    'settings.about': 'About MarkText',
+    'settings.back': 'Back to settings',
+    'settings.entry.appearance': 'Theme, language, text',
+    'settings.entry.editing': 'Pairs, code, toolbar',
+    'settings.entry.markdown': 'Headings, lists, HTML',
+    'settings.entry.filesMedia': 'Drafts, images, sharing',
+    'settings.entry.advanced': 'Logs, reset, diagnostics',
+    'settings.entry.about': 'Version and links',
+
+    'settings.section.language': 'Language',
+    'settings.section.theme': 'Theme',
+    'settings.section.reading': 'Reading',
+    'settings.section.autoPair': 'Pairs',
+    'settings.section.codeBlocks': 'Code',
+    'settings.section.mobileToolbar': 'Toolbar',
+    'settings.section.style': 'Writing',
+    'settings.section.rendering': 'Rendering',
+    'settings.section.drafts': 'Drafts',
+    'settings.section.images': 'Images',
+    'settings.section.maintenance': 'Maintenance',
+    'settings.section.diagnostics': 'Diagnostics',
+
+    'settings.language.app': 'Language',
+    'settings.language.english': 'English',
+    'settings.language.chineseSimplified': '中文',
+
+    'settings.appearance.followSystemTheme': 'System theme',
+    'settings.appearance.appTheme': 'App theme',
+    'settings.appearance.editorTheme': 'Editor theme',
+    'settings.appearance.fontSize': 'Font',
+    'settings.appearance.lineHeight': 'Line height',
+
+    'settings.editing.autoPairBrackets': 'Brackets',
+    'settings.editing.autoPairMarkdown': 'Markdown marks',
+    'settings.editing.autoPairQuotes': 'Quotes',
+    'settings.editing.codeLineNumbers': 'Line numbers',
+    'settings.editing.wrapCodeBlocks': 'Wrap code',
+    'settings.editing.keyboardBehavior': 'Keyboard',
+
+    'settings.markdown.headingStyle': 'Headings',
+    'settings.markdown.bulletMarker': 'Bullets',
+    'settings.markdown.orderedDelimiter': 'Ordered lists',
+    'settings.markdown.listIndentation': 'Indent',
+    'settings.markdown.htmlRendering': 'HTML',
+    'settings.markdown.footnotes': 'Footnotes',
+    'settings.markdown.superSub': 'Super/subscript',
+
+    'settings.files.localDrafts': 'Local drafts',
+    'settings.files.recoveryDrafts': 'Recovery',
+    'settings.files.imageImport': 'Import images',
+    'settings.files.imageShare': 'Share images',
+    'settings.files.imageFolder': 'Image folder',
+
+    'settings.advanced.exportLogs': 'Export logs',
+    'settings.advanced.clearDrafts': 'Clear local drafts',
+    'settings.advanced.reset': 'Reset settings',
+    'settings.advanced.diagnostics': 'Device info',
+    'settings.advanced.markdownCompat': 'Compatibility',
+    'settings.advanced.diagrams': 'Diagrams',
+
+    'settings.value.on': 'On',
+    'settings.value.off': 'Off',
+    'settings.value.system': 'System',
+    'settings.value.default': 'Default',
+    'settings.value.medium': 'Medium',
+    'settings.value.normal': 'Normal',
+    'settings.value.dockAboveKeyboard': 'Docked',
+    'settings.value.atxHeading': 'ATX (#)',
+    'settings.value.hyphen': '-',
+    'settings.value.period': '.',
+    'settings.value.twoSpaces': '2 spaces',
+    'settings.value.keepRecentDrafts': 'Recent',
+    'settings.value.keepOnSaveFailure': 'On failure',
+    'settings.value.copyIntoAppStorage': 'Copy',
+    'settings.value.attachImportedImages': 'Attach',
+    'settings.value.androidPicker': 'Picker',
+    'settings.value.manual': 'Manual',
+    'settings.value.available': 'Ready',
+    'settings.value.advanced': 'Advanced',
+
+    'about.section.app': 'Info',
+    'about.section.project': 'Project',
+    'about.section.upstream': 'Upstream',
+    'about.section.support': 'Support',
+    'about.section.updates': 'Updates',
+    'about.section.legal': 'Legal',
+    'about.app': 'Name',
+    'about.version': 'Version',
+    'about.githubRepository': 'Repository',
+    'about.allReleases': 'Releases',
+    'about.githubReleases': 'GitHub',
+    'about.upstreamMarkText': 'MarkText',
+    'about.muyaAttribution': 'Muya',
+    'about.reportIssue': 'Report issue',
+    'about.githubIssues': 'GitHub issues',
+    'about.checkUpdates': 'Check updates',
+    'about.update.checking': 'Checking',
+    'about.update.available': 'Update available: v{version}',
+    'about.update.current': 'You are on the latest version',
+    'about.update.noReleases': 'No published releases yet',
+    'about.update.badRelease': 'Latest release did not include a version',
+    'about.update.unavailable': 'Could not reach GitHub releases',
+    'about.latestRelease': 'Latest release',
+    'about.licenseNotices': 'Notices',
+    'about.thirdPartyNotices': 'Licenses',
+  },
+  [APP_LOCALES.ZH_CN]: {
+    'app.name': 'MarkText Android',
+
+    'home.documents.aria': '最近文档',
+    'home.open': '打开',
+    'home.newDocument': '新建文档',
+    'home.documentSections': '文档分区',
+    'home.recent': '最近',
+    'home.continueWriting': '继续写作',
+    'home.earlier': '更早',
+    'home.emptyTitle': '没有最近的 Markdown 文件',
+    'home.emptyBody': '新建一个本地草稿，或从设备打开 Markdown 文件。',
+
+    'nav.documents': '文档',
+    'nav.settings': '设置',
+
+    'settings.title': '设置',
+    'settings.display': '显示',
+    'settings.editor': '编辑器',
+    'settings.files': '文件',
+    'settings.more': '更多',
+    'settings.appearance': '外观',
+    'settings.editing': '编辑',
+    'settings.markdown': 'Markdown',
+    'settings.filesMedia': '文件与媒体',
+    'settings.advanced': '高级',
+    'settings.about': '关于 MarkText',
+    'settings.back': '返回设置',
+    'settings.entry.appearance': '主题、语言、文字',
+    'settings.entry.editing': '配对、代码、工具栏',
+    'settings.entry.markdown': '标题、列表、HTML',
+    'settings.entry.filesMedia': '草稿、图片、分享',
+    'settings.entry.advanced': '日志、重置、诊断',
+    'settings.entry.about': '版本与链接',
+
+    'settings.section.language': '语言',
+    'settings.section.theme': '主题',
+    'settings.section.reading': '阅读',
+    'settings.section.autoPair': '配对',
+    'settings.section.codeBlocks': '代码',
+    'settings.section.mobileToolbar': '工具栏',
+    'settings.section.style': '书写',
+    'settings.section.rendering': '渲染',
+    'settings.section.drafts': '草稿',
+    'settings.section.images': '图片',
+    'settings.section.maintenance': '维护',
+    'settings.section.diagnostics': '诊断',
+
+    'settings.language.app': '语言',
+    'settings.language.english': 'English',
+    'settings.language.chineseSimplified': '中文',
+
+    'settings.appearance.followSystemTheme': '系统主题',
+    'settings.appearance.appTheme': '应用主题',
+    'settings.appearance.editorTheme': '编辑器主题',
+    'settings.appearance.fontSize': '字号',
+    'settings.appearance.lineHeight': '行高',
+
+    'settings.editing.autoPairBrackets': '括号',
+    'settings.editing.autoPairMarkdown': 'Markdown 标记',
+    'settings.editing.autoPairQuotes': '引号',
+    'settings.editing.codeLineNumbers': '行号',
+    'settings.editing.wrapCodeBlocks': '代码换行',
+    'settings.editing.keyboardBehavior': '键盘',
+
+    'settings.markdown.headingStyle': '标题',
+    'settings.markdown.bulletMarker': '无序列表',
+    'settings.markdown.orderedDelimiter': '有序列表',
+    'settings.markdown.listIndentation': '缩进',
+    'settings.markdown.htmlRendering': 'HTML',
+    'settings.markdown.footnotes': '脚注',
+    'settings.markdown.superSub': '上标/下标',
+
+    'settings.files.localDrafts': '本地草稿',
+    'settings.files.recoveryDrafts': '恢复',
+    'settings.files.imageImport': '导入图片',
+    'settings.files.imageShare': '分享图片',
+    'settings.files.imageFolder': '图片文件夹',
+
+    'settings.advanced.exportLogs': '导出日志',
+    'settings.advanced.clearDrafts': '清除本地草稿',
+    'settings.advanced.reset': '重置设置',
+    'settings.advanced.diagnostics': '设备信息',
+    'settings.advanced.markdownCompat': '兼容性',
+    'settings.advanced.diagrams': '图表',
+
+    'settings.value.on': '开',
+    'settings.value.off': '关',
+    'settings.value.system': '跟随系统',
+    'settings.value.default': '默认',
+    'settings.value.medium': '中',
+    'settings.value.normal': '标准',
+    'settings.value.dockAboveKeyboard': '停靠',
+    'settings.value.atxHeading': 'ATX (#)',
+    'settings.value.hyphen': '-',
+    'settings.value.period': '.',
+    'settings.value.twoSpaces': '2 空格',
+    'settings.value.keepRecentDrafts': '最近',
+    'settings.value.keepOnSaveFailure': '失败时',
+    'settings.value.copyIntoAppStorage': '复制',
+    'settings.value.attachImportedImages': '附带',
+    'settings.value.androidPicker': '选择器',
+    'settings.value.manual': '手动',
+    'settings.value.available': '就绪',
+    'settings.value.advanced': '高级',
+
+    'about.section.app': '信息',
+    'about.section.project': '项目',
+    'about.section.upstream': '上游',
+    'about.section.support': '支持',
+    'about.section.updates': '更新',
+    'about.section.legal': '法律',
+    'about.app': '名称',
+    'about.version': '版本',
+    'about.githubRepository': '仓库',
+    'about.allReleases': '版本',
+    'about.githubReleases': 'GitHub Releases',
+    'about.upstreamMarkText': 'MarkText',
+    'about.muyaAttribution': 'Muya',
+    'about.reportIssue': '报告问题',
+    'about.githubIssues': 'GitHub Issues',
+    'about.checkUpdates': '检查更新',
+    'about.update.checking': '检查中',
+    'about.update.available': '发现新版本：v{version}',
+    'about.update.current': '已是最新版本',
+    'about.update.noReleases': '暂无发布版本',
+    'about.update.badRelease': '最新发布未包含版本号',
+    'about.update.unavailable': '无法连接 GitHub Releases',
+    'about.latestRelease': '最新版本',
+    'about.licenseNotices': '声明',
+    'about.thirdPartyNotices': '许可证',
+  },
+} as const
+
+export type I18nKey = keyof (typeof MESSAGES)[typeof APP_LOCALES.EN]
+
+export const APP_LANGUAGE_OPTIONS = [
+  {
+    id: APP_LOCALES.EN,
+    labelKey: 'settings.language.english',
+    testId: 'settings-language-option-en',
+  },
+  {
+    id: APP_LOCALES.ZH_CN,
+    labelKey: 'settings.language.chineseSimplified',
+    testId: 'settings-language-option-zh-cn',
+  },
+] as const satisfies readonly {
+  id: AppLocale
+  labelKey: I18nKey
+  testId: string
+}[]
+
+function isAppLocale(value: unknown): value is AppLocale {
+  return Object.values(APP_LOCALES).includes(value as AppLocale)
+}
+
+function getStoredLocale() {
+  if (typeof window === 'undefined') {
+    return DEFAULT_APP_LOCALE
+  }
+
+  try {
+    const storedLocale = window.localStorage.getItem(APP_LOCALE_STORAGE_KEY)
+    return isAppLocale(storedLocale) ? storedLocale : DEFAULT_APP_LOCALE
+  } catch {
+    return DEFAULT_APP_LOCALE
+  }
+}
+
+function writeStoredLocale(nextLocale: AppLocale) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(APP_LOCALE_STORAGE_KEY, nextLocale)
+  } catch {
+    // Changing language should still work for the current session if storage is unavailable.
+  }
+}
+
+function applyDocumentLocale(nextLocale: AppLocale) {
+  if (typeof document !== 'undefined') {
+    document.documentElement.lang = nextLocale
+  }
+}
+
+function interpolate(message: string, params: Record<string, string | number> = {}) {
+  return message.replace(/\{(\w+)\}/g, (match, key) =>
+    Object.prototype.hasOwnProperty.call(params, key) ? String(params[key]) : match,
+  )
+}
+
+const appLocale = ref<AppLocale>(getStoredLocale())
+applyDocumentLocale(appLocale.value)
+
+export function setAppLocale(nextLocale: AppLocale) {
+  appLocale.value = nextLocale
+  writeStoredLocale(nextLocale)
+  applyDocumentLocale(nextLocale)
+}
+
+export function t(key: I18nKey, params?: Record<string, string | number>) {
+  const message = MESSAGES[appLocale.value][key] ?? MESSAGES[DEFAULT_APP_LOCALE][key]
+  return interpolate(message, params)
+}
+
+export function useI18n() {
+  return {
+    locale: readonly(appLocale),
+    setLocale: setAppLocale,
+    t,
+  }
+}

--- a/src/lib/settingsContent.ts
+++ b/src/lib/settingsContent.ts
@@ -1,0 +1,236 @@
+import type { I18nKey } from './i18n'
+import { SETTINGS_PAGES, type SettingsPage } from './settingsNavigation'
+
+export interface SettingsDetailRow {
+  labelKey: I18nKey
+  valueKey: I18nKey
+  testId: string
+}
+
+export interface SettingsDetailSection {
+  titleKey: I18nKey
+  rows: readonly SettingsDetailRow[]
+}
+
+export const SETTINGS_PAGE_TITLE_KEYS = {
+  [SETTINGS_PAGES.INDEX]: 'settings.title',
+  [SETTINGS_PAGES.APPEARANCE]: 'settings.appearance',
+  [SETTINGS_PAGES.EDITING]: 'settings.editing',
+  [SETTINGS_PAGES.MARKDOWN]: 'settings.markdown',
+  [SETTINGS_PAGES.FILES_MEDIA]: 'settings.filesMedia',
+  [SETTINGS_PAGES.ADVANCED]: 'settings.advanced',
+  [SETTINGS_PAGES.ABOUT]: 'settings.about',
+} as const satisfies Record<SettingsPage, I18nKey>
+
+export const SETTINGS_DETAIL_SECTIONS: Partial<Record<SettingsPage, readonly SettingsDetailSection[]>> = {
+  [SETTINGS_PAGES.APPEARANCE]: [
+    {
+      titleKey: 'settings.section.theme',
+      rows: [
+        {
+          labelKey: 'settings.appearance.followSystemTheme',
+          valueKey: 'settings.value.on',
+          testId: 'settings-appearance-system-theme',
+        },
+        {
+          labelKey: 'settings.appearance.appTheme',
+          valueKey: 'settings.value.system',
+          testId: 'settings-appearance-app-theme',
+        },
+        {
+          labelKey: 'settings.appearance.editorTheme',
+          valueKey: 'settings.value.default',
+          testId: 'settings-appearance-editor-theme',
+        },
+      ],
+    },
+    {
+      titleKey: 'settings.section.reading',
+      rows: [
+        {
+          labelKey: 'settings.appearance.fontSize',
+          valueKey: 'settings.value.medium',
+          testId: 'settings-appearance-font-size',
+        },
+        {
+          labelKey: 'settings.appearance.lineHeight',
+          valueKey: 'settings.value.normal',
+          testId: 'settings-appearance-line-height',
+        },
+      ],
+    },
+  ],
+  [SETTINGS_PAGES.EDITING]: [
+    {
+      titleKey: 'settings.section.autoPair',
+      rows: [
+        {
+          labelKey: 'settings.editing.autoPairBrackets',
+          valueKey: 'settings.value.on',
+          testId: 'settings-editing-brackets',
+        },
+        {
+          labelKey: 'settings.editing.autoPairMarkdown',
+          valueKey: 'settings.value.on',
+          testId: 'settings-editing-markdown-syntax',
+        },
+        {
+          labelKey: 'settings.editing.autoPairQuotes',
+          valueKey: 'settings.value.on',
+          testId: 'settings-editing-quotes',
+        },
+      ],
+    },
+    {
+      titleKey: 'settings.section.codeBlocks',
+      rows: [
+        {
+          labelKey: 'settings.editing.codeLineNumbers',
+          valueKey: 'settings.value.off',
+          testId: 'settings-editing-code-lines',
+        },
+        {
+          labelKey: 'settings.editing.wrapCodeBlocks',
+          valueKey: 'settings.value.on',
+          testId: 'settings-editing-code-wrap',
+        },
+      ],
+    },
+    {
+      titleKey: 'settings.section.mobileToolbar',
+      rows: [
+        {
+          labelKey: 'settings.editing.keyboardBehavior',
+          valueKey: 'settings.value.dockAboveKeyboard',
+          testId: 'settings-editing-toolbar-keyboard',
+        },
+      ],
+    },
+  ],
+  [SETTINGS_PAGES.MARKDOWN]: [
+    {
+      titleKey: 'settings.section.style',
+      rows: [
+        {
+          labelKey: 'settings.markdown.headingStyle',
+          valueKey: 'settings.value.atxHeading',
+          testId: 'settings-markdown-heading-style',
+        },
+        {
+          labelKey: 'settings.markdown.bulletMarker',
+          valueKey: 'settings.value.hyphen',
+          testId: 'settings-markdown-bullet-marker',
+        },
+        {
+          labelKey: 'settings.markdown.orderedDelimiter',
+          valueKey: 'settings.value.period',
+          testId: 'settings-markdown-ordered-delimiter',
+        },
+        {
+          labelKey: 'settings.markdown.listIndentation',
+          valueKey: 'settings.value.twoSpaces',
+          testId: 'settings-markdown-list-indentation',
+        },
+      ],
+    },
+    {
+      titleKey: 'settings.section.rendering',
+      rows: [
+        {
+          labelKey: 'settings.markdown.htmlRendering',
+          valueKey: 'settings.value.on',
+          testId: 'settings-markdown-html-rendering',
+        },
+        {
+          labelKey: 'settings.markdown.footnotes',
+          valueKey: 'settings.value.on',
+          testId: 'settings-markdown-footnotes',
+        },
+        {
+          labelKey: 'settings.markdown.superSub',
+          valueKey: 'settings.value.on',
+          testId: 'settings-markdown-super-sub',
+        },
+      ],
+    },
+  ],
+  [SETTINGS_PAGES.FILES_MEDIA]: [
+    {
+      titleKey: 'settings.section.drafts',
+      rows: [
+        {
+          labelKey: 'settings.files.localDrafts',
+          valueKey: 'settings.value.keepRecentDrafts',
+          testId: 'settings-files-local-drafts',
+        },
+        {
+          labelKey: 'settings.files.recoveryDrafts',
+          valueKey: 'settings.value.keepOnSaveFailure',
+          testId: 'settings-files-recovery-drafts',
+        },
+      ],
+    },
+    {
+      titleKey: 'settings.section.images',
+      rows: [
+        {
+          labelKey: 'settings.files.imageImport',
+          valueKey: 'settings.value.copyIntoAppStorage',
+          testId: 'settings-files-image-import',
+        },
+        {
+          labelKey: 'settings.files.imageShare',
+          valueKey: 'settings.value.attachImportedImages',
+          testId: 'settings-files-image-share',
+        },
+        {
+          labelKey: 'settings.files.imageFolder',
+          valueKey: 'settings.value.androidPicker',
+          testId: 'settings-files-image-folder',
+        },
+      ],
+    },
+  ],
+  [SETTINGS_PAGES.ADVANCED]: [
+    {
+      titleKey: 'settings.section.maintenance',
+      rows: [
+        {
+          labelKey: 'settings.advanced.exportLogs',
+          valueKey: 'settings.value.manual',
+          testId: 'settings-advanced-export-logs',
+        },
+        {
+          labelKey: 'settings.advanced.clearDrafts',
+          valueKey: 'settings.value.manual',
+          testId: 'settings-advanced-clear-drafts',
+        },
+        {
+          labelKey: 'settings.advanced.reset',
+          valueKey: 'settings.value.manual',
+          testId: 'settings-advanced-reset',
+        },
+      ],
+    },
+    {
+      titleKey: 'settings.section.diagnostics',
+      rows: [
+        {
+          labelKey: 'settings.advanced.diagnostics',
+          valueKey: 'settings.value.available',
+          testId: 'settings-advanced-diagnostics',
+        },
+        {
+          labelKey: 'settings.advanced.markdownCompat',
+          valueKey: 'settings.value.advanced',
+          testId: 'settings-advanced-markdown-compat',
+        },
+        {
+          labelKey: 'settings.advanced.diagrams',
+          valueKey: 'settings.value.advanced',
+          testId: 'settings-advanced-diagrams',
+        },
+      ],
+    },
+  ],
+} as const

--- a/src/lib/settingsNavigation.ts
+++ b/src/lib/settingsNavigation.ts
@@ -1,31 +1,88 @@
+import type { I18nKey } from './i18n'
+
 export const SETTINGS_PAGES = Object.freeze({
   INDEX: 'index',
+  APPEARANCE: 'appearance',
+  EDITING: 'editing',
+  MARKDOWN: 'markdown',
+  FILES_MEDIA: 'files-media',
+  ADVANCED: 'advanced',
   ABOUT: 'about',
-  REFERENCES: 'references',
 } as const)
 
 export type SettingsPage = (typeof SETTINGS_PAGES)[keyof typeof SETTINGS_PAGES]
 
 export interface SettingsHomeItem {
   id: Exclude<SettingsPage, typeof SETTINGS_PAGES.INDEX>
-  label: string
-  value: string
+  labelKey: I18nKey
+  valueKey: I18nKey
   testId: string
 }
 
-export const SETTINGS_HOME_ITEMS = [
+export interface SettingsHomeSection {
+  titleKey: I18nKey
+  items: readonly SettingsHomeItem[]
+}
+
+export const SETTINGS_HOME_SECTIONS = [
   {
-    id: SETTINGS_PAGES.ABOUT,
-    label: 'About MarkText',
-    value: 'Version and updates',
-    testId: 'settings-entry-about',
+    titleKey: 'settings.display',
+    items: [
+      {
+        id: SETTINGS_PAGES.APPEARANCE,
+        labelKey: 'settings.appearance',
+        valueKey: 'settings.entry.appearance',
+        testId: 'settings-entry-appearance',
+      },
+    ],
   },
   {
-    id: SETTINGS_PAGES.REFERENCES,
-    label: 'References',
-    value: 'Repository and upstream',
-    testId: 'settings-entry-references',
+    titleKey: 'settings.editor',
+    items: [
+      {
+        id: SETTINGS_PAGES.EDITING,
+        labelKey: 'settings.editing',
+        valueKey: 'settings.entry.editing',
+        testId: 'settings-entry-editing',
+      },
+      {
+        id: SETTINGS_PAGES.MARKDOWN,
+        labelKey: 'settings.markdown',
+        valueKey: 'settings.entry.markdown',
+        testId: 'settings-entry-markdown',
+      },
+    ],
   },
-] as const satisfies readonly SettingsHomeItem[]
+  {
+    titleKey: 'settings.files',
+    items: [
+      {
+        id: SETTINGS_PAGES.FILES_MEDIA,
+        labelKey: 'settings.filesMedia',
+        valueKey: 'settings.entry.filesMedia',
+        testId: 'settings-entry-files-media',
+      },
+    ],
+  },
+  {
+    titleKey: 'settings.more',
+    items: [
+      {
+        id: SETTINGS_PAGES.ADVANCED,
+        labelKey: 'settings.advanced',
+        valueKey: 'settings.entry.advanced',
+        testId: 'settings-entry-advanced',
+      },
+      {
+        id: SETTINGS_PAGES.ABOUT,
+        labelKey: 'settings.about',
+        valueKey: 'settings.entry.about',
+        testId: 'settings-entry-about',
+      },
+    ],
+  },
+] as const satisfies readonly SettingsHomeSection[]
+
+export const SETTINGS_HOME_ITEMS = SETTINGS_HOME_SECTIONS.flatMap(section => [...section.items])
 
 export const DEFAULT_SETTINGS_PAGE: SettingsPage = SETTINGS_PAGES.INDEX

--- a/tests/e2e/mobile-home-navigation.spec.ts
+++ b/tests/e2e/mobile-home-navigation.spec.ts
@@ -108,11 +108,78 @@ test('switches between document home and the settings about screen', async ({ pa
   await expect(page.getByTestId('settings-index')).toBeVisible()
   await expect(page.getByTestId('new-document-button')).toBeHidden()
   await expect(page.getByTestId('bottom-nav-settings')).toHaveAttribute('aria-current', 'page')
+  await expect(page.getByTestId('settings-entry-appearance')).toBeVisible()
+  await expect(page.getByTestId('settings-entry-editing')).toBeVisible()
+  await expect(page.getByTestId('settings-entry-markdown')).toBeVisible()
+  await expect(page.getByTestId('settings-entry-files-media')).toBeVisible()
+  await expect(page.getByTestId('settings-entry-advanced')).toBeVisible()
+
+  await page.getByTestId('settings-entry-appearance').click()
+  await expect(page.getByTestId('settings-title')).toContainText('Appearance')
+  await expect(page.getByTestId('settings-language-app')).toContainText('English')
+  await expect(page.getByTestId('settings-appearance-system-theme')).toContainText('On')
+  await expect(page.getByTestId('settings-appearance-font-size')).toContainText('Medium')
+
+  await page.getByTestId('settings-language-option-zh-cn').click()
+  await expect(page.getByTestId('settings-title')).toContainText('外观')
+  await expect(page.getByTestId('settings-language-app')).toContainText('中文')
+  await expect(page.getByTestId('settings-appearance-system-theme')).toContainText('开')
+
+  await page.getByTestId('settings-language-option-en').click()
+  await expect(page.getByTestId('settings-title')).toContainText('Appearance')
+
+  await page.getByTestId('settings-detail-back').click()
+  await expect(page.getByTestId('settings-index')).toBeVisible()
+
+  await page.getByTestId('settings-entry-editing').click()
+  await expect(page.getByTestId('settings-title')).toContainText('Editing')
+  await expect(page.getByTestId('settings-editing-toolbar-keyboard')).toContainText('Docked')
+
+  await page.getByTestId('settings-detail-back').click()
+  await expect(page.getByTestId('settings-index')).toBeVisible()
+
+  await page.getByTestId('settings-entry-markdown').click()
+  await expect(page.getByTestId('settings-title')).toContainText('Markdown')
+  await expect(page.getByTestId('settings-markdown-heading-style')).toContainText('ATX (#)')
+
+  await page.getByTestId('settings-detail-back').click()
+  await expect(page.getByTestId('settings-index')).toBeVisible()
+
+  await page.getByTestId('settings-entry-files-media').click()
+  await expect(page.getByTestId('settings-title')).toContainText('Files & Media')
+  await expect(page.getByTestId('settings-files-image-folder')).toContainText('Picker')
+
+  await page.getByTestId('settings-detail-back').click()
+  await expect(page.getByTestId('settings-index')).toBeVisible()
+
+  await page.getByTestId('settings-entry-advanced').click()
+  await expect(page.getByTestId('settings-title')).toContainText('Advanced')
+  await expect(page.getByTestId('settings-advanced-diagrams')).toContainText('Advanced')
+
+  await page.getByTestId('settings-detail-back').click()
+  await expect(page.getByTestId('settings-index')).toBeVisible()
 
   await page.getByTestId('settings-entry-about').click()
   await expect(page.getByTestId('settings-title')).toContainText('About MarkText')
   await expect(page.getByTestId('settings-about-app')).toBeVisible()
   await expect(page.getByTestId('settings-about-version')).toBeVisible()
+  await expect(page.getByTestId('settings-reference-repository')).toHaveAttribute(
+    'href',
+    'https://github.com/Renakoni/marktext-android',
+  )
+  await expect(page.getByTestId('settings-reference-issues')).toHaveAttribute(
+    'href',
+    'https://github.com/Renakoni/marktext-android/issues',
+  )
+  await expect(page.getByTestId('settings-reference-upstream-marktext')).toHaveAttribute(
+    'href',
+    'https://github.com/marktext/marktext',
+  )
+  await expect(page.getByTestId('settings-reference-muya')).toHaveAttribute(
+    'href',
+    'https://github.com/marktext/muya',
+  )
+  await expect(page.getByTestId('settings-about-notices')).toContainText('Licenses')
 
   await page.getByTestId('settings-check-updates').click()
   await expect(page.getByTestId('settings-check-updates')).toContainText(
@@ -125,17 +192,6 @@ test('switches between document home and the settings about screen', async ({ pa
 
   await page.getByTestId('settings-detail-back').click()
   await expect(page.getByTestId('settings-index')).toBeVisible()
-
-  await page.getByTestId('settings-entry-references').click()
-  await expect(page.getByTestId('settings-title')).toContainText('References')
-  await expect(page.getByTestId('settings-reference-repository')).toHaveAttribute(
-    'href',
-    'https://github.com/Renakoni/marktext-android',
-  )
-  await expect(page.getByTestId('settings-reference-issues')).toHaveAttribute(
-    'href',
-    'https://github.com/Renakoni/marktext-android/issues',
-  )
 
   await page.getByTestId('bottom-nav-documents').click()
 


### PR DESCRIPTION
## Summary
- expands the Settings index into mobile-friendly groups: Display, Editor, Files, More
- adds static detail pages for Appearance, Editing, Markdown, Files & Media, and Advanced
- folds repository, upstream, support, updates, and notices into About MarkText
- adds a lightweight English / Chinese language setting under Appearance, persisted locally
- keeps Settings content data-driven through small config modules and focused components
- tightens settings copy so labels stay short and mobile-native

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm exec playwright test tests/e2e/mobile-home-navigation.spec.ts --project=mobile-chromium
- pnpm test:e2e
- pnpm android:sync
- .\android\gradlew.bat -p android assembleDebug
- adb install -r android\app\build\outputs\apk\debug\app-debug.apk
- MCP/ADB visual smoke on emulator-5554 for Settings index, Appearance, and English/Chinese switching

## Notes
- This PR is still mostly front-end settings structure. Most settings are placeholders and are not wired to editor behavior yet.
- Spellcheck stays out for now until Android WebView / Muya capability is confirmed.