### PR TITLE
Polish mobile settings layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lerna-debug.log*
 HANDOFF.md
 todolist.md
 AGENTS.md
+PRODUCT.md
 refs/
 
 # Environment

--- a/src/components/AppBottomNavigation.vue
+++ b/src/components/AppBottomNavigation.vue
@@ -67,10 +67,10 @@ function selectTab(tab: HomeTab) {
 
 .bottom-nav-indicator {
   position: absolute;
-  top: 4px;
-  bottom: 4px;
-  left: 0;
-  width: 50%;
+  top: 6px;
+  bottom: 6px;
+  left: 6px;
+  width: calc(50% - 6px);
   pointer-events: none;
   transition: transform 340ms var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
   will-change: transform;
@@ -78,9 +78,9 @@ function selectTab(tab: HomeTab) {
 
 .bottom-nav-indicator::before {
   position: absolute;
-  inset: 0 6px;
+  inset: 0 16px;
   border-radius: 999px;
-  background: var(--accent-soft);
+  background: color-mix(in srgb, var(--accent-soft) 72%, var(--surface) 28%);
   content: '';
 }
 

--- a/src/components/HomeShell.vue
+++ b/src/components/HomeShell.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import AppBottomNavigation from './AppBottomNavigation.vue'
 import DocumentHome from './DocumentHome.vue'
 import SettingsHome from './SettingsHome.vue'
 import type { HomeDocumentItem } from '../lib/homeDocuments'
 import { HOME_TABS, type HomeTab } from '../lib/homeNavigation'
-import type { SettingsPage } from '../lib/settingsNavigation'
+import { SETTINGS_PAGES, type SettingsPage } from '../lib/settingsNavigation'
 
 interface Props {
   activeTab: HomeTab
@@ -27,6 +27,12 @@ const emit = defineEmits<{
 
 const homeMain = ref<HTMLElement | null>(null)
 
+const isSettingsDetail = computed(
+  () => props.activeTab === HOME_TABS.SETTINGS && props.settingsPage !== SETTINGS_PAGES.INDEX,
+)
+
+const showBottomNav = computed(() => !isSettingsDetail.value)
+
 watch(
   () => [props.activeTab, props.settingsPage] as const,
   () => {
@@ -37,7 +43,7 @@ watch(
 </script>
 
 <template>
-  <main class="app-shell is-home">
+  <main class="app-shell is-home" :class="{ 'is-detail': isSettingsDetail }">
     <div ref="homeMain" class="home-main">
       <DocumentHome
         v-if="activeTab === HOME_TABS.DOCUMENTS"
@@ -54,7 +60,11 @@ watch(
         @set-page="page => emit('setSettingsPage', page)"
       />
     </div>
-    <AppBottomNavigation :active-tab="activeTab" @set-tab="tab => emit('setTab', tab)" />
+    <AppBottomNavigation
+      v-if="showBottomNav"
+      :active-tab="activeTab"
+      @set-tab="tab => emit('setTab', tab)"
+    />
   </main>
 </template>
 

--- a/src/components/SettingsHome.vue
+++ b/src/components/SettingsHome.vue
@@ -23,21 +23,28 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <section class="settings-screen" :aria-label="t('settings.title')" data-testid="settings-screen">
+  <section
+    class="settings-screen"
+    :class="{ 'is-detail': activePage !== SETTINGS_PAGES.INDEX }"
+    :aria-label="t('settings.title')"
+    data-testid="settings-screen"
+  >
     <header class="settings-top" :class="{ 'is-detail': activePage !== SETTINGS_PAGES.INDEX }">
-      <button
-        v-if="activePage !== SETTINGS_PAGES.INDEX"
-        class="settings-back-button"
-        type="button"
-        :aria-label="t('settings.back')"
-        data-testid="settings-detail-back"
-        @click="emit('setPage', SETTINGS_PAGES.INDEX)"
-      >
-        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path d="M15 6l-6 6 6 6" />
-        </svg>
-      </button>
-      <h1 data-testid="settings-title">{{ t(SETTINGS_PAGE_TITLE_KEYS[activePage]) }}</h1>
+      <div class="settings-top-inner">
+        <button
+          v-if="activePage !== SETTINGS_PAGES.INDEX"
+          class="settings-back-button"
+          type="button"
+          :aria-label="t('settings.back')"
+          data-testid="settings-detail-back"
+          @click="emit('setPage', SETTINGS_PAGES.INDEX)"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M15 6l-6 6 6 6" />
+          </svg>
+        </button>
+        <h1 data-testid="settings-title">{{ t(SETTINGS_PAGE_TITLE_KEYS[activePage]) }}</h1>
+      </div>
     </header>
     <div class="settings-content">
       <template v-if="activePage === SETTINGS_PAGES.INDEX">
@@ -51,7 +58,6 @@ const { t } = useI18n()
               v-for="item in section.items"
               :key="item.id"
               :label="t(item.labelKey)"
-              :value="t(item.valueKey)"
               button
               chevron
               :test-id="item.testId"
@@ -73,7 +79,24 @@ const { t } = useI18n()
   background: var(--app-bg);
 }
 
+.settings-screen.is-detail {
+  padding-top: 0;
+}
+
 .settings-top {
+  display: block;
+}
+
+.settings-top.is-detail {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  padding: calc(env(safe-area-inset-top, 0px) + 12px) 0 12px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-top-inner {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -122,11 +145,21 @@ const { t } = useI18n()
   letter-spacing: -0.022em;
 }
 
+.settings-top.is-detail h1 {
+  font-size: 20px;
+  letter-spacing: -0.012em;
+}
+
 .settings-content {
   display: grid;
   max-width: 720px;
-  margin: 22px auto 0;
-  gap: 22px;
+  margin: 28px auto 0;
+  gap: 30px;
+}
+
+.settings-screen.is-detail .settings-content {
+  margin-top: 22px;
+  gap: 26px;
 }
 
 .settings-index {

--- a/src/components/settings/SettingsChoiceRow.vue
+++ b/src/components/settings/SettingsChoiceRow.vue
@@ -40,6 +40,7 @@ defineEmits<{
 
 <style scoped>
 .settings-choice-row {
+  position: relative;
   display: grid;
   gap: 10px;
   width: 100%;
@@ -47,12 +48,7 @@ defineEmits<{
   min-height: 72px;
   padding: 12px 20px 14px;
   border: 0;
-  border-bottom: 1px solid var(--border);
   color: var(--text);
-}
-
-.settings-choice-row:last-child {
-  border-bottom: 0;
 }
 
 .settings-choice-row.is-label-hidden {

--- a/src/components/settings/SettingsRow.vue
+++ b/src/components/settings/SettingsRow.vue
@@ -59,18 +59,14 @@ const hasChevron = computed(() => Boolean(props.chevron || props.href))
   gap: 14px;
   width: 100%;
   min-width: 0;
-  min-height: 58px;
+  min-height: 60px;
   padding: 12px 20px;
   border: 0;
-  border-bottom: 1px solid var(--border);
   background: transparent;
   color: var(--text);
   font: inherit;
+  text-align: left;
   text-decoration: none;
-}
-
-.settings-row:last-child {
-  border-bottom: 0;
 }
 
 .settings-row.has-chevron {
@@ -84,8 +80,8 @@ const hasChevron = computed(() => Boolean(props.chevron || props.href))
   right: 20px;
   width: 9px;
   height: 9px;
-  border-top: 1.6px solid var(--text-faint);
-  border-right: 1.6px solid var(--text-faint);
+  border-top: 1.4px solid color-mix(in srgb, var(--text-faint) 70%, var(--surface));
+  border-right: 1.4px solid color-mix(in srgb, var(--text-faint) 70%, var(--surface));
   content: '';
   transform: translateY(-50%) rotate(45deg);
   pointer-events: none;
@@ -116,8 +112,8 @@ const hasChevron = computed(() => Boolean(props.chevron || props.href))
 
 .settings-row-label {
   font-size: 16px;
-  font-weight: 600;
-  letter-spacing: -0.008em;
+  font-weight: 560;
+  letter-spacing: -0.006em;
 }
 
 .settings-row-value {

--- a/src/components/settings/SettingsSection.vue
+++ b/src/components/settings/SettingsSection.vue
@@ -16,27 +16,23 @@ defineProps<{
 <style scoped>
 .settings-section {
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 
 .settings-section h2 {
   max-width: 720px;
   width: 100%;
   margin: 0 auto;
-  padding: 0 24px;
+  padding: 0 22px;
   color: var(--text-faint);
-  font-size: 12px;
+  font-size: 11px;
   line-height: 1.2;
   font-weight: 600;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.09em;
   text-transform: uppercase;
 }
 
 .settings-section-body {
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
   background: var(--surface);
-  box-shadow: var(--shadow-sm);
 }
 </style>

--- a/src/components/settings/SettingsSelectRow.vue
+++ b/src/components/settings/SettingsSelectRow.vue
@@ -33,21 +33,17 @@ defineEmits<{
 
 <style scoped>
 .settings-select-row {
+  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(132px, 46%);
   align-items: center;
   gap: 14px;
   width: 100%;
   min-width: 0;
-  min-height: 58px;
+  min-height: 60px;
   padding: 12px 20px;
   border: 0;
-  border-bottom: 1px solid var(--border);
   color: var(--text);
-}
-
-.settings-select-row:last-child {
-  border-bottom: 0;
 }
 
 .settings-select-label {

--- a/src/components/settings/SettingsSliderRow.vue
+++ b/src/components/settings/SettingsSliderRow.vue
@@ -38,6 +38,7 @@ function updateValue(value: string) {
 
 <style scoped>
 .settings-slider-row {
+  position: relative;
   display: grid;
   gap: 14px;
   width: 100%;
@@ -45,12 +46,7 @@ function updateValue(value: string) {
   min-height: 76px;
   padding: 12px 20px 16px;
   border: 0;
-  border-bottom: 1px solid var(--border);
   color: var(--text);
-}
-
-.settings-slider-row:last-child {
-  border-bottom: 0;
 }
 
 .settings-slider-head {

--- a/src/components/settings/SettingsTextRow.vue
+++ b/src/components/settings/SettingsTextRow.vue
@@ -36,6 +36,7 @@ defineEmits<{
 
 <style scoped>
 .settings-text-row {
+  position: relative;
   display: grid;
   gap: 10px;
   width: 100%;
@@ -43,12 +44,7 @@ defineEmits<{
   min-height: 76px;
   padding: 12px 20px 14px;
   border: 0;
-  border-bottom: 1px solid var(--border);
   color: var(--text);
-}
-
-.settings-text-row:last-child {
-  border-bottom: 0;
 }
 
 .settings-text-label {

--- a/src/components/settings/SettingsToggleRow.vue
+++ b/src/components/settings/SettingsToggleRow.vue
@@ -28,25 +28,21 @@ defineEmits<{
 
 <style scoped>
 .settings-toggle-row {
+  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 14px;
   width: 100%;
   min-width: 0;
-  min-height: 58px;
+  min-height: 60px;
   padding: 12px 20px;
   border: 0;
-  border-bottom: 1px solid var(--border);
   background: transparent;
   color: var(--text);
   font: inherit;
   text-align: left;
   touch-action: manipulation;
-}
-
-.settings-toggle-row:last-child {
-  border-bottom: 0;
 }
 
 .settings-toggle-row:active {


### PR DESCRIPTION
## Summary
- Refine the mobile settings index into a lighter settings-list layout by removing dense row dividers and card-like section frames.
- Hide the bottom navigation on settings detail pages so detail screens read like focused mobile subpages.
- Add a sticky detail header with a back affordance and slightly calmer row typography/chevrons.
- Soften the bottom navigation selected state to reduce visual weight on the settings shell.

## Verification
- pnpm lint
- pnpm test
- pnpm build

## Notes
- This is a front-end/settings presentation polish only.
- It does not wire new settings behavior and does not change Markdown document write paths.
- Local-only PRODUCT.md remains uncommitted.