### PR TITLE
Polish mobile home, settings, and editor action sheet

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1416,6 +1416,14 @@ function toggleEditorMenu() {
   }
 }
 
+function closeEditorMenu() {
+  editorMenuOpen.value = false
+}
+
+function openEditorSearch() {
+  appLog.info('editor search requested')
+}
+
 function toggleEditorToolbar() {
   editorToolbarExpanded.value = !editorToolbarExpanded.value
   if (editorToolbarExpanded.value) {
@@ -1766,55 +1774,49 @@ onBeforeUnmount(() => {
 
   <main v-else class="app-shell">
     <header class="top-bar">
-      <button class="nav-button" type="button" data-testid="back-button" @click="showHome">Back</button>
+      <button
+        class="nav-button"
+        type="button"
+        aria-label="Back"
+        data-testid="back-button"
+        @click="showHome"
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M15 6l-6 6 6 6" />
+        </svg>
+      </button>
       <div class="document-heading">
-        <span>MarkText Android</span>
         <h1>{{ documentTitle }}</h1>
         <p>{{ status }}</p>
       </div>
-      <div v-if="canShowEditorActions()" class="editor-actions">
+      <div v-if="editorReady" class="editor-actions">
         <button
-          class="menu-button"
+          class="icon-button"
+          type="button"
+          aria-label="Search"
+          title="Search"
+          @click="openEditorSearch"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="11" cy="11" r="6" />
+            <path d="M16 16l4.5 4.5" />
+          </svg>
+        </button>
+        <button
+          v-if="canShowEditorActions()"
+          class="icon-button"
           type="button"
           aria-label="More actions"
           :aria-expanded="editorMenuOpen"
           data-testid="editor-menu-button"
           @click="toggleEditorMenu"
         >
-          ...
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="5" r="1.6" />
+            <circle cx="12" cy="12" r="1.6" />
+            <circle cx="12" cy="19" r="1.6" />
+          </svg>
         </button>
-        <div v-if="editorMenuOpen" class="editor-menu" role="menu">
-          <button
-            v-if="canShareCurrentDocument()"
-            type="button"
-            role="menuitem"
-            data-testid="share-document-button"
-            :disabled="sharingCurrentDocument || !editorReady"
-            @click="shareCurrentMarkdownDocument"
-          >
-            Share
-          </button>
-          <button
-            v-if="canSaveLocalDraftToAndroidDocument()"
-            type="button"
-            role="menuitem"
-            data-testid="save-to-device-button"
-            :disabled="savingLocalDraftToAndroid"
-            @click="() => saveLocalDraftToAndroidDocument()"
-          >
-            Save to device
-          </button>
-          <button
-            v-if="canSaveAndroidDocumentCopy()"
-            type="button"
-            role="menuitem"
-            data-testid="save-copy-button"
-            :disabled="savingAndroidDocumentCopy"
-            @click="() => saveAndroidDocumentCopy()"
-          >
-            Save a copy
-          </button>
-        </div>
       </div>
     </header>
 
@@ -1839,6 +1841,83 @@ onBeforeUnmount(() => {
       @toggle-expanded="toggleEditorToolbar"
       @set-panel="setEditorToolbarPanel"
     />
+
+    <Transition name="editor-sheet">
+      <section
+        v-if="editorMenuOpen"
+        class="editor-action-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Document actions"
+        data-testid="editor-action-sheet"
+        @click="closeEditorMenu"
+        @keydown.esc="closeEditorMenu"
+      >
+        <div class="editor-action-panel" @click.stop>
+          <div class="editor-action-grabber" aria-hidden="true" />
+          <h2 class="editor-action-title">Document</h2>
+          <div class="editor-action-list" role="menu">
+            <button
+              v-if="canShareCurrentDocument()"
+              class="editor-action-row"
+              type="button"
+              role="menuitem"
+              data-testid="share-document-button"
+              :disabled="sharingCurrentDocument"
+              @click="shareCurrentMarkdownDocument"
+            >
+              <span class="editor-action-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <circle cx="6" cy="12" r="2.4" fill="currentColor" stroke="none" />
+                  <circle cx="18" cy="6" r="2.4" fill="currentColor" stroke="none" />
+                  <circle cx="18" cy="18" r="2.4" fill="currentColor" stroke="none" />
+                  <path d="M8.1 10.9l7.8-3.6M8.1 13.1l7.8 3.6" />
+                </svg>
+              </span>
+              <span class="editor-action-label">Share</span>
+            </button>
+            <button
+              v-if="canSaveLocalDraftToAndroidDocument()"
+              class="editor-action-row"
+              type="button"
+              role="menuitem"
+              data-testid="save-to-device-button"
+              :disabled="savingLocalDraftToAndroid"
+              @click="() => saveLocalDraftToAndroidDocument()"
+            >
+              <span class="editor-action-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path d="M6 4h9l3 3v13H6z" />
+                  <path d="M9 4v5h6" />
+                  <rect x="9" y="14" width="6" height="5" rx="0.6" />
+                </svg>
+              </span>
+              <span class="editor-action-label">Save to device</span>
+            </button>
+            <button
+              v-if="canSaveAndroidDocumentCopy()"
+              class="editor-action-row"
+              type="button"
+              role="menuitem"
+              data-testid="save-copy-button"
+              :disabled="savingAndroidDocumentCopy"
+              @click="() => saveAndroidDocumentCopy()"
+            >
+              <span class="editor-action-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path d="M6 4h9l3 3v13H6z" />
+                  <path d="M9 4v5h6" />
+                  <rect x="9" y="14" width="6" height="5" rx="0.6" />
+                  <circle cx="18" cy="17.5" r="3.4" fill="var(--surface)" stroke="none" />
+                  <path d="M18 15.6v3.8M16.1 17.5h3.8" />
+                </svg>
+              </span>
+              <span class="editor-action-label">Save a copy</span>
+            </button>
+          </div>
+        </div>
+      </section>
+    </Transition>
 
     <section
       v-if="linkSheetOpen"

--- a/src/components/AppBottomNavigation.vue
+++ b/src/components/AppBottomNavigation.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import AppBottomNavigationIcon from './AppBottomNavigationIcon.vue'
 import { HOME_TAB_ITEMS, type HomeTab } from '../lib/homeNavigation'
 import { useI18n } from '../lib/i18n'
 
-defineProps<{
+const props = defineProps<{
   activeTab: HomeTab
 }>()
 
@@ -14,6 +15,12 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const tabs = HOME_TAB_ITEMS
 
+const activeIndex = computed(() =>
+  Math.max(0, tabs.findIndex(tab => tab.id === props.activeTab)),
+)
+
+const indicatorTransform = computed(() => `translateX(${activeIndex.value * 100}%)`)
+
 function selectTab(tab: HomeTab) {
   emit('setTab', tab)
 }
@@ -21,58 +28,114 @@ function selectTab(tab: HomeTab) {
 
 <template>
   <nav class="app-bottom-navigation" aria-label="Primary" data-testid="app-bottom-navigation">
-    <button
-      v-for="tab in tabs"
-      :key="tab.id"
-      class="bottom-nav-button"
-      :class="{ 'is-active': activeTab === tab.id }"
-      type="button"
-      :aria-label="t(tab.labelKey)"
-      :aria-current="activeTab === tab.id ? 'page' : undefined"
-      :data-testid="`bottom-nav-${tab.id}`"
-      @click="selectTab(tab.id)"
-    >
-      <AppBottomNavigationIcon :name="tab.icon" />
-    </button>
+    <div class="bottom-nav-track">
+      <span class="bottom-nav-indicator" :style="{ transform: indicatorTransform }" aria-hidden="true" />
+      <button
+        v-for="tab in tabs"
+        :key="tab.id"
+        class="bottom-nav-button"
+        :class="{ 'is-active': activeTab === tab.id }"
+        type="button"
+        :aria-label="t(tab.labelKey)"
+        :aria-current="activeTab === tab.id ? 'page' : undefined"
+        :data-testid="`bottom-nav-${tab.id}`"
+        @click="selectTab(tab.id)"
+      >
+        <span class="bottom-nav-icon" aria-hidden="true">
+          <AppBottomNavigationIcon :name="tab.icon" />
+        </span>
+        <span class="bottom-nav-label">{{ t(tab.labelKey) }}</span>
+      </button>
+    </div>
   </nav>
 </template>
 
 <style scoped>
 .app-bottom-navigation {
+  padding: 8px 12px calc(env(safe-area-inset-bottom, 0px) + 8px);
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.bottom-nav-track {
+  position: relative;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 10px;
-  padding: 8px 20px calc(env(safe-area-inset-bottom, 0px) + 8px);
-  border-top: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface-muted) 82%, var(--surface) 18%);
+  gap: 0;
+  border-radius: 999px;
+}
+
+.bottom-nav-indicator {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 0;
+  width: 50%;
+  pointer-events: none;
+  transition: transform 340ms var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
+  will-change: transform;
+}
+
+.bottom-nav-indicator::before {
+  position: absolute;
+  inset: 0 6px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  content: '';
 }
 
 .bottom-nav-button {
   display: grid;
-  place-items: center;
+  grid-template-columns: auto auto;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
   min-width: 0;
-  min-height: 48px;
+  min-height: 44px;
+  padding: 0 8px;
   border: 0;
-  border-radius: 8px;
+  border-radius: 999px;
   background: transparent;
-  color: var(--text-muted);
+  color: var(--text-faint);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.006em;
   touch-action: manipulation;
+  position: relative;
+  z-index: 1;
+  transition: color 200ms var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
 }
 
 .bottom-nav-button.is-active {
-  background: var(--surface);
   color: var(--accent-strong);
-  box-shadow: inset 0 0 0 1px var(--border);
 }
 
 .bottom-nav-button:active {
-  transform: translateY(1px);
+  color: var(--text-muted);
+}
+
+.bottom-nav-icon {
+  display: inline-grid;
+  place-items: center;
+  height: 22px;
+}
+
+.bottom-nav-label {
+  line-height: 1;
+  white-space: nowrap;
 }
 
 @media (min-width: 720px) {
   .app-bottom-navigation {
-    padding-right: max(24px, calc((100vw - 760px) / 2));
-    padding-left: max(24px, calc((100vw - 760px) / 2));
+    padding-right: max(24px, calc((100vw - 720px) / 2));
+    padding-left: max(24px, calc((100vw - 720px) / 2));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bottom-nav-indicator {
+    transition: none;
   }
 }
 </style>

--- a/src/components/AppBottomNavigationIcon.vue
+++ b/src/components/AppBottomNavigationIcon.vue
@@ -35,12 +35,12 @@ defineProps<{
 
 <style scoped>
 .bottom-nav-icon {
-  width: 25px;
-  height: 25px;
+  width: 23px;
+  height: 23px;
   fill: none;
   stroke: currentColor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 1.9;
+  stroke-width: 1.8;
 }
 </style>

--- a/src/components/DocumentHome.vue
+++ b/src/components/DocumentHome.vue
@@ -32,6 +32,11 @@ const { t } = useI18n()
           data-testid="open-file-button"
           @click="$emit('openFile')"
         >
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M4 6h12M4 12h12M4 18h8" />
+            <path d="M16 14l4 4-4 4" />
+            <path d="M20 18h-6" />
+          </svg>
           {{ t('home.open') }}
         </button>
         <button
@@ -42,44 +47,73 @@ const { t } = useI18n()
           :title="t('home.newDocument')"
           @click="$emit('newDocument')"
         >
-          +
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M12 5v14M5 12h14" />
+          </svg>
         </button>
       </div>
     </header>
 
     <p v-if="notice" class="home-notice" role="status">{{ notice }}</p>
 
-    <nav class="home-tabs" :aria-label="t('home.documentSections')">
-      <button class="home-tab is-active" type="button">{{ t('home.recent') }}</button>
-    </nav>
-
     <div class="home-content">
       <section v-if="continueDocument" class="document-group" aria-labelledby="continue-title">
-        <h2 id="continue-title">{{ t('home.continueWriting') }}</h2>
-        <button class="document-row" type="button" @click="$emit('openDocument', continueDocument.id)">
-          <span class="document-icon" aria-hidden="true">M</span>
-          <span class="document-text">
-            <strong>{{ continueDocument.title }}</strong>
-            <span>{{ continueDocument.details }}</span>
+        <h2 id="continue-title" class="home-section-label">{{ t('home.continueWriting') }}</h2>
+        <button
+          class="continue-card"
+          type="button"
+          @click="$emit('openDocument', continueDocument.id)"
+        >
+          <span class="continue-card-head">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M7 4h7l4 4v12H7z" />
+              <path d="M14 4v5h5" />
+              <path d="M9.5 14h5" />
+            </svg>
+            {{ t('home.continueWriting') }}
+          </span>
+          <span>
+            <span class="continue-card-title">{{ continueDocument.title }}</span>
+            <span class="continue-card-meta">{{ continueDocument.details }}</span>
+          </span>
+          <span class="continue-card-cta">
+            {{ t('home.continueAction') }}
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M9 6l6 6-6 6" />
+            </svg>
           </span>
         </button>
       </section>
 
       <section v-if="earlierDocuments.length > 0" class="document-group" aria-labelledby="earlier-title">
-        <h2 id="earlier-title">{{ t('home.earlier') }}</h2>
-        <button
-          v-for="document in earlierDocuments"
-          :key="document.id"
-          class="document-row"
-          type="button"
-          @click="$emit('openDocument', document.id)"
-        >
-          <span class="document-icon" aria-hidden="true">M</span>
-          <span class="document-text">
-            <strong>{{ document.title }}</strong>
-            <span>{{ document.details }}</span>
-          </span>
-        </button>
+        <h2 id="earlier-title" class="home-section-label">{{ t('home.earlier') }}</h2>
+        <div class="document-list">
+          <button
+            v-for="document in earlierDocuments"
+            :key="document.id"
+            class="document-row"
+            type="button"
+            @click="$emit('openDocument', document.id)"
+          >
+            <span class="document-glyph" aria-hidden="true">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M7 3h7l4 4v14H7z" />
+                <path d="M14 3v5h5" />
+                <path d="M9.5 12h5" />
+                <path d="M9.5 16h5" />
+              </svg>
+            </span>
+            <span class="document-text">
+              <strong>{{ document.title }}</strong>
+              <span>{{ document.details }}</span>
+            </span>
+            <span class="document-chevron" aria-hidden="true">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M9 6l6 6-6 6" />
+              </svg>
+            </span>
+          </button>
+        </div>
       </section>
 
       <section
@@ -88,6 +122,13 @@ const { t } = useI18n()
         aria-labelledby="recent-title"
       >
         <div class="empty-recent">
+          <span class="empty-mark" aria-hidden="true">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M7 3h7l4 4v14H7z" />
+              <path d="M14 3v5h5" />
+              <path d="M9.5 13h5" />
+            </svg>
+          </span>
           <h2 id="recent-title">{{ t('home.emptyTitle') }}</h2>
           <p>{{ t('home.emptyBody') }}</p>
         </div>

--- a/src/components/HomeShell.vue
+++ b/src/components/HomeShell.vue
@@ -62,6 +62,7 @@ watch(
 .home-main {
   min-height: 0;
   overflow: auto;
+  background: var(--app-bg);
   -webkit-overflow-scrolling: touch;
 }
 </style>

--- a/src/components/SettingsHome.vue
+++ b/src/components/SettingsHome.vue
@@ -32,7 +32,11 @@ const { t } = useI18n()
         :aria-label="t('settings.back')"
         data-testid="settings-detail-back"
         @click="emit('setPage', SETTINGS_PAGES.INDEX)"
-      />
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M15 6l-6 6 6 6" />
+        </svg>
+      </button>
       <h1 data-testid="settings-title">{{ t(SETTINGS_PAGE_TITLE_KEYS[activePage]) }}</h1>
     </header>
     <div class="settings-content">
@@ -65,70 +69,68 @@ const { t } = useI18n()
 <style scoped>
 .settings-screen {
   min-height: 100%;
-  padding: calc(env(safe-area-inset-top, 0px) + 18px) 0 28px;
-  background: var(--surface);
+  padding: calc(env(safe-area-inset-top, 0px) + 26px) 0 40px;
+  background: var(--app-bg);
 }
 
 .settings-top {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  display: flex;
   align-items: center;
-  max-width: 760px;
+  gap: 10px;
+  max-width: 720px;
   margin: 0 auto;
   padding: 0 20px;
 }
 
-.settings-top.is-detail {
-  grid-template-columns: 44px minmax(0, 1fr) 44px;
-}
-
 .settings-back-button {
-  position: relative;
-  width: 44px;
-  height: 44px;
-  margin-left: -10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 36px;
+  padding: 0 10px 0 6px;
+  margin-left: -6px;
   border: 0;
+  border-radius: 999px;
   background: transparent;
-  color: var(--text);
+  color: var(--accent-strong);
+  font: inherit;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.006em;
 }
 
-.settings-back-button::before {
-  position: absolute;
-  top: 50%;
-  left: 16px;
-  width: 13px;
-  height: 13px;
-  border-bottom: 2.5px solid currentColor;
-  border-left: 2.5px solid currentColor;
-  content: '';
-  transform: translateY(-50%) rotate(45deg);
+.settings-back-button svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .settings-back-button:active {
-  transform: translateY(1px);
+  background: var(--surface-muted);
 }
 
 .settings-top h1 {
   margin: 0;
   color: var(--text);
   font-size: 28px;
-  line-height: 1.08;
-  font-weight: 760;
-}
-
-.settings-top.is-detail h1 {
-  text-align: center;
+  line-height: 1.04;
+  font-weight: 700;
+  letter-spacing: -0.022em;
 }
 
 .settings-content {
   display: grid;
-  max-width: 760px;
-  margin: 30px auto 0;
-  gap: 24px;
+  max-width: 720px;
+  margin: 22px auto 0;
+  gap: 22px;
 }
 
 .settings-index {
   display: grid;
-  gap: 24px;
+  gap: 22px;
 }
 </style>

--- a/src/components/settings/SettingsChoiceRow.vue
+++ b/src/components/settings/SettingsChoiceRow.vue
@@ -42,10 +42,11 @@ defineEmits<{
 .settings-choice-row {
   display: grid;
   gap: 10px;
-  width: min(100%, 760px);
+  width: 100%;
+  min-width: 0;
   min-height: 72px;
-  margin: 0 auto;
   padding: 12px 20px 14px;
+  border: 0;
   border-bottom: 1px solid var(--border);
   color: var(--text);
 }
@@ -62,8 +63,9 @@ defineEmits<{
 .settings-choice-label {
   min-width: 0;
   font-size: 16px;
-  font-weight: 720;
-  line-height: 1.25;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.008em;
   overflow-wrap: anywhere;
 }
 
@@ -79,28 +81,32 @@ defineEmits<{
   min-height: 38px;
   padding: 0 10px;
   border: 1px solid var(--border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--surface) 86%, var(--surface-muted) 14%);
+  border-radius: var(--radius-sm, 10px);
+  background: var(--surface-muted);
   color: var(--text-muted);
   font: inherit;
   font-size: 14px;
-  font-weight: 720;
-  letter-spacing: 0;
+  font-weight: 600;
+  letter-spacing: -0.006em;
   touch-action: manipulation;
+  transition:
+    background 140ms var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1)),
+    color 140ms var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1)),
+    border-color 140ms var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
 }
 
 .settings-choice-option.is-active {
   border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
-  background: color-mix(in srgb, var(--accent) 12%, var(--surface));
+  background: var(--accent-soft);
   color: var(--accent-strong);
 }
 
 .settings-choice-option:active {
-  transform: translateY(1px);
+  transform: translateY(0.5px);
 }
 
 .settings-choice-option:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
   outline-offset: 1px;
 }
 </style>

--- a/src/components/settings/SettingsRow.vue
+++ b/src/components/settings/SettingsRow.vue
@@ -57,10 +57,11 @@ const hasChevron = computed(() => Boolean(props.chevron || props.href))
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 14px;
-  width: min(100%, 760px);
-  min-height: 64px;
-  margin: 0 auto;
+  width: 100%;
+  min-width: 0;
+  min-height: 58px;
   padding: 12px 20px;
+  border: 0;
   border-bottom: 1px solid var(--border);
   background: transparent;
   color: var(--text);
@@ -73,20 +74,21 @@ const hasChevron = computed(() => Boolean(props.chevron || props.href))
 }
 
 .settings-row.has-chevron {
-  padding-right: 48px;
+  grid-template-columns: minmax(0, 1fr) auto 18px;
+  padding-right: 16px;
 }
 
 .settings-row.has-chevron::after {
   position: absolute;
   top: 50%;
-  right: 24px;
-  width: 8px;
-  height: 8px;
-  border-top: 2px solid currentColor;
-  border-right: 2px solid currentColor;
-  color: var(--text-muted);
+  right: 20px;
+  width: 9px;
+  height: 9px;
+  border-top: 1.6px solid var(--text-faint);
+  border-right: 1.6px solid var(--text-faint);
   content: '';
   transform: translateY(-50%) rotate(45deg);
+  pointer-events: none;
 }
 
 .settings-row.is-link:active,
@@ -96,52 +98,36 @@ const hasChevron = computed(() => Boolean(props.chevron || props.href))
 
 .settings-row.is-link:focus-visible,
 .settings-row.is-action:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
   outline-offset: -2px;
 }
 
-.settings-row.is-action {
-  width: 100%;
-  max-width: 760px;
-  border-top: 0;
-  border-right: 0;
-  border-left: 0;
-  text-align: left;
-}
-
 .settings-row.is-action:disabled {
-  color: var(--text-muted);
-}
-
-.settings-row.has-chevron {
-  grid-template-columns: minmax(0, 1fr);
-  align-content: center;
-  gap: 3px;
-}
-
-.settings-row.has-chevron .settings-row-value {
-  max-width: none;
-  text-align: left;
+  color: var(--text-faint);
 }
 
 .settings-row-label,
 .settings-row-value {
   min-width: 0;
-  line-height: 1.25;
+  line-height: 1.3;
   overflow-wrap: anywhere;
   white-space: normal;
 }
 
 .settings-row-label {
   font-size: 16px;
-  font-weight: 720;
+  font-weight: 600;
+  letter-spacing: -0.008em;
 }
 
 .settings-row-value {
-  max-width: 42vw;
+  max-width: 46vw;
   color: var(--text-muted);
-  font-size: 13px;
-  font-weight: 620;
+  font-size: 13.5px;
+  font-weight: 500;
   text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 </style>

--- a/src/components/settings/SettingsSection.vue
+++ b/src/components/settings/SettingsSection.vue
@@ -20,20 +20,23 @@ defineProps<{
 }
 
 .settings-section h2 {
-  max-width: 760px;
+  max-width: 720px;
   width: 100%;
   margin: 0 auto;
-  padding: 0 20px;
-  color: var(--text-muted);
-  font-size: 13px;
+  padding: 0 24px;
+  color: var(--text-faint);
+  font-size: 12px;
   line-height: 1.2;
-  font-weight: 760;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .settings-section-body {
   overflow: hidden;
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   background: var(--surface);
+  box-shadow: var(--shadow-sm);
 }
 </style>

--- a/src/components/settings/SettingsSelectRow.vue
+++ b/src/components/settings/SettingsSelectRow.vue
@@ -37,10 +37,11 @@ defineEmits<{
   grid-template-columns: minmax(0, 1fr) minmax(132px, 46%);
   align-items: center;
   gap: 14px;
-  width: min(100%, 760px);
-  min-height: 64px;
-  margin: 0 auto;
+  width: 100%;
+  min-width: 0;
+  min-height: 58px;
   padding: 12px 20px;
+  border: 0;
   border-bottom: 1px solid var(--border);
   color: var(--text);
 }
@@ -52,8 +53,9 @@ defineEmits<{
 .settings-select-label {
   min-width: 0;
   font-size: 16px;
-  font-weight: 720;
-  line-height: 1.25;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.008em;
   overflow-wrap: anywhere;
 }
 
@@ -62,16 +64,16 @@ defineEmits<{
   min-height: 38px;
   padding: 0 34px 0 12px;
   border: 1px solid var(--border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--surface) 86%, var(--surface-muted) 14%);
+  border-radius: var(--radius-sm, 10px);
+  background: var(--surface-muted);
   color: var(--text);
   font: inherit;
   font-size: 14px;
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .settings-select:focus-visible {
-  border-color: color-mix(in srgb, var(--accent) 54%, var(--border));
+  border-color: var(--accent);
   outline: 2px solid color-mix(in srgb, var(--accent) 18%, transparent);
   outline-offset: 1px;
 }

--- a/src/components/settings/SettingsSliderRow.vue
+++ b/src/components/settings/SettingsSliderRow.vue
@@ -40,10 +40,11 @@ function updateValue(value: string) {
 .settings-slider-row {
   display: grid;
   gap: 14px;
-  width: min(100%, 760px);
+  width: 100%;
+  min-width: 0;
   min-height: 76px;
-  margin: 0 auto;
   padding: 12px 20px 16px;
+  border: 0;
   border-bottom: 1px solid var(--border);
   color: var(--text);
 }
@@ -62,15 +63,16 @@ function updateValue(value: string) {
 .settings-slider-label {
   min-width: 0;
   font-size: 16px;
-  font-weight: 720;
-  line-height: 1.25;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.008em;
   overflow-wrap: anywhere;
 }
 
 .settings-slider-value {
   color: var(--text-muted);
   font-size: 13px;
-  font-weight: 720;
+  font-weight: 600;
 }
 
 .settings-slider {
@@ -79,7 +81,7 @@ function updateValue(value: string) {
 }
 
 .settings-slider:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
   outline-offset: 4px;
 }
 </style>

--- a/src/components/settings/SettingsTextRow.vue
+++ b/src/components/settings/SettingsTextRow.vue
@@ -38,10 +38,11 @@ defineEmits<{
 .settings-text-row {
   display: grid;
   gap: 10px;
-  width: min(100%, 760px);
+  width: 100%;
+  min-width: 0;
   min-height: 76px;
-  margin: 0 auto;
   padding: 12px 20px 14px;
+  border: 0;
   border-bottom: 1px solid var(--border);
   color: var(--text);
 }
@@ -53,8 +54,9 @@ defineEmits<{
 .settings-text-label {
   min-width: 0;
   font-size: 16px;
-  font-weight: 720;
-  line-height: 1.25;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.008em;
   overflow-wrap: anywhere;
 }
 
@@ -63,8 +65,8 @@ defineEmits<{
   min-height: 40px;
   padding: 8px 11px;
   border: 1px solid var(--border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--surface) 86%, var(--surface-muted) 14%);
+  border-radius: var(--radius-sm, 10px);
+  background: var(--surface-muted);
   color: var(--text);
   font: inherit;
   font-size: 14px;
@@ -76,7 +78,7 @@ defineEmits<{
 }
 
 .settings-text-input:focus-visible {
-  border-color: color-mix(in srgb, var(--accent) 54%, var(--border));
+  border-color: var(--accent);
   outline: 2px solid color-mix(in srgb, var(--accent) 18%, transparent);
   outline-offset: 1px;
 }

--- a/src/components/settings/SettingsToggleRow.vue
+++ b/src/components/settings/SettingsToggleRow.vue
@@ -32,9 +32,9 @@ defineEmits<{
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 14px;
-  width: min(100%, 760px);
-  min-height: 64px;
-  margin: 0 auto;
+  width: 100%;
+  min-width: 0;
+  min-height: 58px;
   padding: 12px 20px;
   border: 0;
   border-bottom: 1px solid var(--border);
@@ -54,44 +54,45 @@ defineEmits<{
 }
 
 .settings-toggle-row:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
   outline-offset: -2px;
 }
 
 .settings-toggle-label {
   min-width: 0;
   font-size: 16px;
-  font-weight: 720;
-  line-height: 1.25;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.008em;
   overflow-wrap: anywhere;
 }
 
 .settings-toggle-track {
   position: relative;
-  width: 52px;
-  height: 32px;
-  border: 1px solid var(--border);
+  width: 50px;
+  height: 30px;
+  border: 1px solid var(--border-strong);
   border-radius: 999px;
-  background: color-mix(in srgb, var(--text-muted) 15%, var(--surface));
+  background: var(--surface-sunken);
   transition:
-    background 160ms ease-out,
-    border-color 160ms ease-out;
+    background 160ms var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1)),
+    border-color 160ms var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
 }
 
 .settings-toggle-thumb {
   position: absolute;
   top: 3px;
   left: 3px;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   border-radius: 999px;
   background: var(--surface);
-  box-shadow: 0 2px 8px rgba(26, 44, 50, 0.18);
-  transition: transform 180ms ease-out;
+  box-shadow: 0 2px 6px oklch(0.25 0.02 255 / 0.18);
+  transition: transform 180ms var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
 }
 
 .settings-toggle-row[aria-checked='true'] .settings-toggle-track {
-  border-color: color-mix(in srgb, var(--accent) 54%, var(--border));
+  border-color: var(--accent);
   background: var(--accent);
 }
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -23,6 +23,7 @@ const MESSAGES = {
     'home.earlier': 'Earlier',
     'home.emptyTitle': 'No recent Markdown files',
     'home.emptyBody': 'Start a local draft or open a Markdown file from this device.',
+    'home.continueAction': 'Continue',
 
     'nav.documents': 'Documents',
     'nav.settings': 'Settings',
@@ -404,6 +405,7 @@ const MESSAGES = {
     'home.earlier': '更早',
     'home.emptyTitle': '没有最近的 Markdown 文件',
     'home.emptyBody': '新建一个本地草稿，或从设备打开 Markdown 文件。',
+    'home.continueAction': '继续',
 
     'nav.documents': '文档',
     'nav.settings': '设置',

--- a/src/style.css
+++ b/src/style.css
@@ -1,13 +1,22 @@
 :root {
-  --app-bg: #f6f7f2;
-  --surface: #ffffff;
-  --surface-muted: #eef3f0;
-  --text: #1f2a2e;
-  --text-muted: #68757a;
-  --border: #d9dfdc;
-  --accent: #167c62;
-  --accent-strong: #0f5f4b;
-  --shadow: 0 8px 28px rgba(26, 44, 50, 0.08);
+  --app-bg: oklch(0.965 0.004 255);
+  --surface: oklch(0.985 0.003 255);
+  --surface-muted: oklch(0.955 0.005 255);
+  --surface-sunken: oklch(0.935 0.006 255);
+  --text: oklch(0.23 0.014 255);
+  --text-muted: oklch(0.52 0.02 255);
+  --text-faint: oklch(0.63 0.018 255);
+  --border: oklch(0.9 0.008 255);
+  --border-strong: oklch(0.86 0.011 255);
+  --accent: oklch(0.52 0.06 255);
+  --accent-strong: oklch(0.45 0.065 255);
+  --accent-soft: oklch(0.93 0.035 255);
+  --danger: oklch(0.5 0.13 25);
+  --shadow-sm: 0 1px 2px oklch(0.25 0.02 255 / 0.05);
+  --shadow: 0 8px 28px oklch(0.25 0.02 255 / 0.07);
+  --radius: 14px;
+  --radius-sm: 10px;
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
 
   color: var(--text);
   background: var(--app-bg);
@@ -46,21 +55,21 @@ body {
   display: grid;
   grid-template-rows: minmax(0, 1fr) auto;
   overflow: hidden;
-  background: var(--surface);
+  background: var(--app-bg);
 }
 
 .home-screen {
   min-height: 100%;
-  padding: calc(env(safe-area-inset-top, 0px) + 18px) 18px 28px;
-  background: var(--surface);
+  padding: calc(env(safe-area-inset-top, 0px) + 26px) 22px 36px;
+  background: var(--app-bg);
 }
 
 .home-top {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  max-width: 760px;
+  max-width: 720px;
   margin: 0 auto;
 }
 
@@ -68,149 +77,290 @@ body {
   margin: 0;
   color: var(--text);
   font-size: 30px;
-  line-height: 1.08;
-  font-weight: 760;
+  line-height: 1.04;
+  font-weight: 700;
+  letter-spacing: -0.022em;
 }
 
 .home-actions {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
-.home-new-button,
-.home-open-button,
-.nav-button {
-  min-height: 44px;
+.home-open-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 40px;
+  padding: 0 15px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 999px;
   background: var(--surface);
   color: var(--text);
   font: inherit;
   font-size: 14px;
-  font-weight: 700;
+  font-weight: 600;
+  letter-spacing: -0.006em;
+  box-shadow:
+    0 1px 2px oklch(0.25 0.02 255 / 0.04),
+    inset 0 1px 0 oklch(1 0 0 / 0.6);
+  transition:
+    border-color 160ms var(--ease-out),
+    background 160ms var(--ease-out),
+    box-shadow 160ms var(--ease-out),
+    transform 120ms var(--ease-out);
 }
 
-.home-open-button {
-  padding: 0 15px;
-  background: var(--surface);
+.home-open-button svg {
+  width: 15px;
+  height: 15px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.home-open-button:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-muted);
+}
+
+.home-open-button:active {
+  background: var(--surface-sunken);
+  transform: translateY(0.5px);
+  box-shadow: 0 1px 1px oklch(0.25 0.02 255 / 0.03);
 }
 
 .home-new-button {
   display: grid;
   place-items: center;
-  flex: 0 0 auto;
-  width: 46px;
-  min-width: 46px;
-  height: 46px;
+  width: 40px;
+  height: 40px;
   padding: 0;
-  border-color: var(--accent);
+  border: 1px solid transparent;
+  border-radius: 999px;
   background: var(--accent);
   color: var(--surface);
-  font-size: 30px;
-  font-weight: 420;
-  line-height: 1;
+  font: inherit;
+  box-shadow:
+    0 2px 8px oklch(0.52 0.06 255 / 0.28),
+    inset 0 1px 0 oklch(1 0 0 / 0.22);
+  transition:
+    background 160ms var(--ease-out),
+    box-shadow 160ms var(--ease-out),
+    transform 120ms var(--ease-out);
 }
 
-.home-new-button:active,
+.home-new-button svg {
+  width: 17px;
+  height: 17px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.home-new-button:hover {
+  background: color-mix(in srgb, var(--accent) 88%, var(--accent-strong) 12%);
+}
+
+.home-new-button:active {
+  background: var(--accent-strong);
+  transform: translateY(0.5px);
+  box-shadow:
+    0 1px 3px oklch(0.52 0.06 255 / 0.2),
+    inset 0 1px 0 oklch(1 0 0 / 0.16);
+}
+
 .home-open-button:active,
-.nav-button:active,
-.document-row:active {
-  transform: translateY(1px);
+.home-new-button:active {
+  transform: translateY(0.5px);
 }
 
 .home-notice {
-  max-width: 760px;
-  margin: 16px auto 0;
-  padding: 11px 12px;
+  max-width: 720px;
+  margin: 18px auto 0;
+  padding: 11px 14px;
   border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface-muted);
-  color: var(--text-muted);
-  font-size: 14px;
-  line-height: 1.35;
+  border-radius: var(--radius-sm);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 13.5px;
+  line-height: 1.4;
+  font-weight: 500;
 }
 
-.home-tabs {
-  display: flex;
-  max-width: 760px;
-  margin: 22px auto 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.home-tab {
-  position: relative;
-  min-height: 46px;
-  padding: 0 2px;
-  border: 0;
-  background: transparent;
-  color: var(--text);
-  font: inherit;
-  font-size: 16px;
-  font-weight: 760;
-}
-
-.home-tab.is-active::after {
-  position: absolute;
-  right: 0;
-  bottom: -1px;
-  left: 0;
-  height: 3px;
-  border-radius: 999px 999px 0 0;
-  background: var(--accent);
-  content: '';
+.home-section-label {
+  max-width: 720px;
+  margin: 26px auto 0;
+  padding: 0 4px;
+  color: var(--text-faint);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .home-content {
-  max-width: 760px;
-  margin: 24px auto 0;
+  max-width: 720px;
+  margin: 12px auto 0;
 }
 
 .document-group + .document-group {
   margin-top: 30px;
 }
 
-.document-group h2 {
-  margin: 0 0 12px;
+.continue-card {
+  display: grid;
+  gap: 14px;
+  width: 100%;
+  padding: 20px 20px 22px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+  text-align: left;
+  font: inherit;
+  transition:
+    border-color 180ms var(--ease-out),
+    box-shadow 180ms var(--ease-out),
+    transform 160ms var(--ease-out);
+}
+
+.continue-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: 0 4px 16px oklch(0.25 0.02 255 / 0.07);
+}
+
+.continue-card:active {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(0.5px);
+}
+
+.continue-card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.continue-card-head svg {
+  width: 15px;
+  height: 15px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.continue-card-title {
+  display: block;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 19px;
+  line-height: 1.25;
+  font-weight: 700;
+  letter-spacing: -0.012em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.continue-card-meta {
+  display: block;
+  overflow: hidden;
   color: var(--text-muted);
-  font-size: 13px;
-  line-height: 1.2;
-  font-weight: 760;
+  font-size: 13.5px;
+  line-height: 1.35;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.continue-card-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent-strong);
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+.continue-card-cta svg {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.document-list {
+  display: grid;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
 }
 
 .document-row {
   display: grid;
-  grid-template-columns: 48px minmax(0, 1fr);
+  grid-template-columns: 34px minmax(0, 1fr) 18px;
   align-items: center;
+  gap: 14px;
   width: 100%;
-  min-height: 76px;
-  padding: 10px 0;
+  min-height: 68px;
+  padding: 12px 18px;
   border: 0;
   border-bottom: 1px solid var(--border);
   background: transparent;
   color: var(--text);
   text-align: left;
   font: inherit;
+  transition: background 140ms var(--ease-out);
 }
 
-.document-icon {
+.document-list .document-row:last-child {
+  border-bottom: 0;
+}
+
+.document-list .document-row:active {
+  background: var(--surface-muted);
+}
+
+.document-glyph {
   display: inline-grid;
   place-items: center;
-  width: 36px;
-  height: 42px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--surface-muted);
-  color: var(--accent-strong);
-  font-size: 18px;
-  font-weight: 800;
-  line-height: 1;
+  width: 34px;
+  height: 34px;
+  color: var(--text-faint);
+}
+
+.document-glyph svg {
+  width: 26px;
+  height: 26px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .document-text {
   display: grid;
   min-width: 0;
-  gap: 5px;
+  gap: 3px;
 }
 
 .document-text strong,
@@ -222,30 +372,80 @@ body {
 
 .document-text strong {
   color: var(--text);
-  font-size: 18px;
-  line-height: 1.2;
-  font-weight: 760;
+  font-size: 16px;
+  line-height: 1.25;
+  font-weight: 600;
+  letter-spacing: -0.008em;
 }
 
 .document-text span {
   color: var(--text-muted);
-  font-size: 14px;
-  line-height: 1.25;
-  font-weight: 560;
+  font-size: 13px;
+  line-height: 1.3;
+  font-weight: 500;
+}
+
+.document-chevron {
+  color: var(--text-faint);
+}
+
+.document-chevron svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .empty-recent {
   display: grid;
-  gap: 16px;
+  gap: 14px;
   justify-items: start;
-  padding: 8px 0;
+  max-width: 720px;
+  margin: 36px auto 0;
+  padding: 8px 4px;
+}
+
+.empty-recent .empty-mark {
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: 56px;
+  margin-bottom: 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text-faint);
+}
+
+.empty-recent .empty-mark svg {
+  width: 26px;
+  height: 26px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.empty-recent h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 17px;
+  line-height: 1.25;
+  font-weight: 700;
+  letter-spacing: -0.012em;
 }
 
 .empty-recent p {
   margin: 0;
+  max-width: 46ch;
   color: var(--text-muted);
-  font-size: 15px;
-  line-height: 1.4;
+  font-size: 14px;
+  line-height: 1.45;
+  font-weight: 500;
 }
 
 .top-bar {
@@ -255,74 +455,195 @@ body {
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 12px;
-  min-height: 68px;
-  padding: calc(env(safe-area-inset-top, 0px) + 10px) 18px 10px;
+  min-height: 64px;
+  padding: calc(env(safe-area-inset-top, 0px) + 10px) 16px 10px;
   border-bottom: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(16px);
+  background: var(--surface);
 }
 
-.nav-button {
-  padding: 0 12px;
+.nav-button,
+.icon-button {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text);
+  touch-action: manipulation;
+  transition:
+    background 140ms var(--ease-out),
+    color 140ms var(--ease-out);
+}
+
+.nav-button svg,
+.icon-button svg {
+  width: 21px;
+  height: 21px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.icon-button svg circle[fill='currentColor'] {
+  fill: currentColor;
+}
+
+.nav-button:hover,
+.icon-button:hover {
+  background: var(--surface-muted);
+  color: var(--text);
+}
+
+.nav-button:active,
+.icon-button:active {
+  background: var(--surface-sunken);
+  transform: translateY(0.5px);
 }
 
 .editor-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
   position: relative;
 }
 
-.menu-button {
+.editor-action-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
   display: grid;
-  place-items: center;
-  width: 44px;
-  height: 44px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-  color: var(--text);
-  font: inherit;
-  font-size: 18px;
-  font-weight: 760;
-  line-height: 1;
+  align-items: end;
+  background: oklch(0.23 0.02 255 / 0.5);
 }
 
-.menu-button:active {
-  transform: translateY(1px);
+.editor-sheet-enter-active,
+.editor-sheet-leave-active {
+  transition: opacity 200ms var(--ease-out);
 }
 
-.editor-menu {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: 30;
-  min-width: 124px;
-  width: 144px;
-  max-width: calc(100vw - 32px);
-  overflow: hidden;
+.editor-sheet-enter-active .editor-action-panel,
+.editor-sheet-leave-active .editor-action-panel {
+  transition: transform 280ms var(--ease-out);
+}
+
+.editor-sheet-enter-from,
+.editor-sheet-leave-to {
+  opacity: 0;
+}
+
+.editor-sheet-enter-from .editor-action-panel,
+.editor-sheet-leave-to .editor-action-panel {
+  transform: translateY(100%);
+}
+
+.editor-action-panel {
+  width: min(100%, 520px);
+  margin: 0 auto;
+  padding: 10px 14px calc(env(safe-area-inset-bottom, 0px) + 14px);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-bottom: 0;
+  border-radius: var(--radius) var(--radius) 0 0;
   background: var(--surface);
   box-shadow: var(--shadow);
 }
 
-.editor-menu button {
+.editor-action-grabber {
+  width: 36px;
+  height: 4px;
+  margin: 2px auto 8px;
+  border-radius: 999px;
+  background: var(--border-strong);
+}
+
+.editor-action-title {
+  margin: 4px 6px 8px;
+  color: var(--text-faint);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.editor-action-list {
+  display: grid;
+  gap: 2px;
+}
+
+.editor-action-row {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr);
+  align-items: center;
+  gap: 14px;
   width: 100%;
-  min-height: 46px;
-  padding: 0 14px;
+  min-height: 56px;
+  padding: 8px 12px;
   border: 0;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: 15.5px;
+  font-weight: 600;
+  letter-spacing: -0.006em;
   text-align: left;
+  transition: background 140ms var(--ease-out);
 }
 
-.editor-menu button:active {
+.editor-action-row:active {
   background: var(--surface-muted);
 }
 
-.editor-menu button:disabled {
-  color: var(--text-muted);
+.editor-action-row:disabled {
+  color: var(--text-faint);
+}
+
+.editor-action-row:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  outline-offset: -2px;
+}
+
+.editor-action-icon {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: var(--surface-muted);
+  color: var(--accent-strong);
+}
+
+.editor-action-row:disabled .editor-action-icon {
+  color: var(--text-faint);
+}
+
+.editor-action-icon svg {
+  width: 22px;
+  height: 22px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.editor-action-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .editor-sheet-enter-active,
+  .editor-sheet-leave-active,
+  .editor-sheet-enter-active .editor-action-panel,
+  .editor-sheet-leave-active .editor-action-panel {
+    transition: none;
+  }
 }
 
 .document-heading {
@@ -331,21 +652,22 @@ body {
 
 .document-heading span {
   display: block;
-  color: var(--text-muted);
+  color: var(--text-faint);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: 600;
   line-height: 1.2;
   text-transform: uppercase;
-  letter-spacing: 0;
+  letter-spacing: 0.05em;
 }
 
 .document-heading h1 {
   overflow: hidden;
   margin: 3px 0 0;
   color: var(--text);
-  font-size: 18px;
-  line-height: 1.2;
+  font-size: 17px;
+  line-height: 1.25;
   font-weight: 700;
+  letter-spacing: -0.012em;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -355,6 +677,7 @@ body {
   color: var(--text-muted);
   font-size: 12px;
   line-height: 1.2;
+  font-weight: 500;
 }
 
 .editor-pane {
@@ -369,7 +692,7 @@ body {
   margin: 0 auto;
   overflow: auto;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: var(--surface);
   box-shadow: var(--shadow);
   -webkit-overflow-scrolling: touch;
@@ -395,6 +718,7 @@ body {
   background: var(--surface-muted);
   font-size: 12px;
   line-height: 1.2;
+  font-weight: 500;
 }
 
 .draft-save-sheet {
@@ -404,15 +728,15 @@ body {
   display: grid;
   align-items: end;
   padding: 18px;
-  background: rgba(31, 42, 46, 0.38);
+  background: oklch(0.23 0.02 255 / 0.42);
 }
 
 .draft-save-panel {
   width: min(100%, 520px);
   margin: 0 auto;
-  padding: 18px;
+  padding: 20px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: var(--surface);
   box-shadow: var(--shadow);
 }
@@ -422,14 +746,16 @@ body {
   color: var(--text);
   font-size: 19px;
   line-height: 1.25;
-  font-weight: 760;
+  font-weight: 700;
+  letter-spacing: -0.012em;
 }
 
 .draft-save-panel p {
   margin: 8px 0 0;
   color: var(--text-muted);
   font-size: 14px;
-  line-height: 1.42;
+  line-height: 1.45;
+  font-weight: 500;
 }
 
 .link-insert-panel {
@@ -445,7 +771,7 @@ body {
 .link-field span {
   color: var(--text-muted);
   font-size: 13px;
-  font-weight: 760;
+  font-weight: 600;
   line-height: 1.2;
 }
 
@@ -454,7 +780,7 @@ body {
   min-height: 46px;
   padding: 0 12px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   background: var(--surface);
   color: var(--text);
   font: inherit;
@@ -471,36 +797,37 @@ body {
 .draft-save-actions {
   display: grid;
   gap: 8px;
-  margin-top: 16px;
+  margin-top: 18px;
 }
 
 .draft-save-actions button {
   min-height: 46px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 999px;
   background: var(--surface);
   color: var(--text);
   font: inherit;
   font-size: 14px;
-  font-weight: 760;
+  font-weight: 600;
 }
 
 .draft-save-actions button:active {
-  transform: translateY(1px);
+  background: var(--surface-muted);
+  transform: translateY(0.5px);
 }
 
 .draft-save-actions button:disabled {
-  color: var(--text-muted);
+  color: var(--text-faint);
 }
 
 .draft-save-actions .primary-action {
-  border-color: var(--accent);
+  border-color: transparent;
   background: var(--accent);
   color: var(--surface);
 }
 
 .draft-save-actions .danger-action {
-  color: #9b2f2f;
+  color: var(--danger);
 }
 
 @media (max-width: 720px) {
@@ -510,7 +837,7 @@ body {
   }
 
   .home-top h1 {
-    font-size: 28px;
+    font-size: 27px;
   }
 
   .top-bar {

--- a/tests/e2e/mobile-recent-home.spec.ts
+++ b/tests/e2e/mobile-recent-home.spec.ts
@@ -346,7 +346,7 @@ test('creates a local draft from real editor input and returns it to the recent 
 
   await page.getByTestId('new-document-button').click()
   await expectEditorReady(page)
-  await expect(page.getByTestId('back-button')).toHaveText('Back')
+  await expect(page.getByTestId('back-button')).toHaveAttribute('aria-label', 'Back')
 
   await page.getByTestId('editor-host').click()
   await page.keyboard.type('# Fresh mobile note')
@@ -368,7 +368,7 @@ test('creates a local draft from real editor input and returns it to the recent 
   await page.getByTestId('prompt-keep-draft-button').click()
 
   await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
-  await expect(page.getByText('Continue writing')).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Continue writing' })).toBeVisible()
   await expect(page.getByText('Fresh mobile note')).toBeVisible()
   await expect(page.getByText('No recent Markdown files')).toBeHidden()
   await expect(page.getByTestId('new-document-button')).toBeVisible()
@@ -1018,15 +1018,20 @@ test('saves a writable Android document as a copy and switches to the new docume
   await page.keyboard.type('copy target text')
 
   await page.getByTestId('editor-menu-button').click()
+  const actionSheet = page.getByTestId('editor-action-sheet')
+  await expect(actionSheet).toBeVisible()
+  await expect(page.getByRole('dialog', { name: 'Document actions' })).toBeVisible()
   await expect(page.getByTestId('save-copy-button')).toBeVisible()
-  const menuButtonBox = await page.getByTestId('editor-menu-button').boundingBox()
-  const menuBox = await page.locator('.editor-menu').boundingBox()
-  expect(menuButtonBox).not.toBeNull()
-  expect(menuBox).not.toBeNull()
-  expect(
-    Math.abs(menuBox!.x + menuBox!.width - (menuButtonBox!.x + menuButtonBox!.width)),
-  ).toBeLessThanOrEqual(2)
-  expect(menuBox!.width).toBeLessThanOrEqual(150)
+  const viewport = page.viewportSize()
+  const sheetBox = await actionSheet.boundingBox()
+  const panelBox = await page.locator('.editor-action-panel').boundingBox()
+  expect(viewport).not.toBeNull()
+  expect(sheetBox).not.toBeNull()
+  expect(panelBox).not.toBeNull()
+  expect(sheetBox!.width).toBeGreaterThanOrEqual(viewport!.width - 2)
+  expect(sheetBox!.height).toBeGreaterThanOrEqual(viewport!.height - 2)
+  expect(panelBox!.y).toBeGreaterThan(viewport!.height / 2)
+  expect(panelBox!.y + panelBox!.height).toBeGreaterThanOrEqual(viewport!.height - 2)
   await page.getByTestId('save-copy-button').click()
 
   await expect(page.getByText('Saved', { exact: true })).toBeVisible()


### PR DESCRIPTION
## Summary

- Refreshes the mobile document home with calmer graphite-light surfaces, clearer Open/New controls, document glyphs, and stronger empty/recent/continue layouts.
- Updates bottom navigation to an icon + label pattern with a pill-style active indicator and reduced-motion handling.
- Polishes the settings shell and settings row components so index rows, toggles, choices, selects, sliders, text inputs, and grouped sections share one mobile visual vocabulary.
- Refines the editor shell with an icon-only back button, cleaner title/status header, and a search affordance.
- Replaces the old desktop-style anchored overflow menu with a mobile bottom action sheet for document actions.
- Updates E2E coverage for the icon-only back button and the new bottom action sheet behavior.

## Notes

- This is a frontend polish PR only; it does not include the Editing settings backend checkpoint.
- The bottom action sheet keeps the existing document actions scoped to current behavior: Share, Save to device, and Save a copy.
- The editor search icon is a shell affordance in this PR; it logs the request but does not implement search behavior yet.
- Local handoff/planning files and screenshots are intentionally not included: PRODUCT.md, HANDOFF.md, todolist.md, AGENTS.md, refs/, and logs/.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm exec playwright test --workers=1` (49 passed)
- `pnpm android:sync`
- `android\\gradlew.bat assembleDebug`
- `adb -s emulator-5554 install -r android\\app\\build\\outputs\\apk\\debug\\app-debug.apk`
- Android emulator smoke on `emulator-5554`: launched app, checked home, editor, overflow bottom action sheet, settings index, and final logcat for crashes/app errors.