### PR TITLE
Refactor settings architecture foundation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
 import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { App } from '@capacitor/app'
 import type { PluginListenerHandle } from '@capacitor/core'
+import LinkInsertSheet from './components/editor/LinkInsertSheet.vue'
 import HomeShell from './components/HomeShell.vue'
 import MobileEditorToolbar from './components/MobileEditorToolbar.vue'
 import {
@@ -28,6 +29,7 @@ import {
 } from './lib/androidImages'
 import {
   createUntitledDocument,
+  getSuggestedMarkdownCopyFileName,
   getSuggestedMarkdownFileName,
   markDocumentSaved,
   markDocumentSaveFailed,
@@ -36,12 +38,22 @@ import {
   updateDocumentMarkdown,
 } from './lib/documentState'
 import {
-  parseLocalDrafts,
+  buildMarkdownImage,
+  buildMarkdownLink,
+  normalizeLinkField,
+} from './lib/editorMarkdownInsert'
+import {
   removeLocalDraft,
-  serializeLocalDrafts,
   upsertLocalDraft,
   type LocalDraftRecord,
 } from './lib/localDrafts'
+import {
+  readLegacyDraft,
+  readStoredAndroidRecentDocuments,
+  readStoredLocalDrafts,
+  writeStoredAndroidRecentDocuments,
+  writeStoredLocalDrafts,
+} from './lib/documentStorage'
 import { createLogger, getNativeLogInfo, isNativeLoggerAvailable } from './lib/logger'
 import {
   MOBILE_COMMANDS,
@@ -54,7 +66,7 @@ import {
   type MobileEditorToolbarPanel,
 } from './lib/mobileToolbarConfig'
 import { DEFAULT_HOME_TAB, HOME_TABS, type HomeTab } from './lib/homeNavigation'
-import type { HomeDocumentItem } from './lib/homeDocuments'
+import { toHomeDocumentItem } from './lib/homeDocuments'
 import {
   DEFAULT_SETTINGS_PAGE,
   SETTINGS_PAGES,
@@ -66,16 +78,10 @@ import {
   createRecentDocumentFromLocalDraft,
   getRecentDocumentListItems,
   markRecentDocumentSaved,
-  parseRecentDocuments,
-  serializeRecentDocuments,
   upsertRecentDocument,
-  type RecentDocumentListItem,
   type RecentDocumentRecord,
 } from './lib/recentDocuments'
 
-const LEGACY_DRAFT_STORAGE_KEY = 'marktext-for-android:draft'
-const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
-const RECENT_DOCUMENTS_STORAGE_KEY = 'marktext-for-android:recent-documents'
 const DRAFT_SAVE_DELAY_MS = 800
 const ANDROID_DOCUMENT_SAVE_DELAY_MS = 1200
 const TRANSIENT_ANDROID_DOCUMENT_MESSAGE =
@@ -89,8 +95,6 @@ const ANDROID_RECOVERY_DRAFT_PREFIX = 'android-recovery:'
 const ANDROID_SAVE_RECOVERY_MESSAGE = 'Save failed. A local recovery draft was kept.'
 const ANDROID_EXIT_RECOVERY_MESSAGE = 'Unsaved changes were kept as a recovery draft.'
 const ANDROID_EXIT_DISCARD_MESSAGE = 'Unsaved changes were discarded.'
-const MARKDOWN_FILE_EXTENSION_REGEXP = /\.(markdown|mdown|mkdn|mkd|md)$/i
-const MARKDOWN_COPY_SUFFIX_REGEXP = /\s+copy(?:\s+(\d+))?$/
 
 type MuyaCoreModule = typeof import('@muyajs/core')
 type MuyaEditor = InstanceType<MuyaCoreModule['Muya']>
@@ -114,7 +118,6 @@ const editorToolbarPanel = ref<MobileEditorToolbarPanel>(DEFAULT_MOBILE_TOOLBAR_
 const linkSheetOpen = ref(false)
 const linkText = ref('')
 const linkUrl = ref('')
-const linkUrlInput = ref<HTMLInputElement | null>(null)
 const promptLocalDraftSaveOnExit = ref(false)
 const savingLocalDraftToAndroid = ref(false)
 const savingAndroidDocumentCopy = ref(false)
@@ -157,34 +160,6 @@ const continueDocument = computed(() =>
   continueDocumentItem.value ? toHomeDocumentItem(continueDocumentItem.value) : null,
 )
 const earlierDocuments = computed(() => earlierDocumentItems.value.map(toHomeDocumentItem))
-
-function toHomeDocumentItem(item: RecentDocumentListItem): HomeDocumentItem {
-  const savedAt = formatSavedTime(item.lastSavedAt ?? item.updatedAt)
-  const count = item.stats ? `${item.stats.words} ${item.stats.words === 1 ? 'word' : 'words'}` : ''
-  const source = item.providerName ?? 'Markdown document'
-
-  return {
-    id: item.id,
-    title: item.title,
-    details: [source, savedAt, count].filter(Boolean).join(' - '),
-  }
-}
-
-function formatSavedTime(value: string | null) {
-  if (!value) {
-    return ''
-  }
-
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return ''
-  }
-
-  return new Intl.DateTimeFormat(undefined, {
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(date)
-}
 
 function getAndroidEditorStatus() {
   if (documentState.value.autosaveState === 'save-failed') {
@@ -245,32 +220,6 @@ function getAndroidExitPromptMessage() {
   }
 
   return 'MarkText could not save this file. Save a copy or keep a recovery draft before leaving.'
-}
-
-function getSuggestedMarkdownCopyFileName(
-  markdown: string,
-  displayName: string,
-  reservedNames: string[] = [],
-) {
-  const suggestedName = getSuggestedMarkdownFileName(markdown, displayName)
-  const extension = suggestedName.match(MARKDOWN_FILE_EXTENSION_REGEXP)?.[0] ?? '.md'
-  const baseName = suggestedName.slice(0, -extension.length) || 'Untitled'
-  const copySuffix = baseName.match(MARKDOWN_COPY_SUFFIX_REGEXP)
-  const copyBaseName = copySuffix
-    ? baseName.slice(0, copySuffix.index).trim() || 'Untitled'
-    : baseName
-  const firstCopyIndex = copySuffix ? Number(copySuffix[1] ?? '1') + 1 : 1
-  const normalizedReservedNames = new Set(reservedNames.map(name => name.toLocaleLowerCase()))
-
-  for (let index = firstCopyIndex; index < firstCopyIndex + 100; index += 1) {
-    const suffix = index === 1 ? 'copy' : `copy ${index}`
-    const candidate = `${copyBaseName} ${suffix}${extension}`
-    if (!normalizedReservedNames.has(candidate.toLocaleLowerCase())) {
-      return candidate
-    }
-  }
-
-  return `${copyBaseName} copy ${Date.now()}${extension}`
 }
 
 async function loadMuyaCore() {
@@ -393,24 +342,6 @@ function captureEditorSelection() {
   return range
 }
 
-function normalizeLinkField(value: string) {
-  return value.trim().replace(/\s+/g, ' ')
-}
-
-function escapeMarkdownLinkText(value: string) {
-  return normalizeLinkField(value).replace(/([\\[\]])/g, '\\$1')
-}
-
-function escapeMarkdownLinkUrl(value: string) {
-  return value.trim().replace(/\)/g, '\\)')
-}
-
-function buildMarkdownLink(text: string, url: string) {
-  const normalizedUrl = escapeMarkdownLinkUrl(url)
-  const normalizedText = escapeMarkdownLinkText(text || normalizedUrl)
-  return `[${normalizedText}](${normalizedUrl})`
-}
-
 function restorePendingLinkRange() {
   const selection = window.getSelection()
   if (!selection || !pendingInlineInsertRange) {
@@ -439,10 +370,6 @@ function openLinkSheet() {
   editorMenuOpen.value = false
   closeEditorToolbar()
   linkSheetOpen.value = true
-
-  void nextTick(() => {
-    linkUrlInput.value?.focus()
-  })
 }
 
 function closeLinkSheet() {
@@ -467,14 +394,6 @@ function insertLinkFromSheet() {
 
   closeLinkSheet()
   syncAfterToolbarCommand(beforeMarkdown)
-}
-
-function escapeMarkdownImageAlt(value: string) {
-  return value.replace(/[\r\n]+/g, ' ').replace(/]/g, '\\]').trim()
-}
-
-function buildMarkdownImage(alt: string, source: string) {
-  return `![${escapeMarkdownImageAlt(alt)}](${source})`
 }
 
 async function insertImageFromAndroidPicker() {
@@ -629,25 +548,12 @@ function clearAndroidDocumentSaveTimer() {
 
 function persistLocalDrafts(nextDrafts: LocalDraftRecord[]) {
   localDrafts.value = nextDrafts
-
-  if (nextDrafts.length > 0) {
-    localStorage.setItem(DRAFTS_STORAGE_KEY, serializeLocalDrafts(nextDrafts))
-  } else {
-    localStorage.removeItem(DRAFTS_STORAGE_KEY)
-  }
-
-  localStorage.removeItem(LEGACY_DRAFT_STORAGE_KEY)
+  writeStoredLocalDrafts(nextDrafts)
 }
 
 function persistAndroidRecentDocuments(nextDocuments: RecentDocumentRecord[]) {
-  const filteredDocuments = nextDocuments.filter(record => record.kind === 'android-document')
+  const filteredDocuments = writeStoredAndroidRecentDocuments(nextDocuments)
   androidRecentDocuments.value = filteredDocuments
-
-  if (filteredDocuments.length > 0) {
-    localStorage.setItem(RECENT_DOCUMENTS_STORAGE_KEY, serializeRecentDocuments(filteredDocuments))
-  } else {
-    localStorage.removeItem(RECENT_DOCUMENTS_STORAGE_KEY)
-  }
 }
 
 function getAndroidRecoveryDraftId(sourceUri: string) {
@@ -1698,11 +1604,9 @@ function discardLocalDraftAndShowHome() {
 onMounted(() => {
   appLog.info('app mounted')
   installAppLifecycleListeners()
-  const restoredDrafts = parseLocalDrafts(localStorage.getItem(DRAFTS_STORAGE_KEY))
-  const restoredRecentDocuments = parseRecentDocuments(
-    localStorage.getItem(RECENT_DOCUMENTS_STORAGE_KEY),
-  ).filter(record => record.kind === 'android-document')
-  const legacyDraft = localStorage.getItem(LEGACY_DRAFT_STORAGE_KEY)
+  const restoredDrafts = readStoredLocalDrafts()
+  const restoredRecentDocuments = readStoredAndroidRecentDocuments()
+  const legacyDraft = readLegacyDraft()
 
   androidRecentDocuments.value = restoredRecentDocuments
 
@@ -1919,55 +1823,13 @@ onBeforeUnmount(() => {
       </section>
     </Transition>
 
-    <section
+    <LinkInsertSheet
       v-if="linkSheetOpen"
-      class="draft-save-sheet"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="link-sheet-title"
-      data-testid="link-insert-sheet"
-      @keydown.esc="closeLinkSheet"
-    >
-      <form class="draft-save-panel link-insert-panel" @submit.prevent="insertLinkFromSheet">
-        <h2 id="link-sheet-title">Insert link</h2>
-        <label class="link-field">
-          <span>Text</span>
-          <input
-            v-model="linkText"
-            type="text"
-            autocomplete="off"
-            autocapitalize="sentences"
-            data-testid="link-text-input"
-          >
-        </label>
-        <label class="link-field">
-          <span>URL</span>
-          <input
-            ref="linkUrlInput"
-            v-model="linkUrl"
-            type="text"
-            inputmode="url"
-            autocomplete="url"
-            autocapitalize="none"
-            spellcheck="false"
-            data-testid="link-url-input"
-          >
-        </label>
-        <div class="draft-save-actions">
-          <button
-            class="primary-action"
-            type="submit"
-            data-testid="link-insert-button"
-            :disabled="!linkUrl.trim()"
-          >
-            Insert
-          </button>
-          <button type="button" data-testid="link-cancel-button" @click="closeLinkSheet">
-            Cancel
-          </button>
-        </div>
-      </form>
-    </section>
+      v-model:text="linkText"
+      v-model:url="linkUrl"
+      @cancel="closeLinkSheet"
+      @insert="insertLinkFromSheet"
+    />
 
     <section
       v-if="draftExitPromptOpen"

--- a/src/components/editor/LinkInsertSheet.vue
+++ b/src/components/editor/LinkInsertSheet.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref } from 'vue'
+
+const props = defineProps<{
+  text: string
+  url: string
+}>()
+
+const emit = defineEmits<{
+  cancel: []
+  insert: []
+  'update:text': [value: string]
+  'update:url': [value: string]
+}>()
+
+const linkUrlInput = ref<HTMLInputElement | null>(null)
+const canInsert = computed(() => props.url.trim().length > 0)
+const textValue = computed({
+  get: () => props.text,
+  set: value => emit('update:text', value),
+})
+const urlValue = computed({
+  get: () => props.url,
+  set: value => emit('update:url', value),
+})
+
+onMounted(() => {
+  void nextTick(() => {
+    linkUrlInput.value?.focus()
+  })
+})
+</script>
+
+<template>
+  <section
+    class="draft-save-sheet"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="link-sheet-title"
+    data-testid="link-insert-sheet"
+    @keydown.esc="emit('cancel')"
+  >
+    <form class="draft-save-panel link-insert-panel" @submit.prevent="emit('insert')">
+      <h2 id="link-sheet-title">Insert link</h2>
+      <label class="link-field">
+        <span>Text</span>
+        <input
+          v-model="textValue"
+          type="text"
+          autocomplete="off"
+          autocapitalize="sentences"
+          data-testid="link-text-input"
+        >
+      </label>
+      <label class="link-field">
+        <span>URL</span>
+        <input
+          ref="linkUrlInput"
+          v-model="urlValue"
+          type="text"
+          inputmode="url"
+          autocomplete="url"
+          autocapitalize="none"
+          spellcheck="false"
+          data-testid="link-url-input"
+        >
+      </label>
+      <div class="draft-save-actions">
+        <button
+          class="primary-action"
+          type="submit"
+          data-testid="link-insert-button"
+          :disabled="!canInsert"
+        >
+          Insert
+        </button>
+        <button type="button" data-testid="link-cancel-button" @click="emit('cancel')">
+          Cancel
+        </button>
+      </div>
+    </form>
+  </section>
+</template>

--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -3,6 +3,7 @@ import {
   createUntitledDocument,
   getDocumentStats,
   getDocumentTitle,
+  getSuggestedMarkdownCopyFileName,
   getSuggestedMarkdownFileName,
   normalizeMarkdownForEditor,
   prepareMarkdownForSave,
@@ -26,6 +27,20 @@ describe('documentState', () => {
 
   it('sanitizes suggested Markdown file names for Android document creation', () => {
     expect(getSuggestedMarkdownFileName('# Meeting: A/B?')).toBe('Meeting A B.md')
+  })
+
+  it('suggests a copy file name without changing the source Markdown title', () => {
+    expect(getSuggestedMarkdownCopyFileName('# Trip notes\n\nbody', 'draft.md')).toBe(
+      'Trip notes copy.md',
+    )
+  })
+
+  it('increments copy file names around reserved Android document names', () => {
+    expect(
+      getSuggestedMarkdownCopyFileName('plain text', 'Trip notes copy.md', [
+        'Trip notes copy 2.md',
+      ]),
+    ).toBe('Trip notes copy 3.md')
   })
 
   it('counts latin words and CJK characters for mobile status text', () => {

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -56,6 +56,7 @@ interface SaveDocumentOptions {
 
 const DEFAULT_UNTITLED_NAME = 'Untitled-1'
 const MARKDOWN_EXTENSION_REGEXP = /\.(markdown|mdown|mkdn|mkd|md)$/i
+const MARKDOWN_COPY_SUFFIX_REGEXP = /\s+copy(?:\s+(\d+))?$/
 const INVALID_FILENAME_CHARS_REGEXP = /[\\/:*?"<>|\r\n]+/g
 const LINE_ENDING_REGEXP = /\r\n|\r|\n/g
 
@@ -188,6 +189,32 @@ export function getSuggestedMarkdownFileName(markdown: string, displayName = DEF
 
   const safeName = baseName || 'Untitled'
   return MARKDOWN_EXTENSION_REGEXP.test(safeName) ? safeName : `${safeName}.md`
+}
+
+export function getSuggestedMarkdownCopyFileName(
+  markdown: string,
+  displayName = DEFAULT_UNTITLED_NAME,
+  reservedNames: string[] = [],
+) {
+  const suggestedName = getSuggestedMarkdownFileName(markdown, displayName)
+  const extension = suggestedName.match(MARKDOWN_EXTENSION_REGEXP)?.[0] ?? '.md'
+  const baseName = suggestedName.slice(0, -extension.length) || 'Untitled'
+  const copySuffix = baseName.match(MARKDOWN_COPY_SUFFIX_REGEXP)
+  const copyBaseName = copySuffix
+    ? baseName.slice(0, copySuffix.index).trim() || 'Untitled'
+    : baseName
+  const firstCopyIndex = copySuffix ? Number(copySuffix[1] ?? '1') + 1 : 1
+  const normalizedReservedNames = new Set(reservedNames.map(name => name.toLocaleLowerCase()))
+
+  for (let index = firstCopyIndex; index < firstCopyIndex + 100; index += 1) {
+    const suffix = index === 1 ? 'copy' : `copy ${index}`
+    const candidate = `${copyBaseName} ${suffix}${extension}`
+    if (!normalizedReservedNames.has(candidate.toLocaleLowerCase())) {
+      return candidate
+    }
+  }
+
+  return `${copyBaseName} copy ${Date.now()}${extension}`
 }
 
 export function createUntitledDocument(options: CreateDocumentOptions = {}): MarkdownDocumentState {

--- a/src/lib/documentStorage.test.ts
+++ b/src/lib/documentStorage.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ANDROID_RECENT_DOCUMENTS_STORAGE_KEY,
+  LEGACY_DRAFT_STORAGE_KEY,
+  LOCAL_DRAFTS_STORAGE_KEY,
+  readLegacyDraft,
+  readStoredAndroidRecentDocuments,
+  readStoredLocalDrafts,
+  writeStoredAndroidRecentDocuments,
+  writeStoredLocalDrafts,
+} from './documentStorage'
+import { createRecentDocumentFromLocalDraft } from './recentDocuments'
+import type { LocalDraftRecord } from './localDrafts'
+import type { RecentDocumentRecord } from './recentDocuments'
+
+class MemoryStorage {
+  private readonly values = new Map<string, string>()
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+}
+
+const localDraft: LocalDraftRecord = {
+  id: 'draft-1',
+  markdown: '# Draft\n\nbody',
+  updatedAt: '2026-06-29T00:01:00.000Z',
+  lastSavedAt: null,
+}
+
+const androidDocument: RecentDocumentRecord = {
+  id: 'android-document:content://provider/notes.md',
+  kind: 'android-document',
+  displayName: 'notes.md',
+  title: 'notes',
+  sourceUri: 'content://provider/notes.md',
+  providerName: 'Documents',
+  pathHint: 'Documents/notes.md',
+  markdownPreview: null,
+  updatedAt: '2026-06-29T00:02:00.000Z',
+  lastOpenedAt: '2026-06-29T00:02:00.000Z',
+  lastSavedAt: null,
+  autosaveState: 'clean',
+  canWrite: true,
+}
+
+describe('documentStorage', () => {
+  it('reads local drafts from the stable drafts key', () => {
+    const storage = new MemoryStorage()
+    storage.setItem(LOCAL_DRAFTS_STORAGE_KEY, JSON.stringify([localDraft]))
+
+    expect(readStoredLocalDrafts(storage)).toEqual([localDraft])
+  })
+
+  it('writes local drafts and clears the legacy draft key', () => {
+    const storage = new MemoryStorage()
+    storage.setItem(LEGACY_DRAFT_STORAGE_KEY, '# Legacy draft')
+
+    writeStoredLocalDrafts([localDraft], storage)
+
+    expect(readStoredLocalDrafts(storage)).toEqual([localDraft])
+    expect(readLegacyDraft(storage)).toBeNull()
+  })
+
+  it('removes the local drafts key and legacy key for an empty draft list', () => {
+    const storage = new MemoryStorage()
+    storage.setItem(LOCAL_DRAFTS_STORAGE_KEY, JSON.stringify([localDraft]))
+    storage.setItem(LEGACY_DRAFT_STORAGE_KEY, '# Legacy draft')
+
+    writeStoredLocalDrafts([], storage)
+
+    expect(storage.getItem(LOCAL_DRAFTS_STORAGE_KEY)).toBeNull()
+    expect(storage.getItem(LEGACY_DRAFT_STORAGE_KEY)).toBeNull()
+  })
+
+  it('reads only Android recent documents from the recent documents key', () => {
+    const storage = new MemoryStorage()
+    storage.setItem(
+      ANDROID_RECENT_DOCUMENTS_STORAGE_KEY,
+      JSON.stringify([createRecentDocumentFromLocalDraft(localDraft), androidDocument]),
+    )
+
+    expect(readStoredAndroidRecentDocuments(storage)).toEqual([androidDocument])
+  })
+
+  it('writes only Android recent documents and returns the stored records', () => {
+    const storage = new MemoryStorage()
+    const localRecentDocument = createRecentDocumentFromLocalDraft(localDraft)
+
+    const storedRecords = writeStoredAndroidRecentDocuments(
+      [localRecentDocument, androidDocument],
+      storage,
+    )
+
+    expect(storedRecords).toEqual([androidDocument])
+    expect(readStoredAndroidRecentDocuments(storage)).toEqual([androidDocument])
+  })
+
+  it('removes the Android recent documents key when no Android records remain', () => {
+    const storage = new MemoryStorage()
+    storage.setItem(ANDROID_RECENT_DOCUMENTS_STORAGE_KEY, JSON.stringify([androidDocument]))
+
+    writeStoredAndroidRecentDocuments([createRecentDocumentFromLocalDraft(localDraft)], storage)
+
+    expect(storage.getItem(ANDROID_RECENT_DOCUMENTS_STORAGE_KEY)).toBeNull()
+  })
+})

--- a/src/lib/documentStorage.ts
+++ b/src/lib/documentStorage.ts
@@ -1,0 +1,68 @@
+import {
+  parseLocalDrafts,
+  serializeLocalDrafts,
+  type LocalDraftRecord,
+} from './localDrafts'
+import {
+  parseRecentDocuments,
+  serializeRecentDocuments,
+  type RecentDocumentRecord,
+} from './recentDocuments'
+
+export const LEGACY_DRAFT_STORAGE_KEY = 'marktext-for-android:draft'
+export const LOCAL_DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
+export const ANDROID_RECENT_DOCUMENTS_STORAGE_KEY =
+  'marktext-for-android:recent-documents'
+
+interface DocumentStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+export function readStoredLocalDrafts(storage: DocumentStorage = localStorage) {
+  return parseLocalDrafts(storage.getItem(LOCAL_DRAFTS_STORAGE_KEY))
+}
+
+export function writeStoredLocalDrafts(
+  records: LocalDraftRecord[],
+  storage: DocumentStorage = localStorage,
+) {
+  if (records.length > 0) {
+    storage.setItem(LOCAL_DRAFTS_STORAGE_KEY, serializeLocalDrafts(records))
+  } else {
+    storage.removeItem(LOCAL_DRAFTS_STORAGE_KEY)
+  }
+
+  storage.removeItem(LEGACY_DRAFT_STORAGE_KEY)
+}
+
+export function readLegacyDraft(storage: DocumentStorage = localStorage) {
+  return storage.getItem(LEGACY_DRAFT_STORAGE_KEY)
+}
+
+export function readStoredAndroidRecentDocuments(
+  storage: DocumentStorage = localStorage,
+) {
+  return parseRecentDocuments(storage.getItem(ANDROID_RECENT_DOCUMENTS_STORAGE_KEY)).filter(
+    record => record.kind === 'android-document',
+  )
+}
+
+export function writeStoredAndroidRecentDocuments(
+  records: RecentDocumentRecord[],
+  storage: DocumentStorage = localStorage,
+) {
+  const androidDocuments = records.filter(record => record.kind === 'android-document')
+
+  if (androidDocuments.length > 0) {
+    storage.setItem(
+      ANDROID_RECENT_DOCUMENTS_STORAGE_KEY,
+      serializeRecentDocuments(androidDocuments),
+    )
+  } else {
+    storage.removeItem(ANDROID_RECENT_DOCUMENTS_STORAGE_KEY)
+  }
+
+  return androidDocuments
+}

--- a/src/lib/editorMarkdownInsert.test.ts
+++ b/src/lib/editorMarkdownInsert.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildMarkdownImage,
+  buildMarkdownLink,
+  normalizeLinkField,
+} from './editorMarkdownInsert'
+
+describe('editorMarkdownInsert', () => {
+  it('normalizes selected link text for the mobile insert sheet', () => {
+    expect(normalizeLinkField('  MarkText\n  for\tAndroid  ')).toBe('MarkText for Android')
+  })
+
+  it('escapes Markdown link text and URL delimiters', () => {
+    expect(buildMarkdownLink('MarkText [Android]', 'https://example.com/a)b')).toBe(
+      '[MarkText \\[Android\\]](https://example.com/a\\)b)',
+    )
+  })
+
+  it('uses the URL as link text when the label is empty', () => {
+    expect(buildMarkdownLink('', ' https://example.com/docs ')).toBe(
+      '[https://example.com/docs](https://example.com/docs)',
+    )
+  })
+
+  it('builds image Markdown with a single-line escaped alt label', () => {
+    expect(buildMarkdownImage('Picked\nicon]', 'marktext-image://local/icon.png')).toBe(
+      '![Picked icon\\]](marktext-image://local/icon.png)',
+    )
+  })
+})

--- a/src/lib/editorMarkdownInsert.ts
+++ b/src/lib/editorMarkdownInsert.ts
@@ -1,0 +1,25 @@
+export function normalizeLinkField(value: string) {
+  return value.trim().replace(/\s+/g, ' ')
+}
+
+function escapeMarkdownLinkText(value: string) {
+  return normalizeLinkField(value).replace(/([\\[\]])/g, '\\$1')
+}
+
+function escapeMarkdownLinkUrl(value: string) {
+  return value.trim().replace(/\)/g, '\\)')
+}
+
+export function buildMarkdownLink(text: string, url: string) {
+  const normalizedUrl = escapeMarkdownLinkUrl(url)
+  const normalizedText = escapeMarkdownLinkText(text || normalizedUrl)
+  return `[${normalizedText}](${normalizedUrl})`
+}
+
+function escapeMarkdownImageAlt(value: string) {
+  return value.replace(/[\r\n]+/g, ' ').replace(/]/g, '\\]').trim()
+}
+
+export function buildMarkdownImage(alt: string, source: string) {
+  return `![${escapeMarkdownImageAlt(alt)}](${source})`
+}

--- a/src/lib/homeDocuments.test.ts
+++ b/src/lib/homeDocuments.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { formatHomeDocumentSavedTime, toHomeDocumentItem } from './homeDocuments'
+import type { RecentDocumentListItem } from './recentDocuments'
+
+describe('homeDocuments', () => {
+  it('omits invalid saved times from document list details', () => {
+    const item: RecentDocumentListItem = {
+      id: 'draft-1',
+      kind: 'local-draft',
+      displayName: 'draft.md',
+      title: 'Draft',
+      sourceUri: null,
+      providerName: 'Local draft',
+      pathHint: null,
+      markdownPreview: '# Draft',
+      updatedAt: 'not-a-date',
+      lastOpenedAt: 'not-a-date',
+      lastSavedAt: null,
+      autosaveState: 'clean',
+      canWrite: true,
+      stats: {
+        words: 1,
+        characters: 7,
+        lines: 1,
+      },
+    }
+
+    expect(toHomeDocumentItem(item)).toEqual({
+      id: 'draft-1',
+      title: 'Draft',
+      details: 'Local draft - 1 word',
+    })
+  })
+
+  it('formats empty saved times as blank text', () => {
+    expect(formatHomeDocumentSavedTime(null)).toBe('')
+    expect(formatHomeDocumentSavedTime('not-a-date')).toBe('')
+  })
+})

--- a/src/lib/homeDocuments.ts
+++ b/src/lib/homeDocuments.ts
@@ -1,5 +1,35 @@
+import type { RecentDocumentListItem } from './recentDocuments'
+
 export interface HomeDocumentItem {
   id: string
   title: string
   details: string
+}
+
+export function formatHomeDocumentSavedTime(value: string | null) {
+  if (!value) {
+    return ''
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+export function toHomeDocumentItem(item: RecentDocumentListItem): HomeDocumentItem {
+  const savedAt = formatHomeDocumentSavedTime(item.lastSavedAt ?? item.updatedAt)
+  const count = item.stats ? `${item.stats.words} ${item.stats.words === 1 ? 'word' : 'words'}` : ''
+  const source = item.providerName ?? 'Markdown document'
+
+  return {
+    id: item.id,
+    title: item.title,
+    details: [source, savedAt, count].filter(Boolean).join(' - '),
+  }
 }


### PR DESCRIPTION
## Summary
- Level 1: extract pure App.vue helpers for markdown link/image insertion, suggested copy filenames, and home document mapping into focused lib modules with unit coverage.
- Level 2: add a narrow documentStorage boundary for local draft, legacy draft, and Android recent document localStorage access without changing keys or stored JSON shape.
- Level 3: extract the link insert sheet into a presentational component while keeping editor selection, insertion, and persistence side effects in App.vue.

## Verification
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm test:e2e

## Risk controls
- No storage key changes.
- No stored JSON shape changes.
- No autosave, recovery, Android document, or markdown render/save behavior changes intended.
- Refactor order follows low-to-higher risk levels and keeps side effects owned by App.vue for this PR.