### PR TITLE
refactor: finish app workflow boundaries

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { App } from '@capacitor/app'
-import type { PluginListenerHandle } from '@capacitor/core'
 import AndroidExitPrompt from './components/editor/AndroidExitPrompt.vue'
 import EditorActionSheet from './components/editor/EditorActionSheet.vue'
 import LinkInsertSheet from './components/editor/LinkInsertSheet.vue'
@@ -9,8 +8,6 @@ import LocalDraftExitPrompt from './components/editor/LocalDraftExitPrompt.vue'
 import HomeShell from './components/HomeShell.vue'
 import MobileEditorToolbar from './components/MobileEditorToolbar.vue'
 import {
-  addAndroidOpenWithDocumentListener,
-  addAndroidShareDocumentListener,
   createAndroidMarkdownDocument,
   getAndroidDocumentErrorCode,
   getAndroidDocumentUserMessage,
@@ -31,25 +28,65 @@ import {
   pickAndroidImageDocument,
 } from './lib/androidImages'
 import {
+  installAppLifecycleListeners as installAppLifecycleListenerHandles,
+  type AppLifecycleListeners,
+} from './lib/appLifecycleListeners'
+import {
+  installAndroidDocumentIntentListeners as installAndroidDocumentIntentListenerHandles,
+  type AndroidDocumentIntentListeners,
+} from './lib/androidDocumentIntentListeners'
+import {
+  createAndroidRecoveryDraft,
+  getAndroidRecoveryDraftId,
+} from './lib/androidRecoveryDrafts'
+import {
+  applyAndroidDocumentAutosaveFailure,
+  applyAndroidDocumentAutosaveSuccess,
+  canApplyAndroidDocumentAutosaveSuccess,
+  createAndroidDocumentAutosaveRequest,
+} from './lib/androidDocumentAutosave'
+import {
+  markSavedAndroidRecentDocument,
+  rememberAndroidRecentDocument,
+} from './lib/androidRecentDocuments'
+import {
   createUntitledDocument,
-  getSuggestedMarkdownCopyFileName,
-  getSuggestedMarkdownFileName,
-  markDocumentSaved,
   markDocumentSaveFailed,
-  markDocumentSaving,
-  prepareMarkdownForSave,
   updateDocumentMarkdown,
 } from './lib/documentState'
+import {
+  createDocumentStateFromLocalDraft,
+} from './lib/documentSessionState'
+import {
+  createAndroidDocumentOpenResult,
+  createAndroidOpenWithDocumentEventAction,
+  createAndroidShareDocumentEventAction,
+  createSharedTextDocumentOpenResult,
+  getIncomingDocumentPreservationAction,
+  openAndroidMarkdownDocumentWorkflow,
+  shouldKeepAndroidRecoveryAfterPreserveFailure,
+  type AndroidDocumentOpenSource,
+} from './lib/androidDocumentOpenWorkflow'
+import { saveAndroidDocumentCopyWorkflow } from './lib/saveAndroidDocumentCopyWorkflow'
+import { saveLocalDraftToAndroidDocumentWorkflow } from './lib/saveLocalDraftToAndroidDocumentWorkflow'
+import { shareAndroidMarkdownDocumentWorkflow } from './lib/shareAndroidMarkdownDocumentWorkflow'
 import {
   buildMarkdownImage,
   buildMarkdownLink,
   normalizeLinkField,
 } from './lib/editorMarkdownInsert'
 import {
+  captureSelectionWithin,
+  insertTextAtRestoredSelection,
+  resolveEditorDomNode,
+} from './lib/editorInlineInsert'
+import { createMuyaEditor, destroyMuyaEditor, type MuyaEditor } from './lib/editorRuntime'
+import {
   removeLocalDraft,
   upsertLocalDraft,
   type LocalDraftRecord,
 } from './lib/localDrafts'
+import { createLocalDraftAutosaveResult } from './lib/localDraftAutosave'
 import {
   readLegacyDraft,
   readStoredAndroidRecentDocuments,
@@ -77,11 +114,8 @@ import {
 } from './lib/settingsNavigation'
 import { createMuyaMobileEditorCommandTarget } from './lib/muyaMobileAdapter'
 import {
-  createRecentDocumentFromAndroidDocument,
   createRecentDocumentFromLocalDraft,
   getRecentDocumentListItems,
-  markRecentDocumentSaved,
-  upsertRecentDocument,
   type RecentDocumentRecord,
 } from './lib/recentDocuments'
 
@@ -94,13 +128,9 @@ const OPEN_WITH_TEMPORARY_ACCESS_MESSAGE =
 const SHARE_TEMPORARY_ACCESS_MESSAGE =
   'Opened from Android share with temporary access. Save a copy to keep editing later.'
 const SHARED_TEXT_IMPORTED_MESSAGE = 'Imported shared text as a local draft.'
-const ANDROID_RECOVERY_DRAFT_PREFIX = 'android-recovery:'
 const ANDROID_SAVE_RECOVERY_MESSAGE = 'Save failed. A local recovery draft was kept.'
 const ANDROID_EXIT_RECOVERY_MESSAGE = 'Unsaved changes were kept as a recovery draft.'
 const ANDROID_EXIT_DISCARD_MESSAGE = 'Unsaved changes were discarded.'
-
-type MuyaCoreModule = typeof import('@muyajs/core')
-type MuyaEditor = InstanceType<MuyaCoreModule['Muya']>
 
 const editorElement = ref<HTMLElement | null>(null)
 const documentState = ref(createUntitledDocument())
@@ -128,16 +158,14 @@ const sharingCurrentDocument = ref(false)
 const importingAndroidImage = ref(false)
 
 let editor: MuyaEditor | null = null
-let muyaCore: MuyaCoreModule | null = null
 let editorInitToken = 0
 let lastContentLogAt = 0
 let draftSaveTimer: number | null = null
 let androidSaveTimer: number | null = null
 let androidSaveInFlight = false
 let androidSaveRequestedAfterCurrent = false
-let appLifecycleListenerHandles: PluginListenerHandle[] = []
-let androidDocumentListenerHandles: PluginListenerHandle[] = []
-let browserLifecycleListenersInstalled = false
+let appLifecycleListeners: AppLifecycleListeners | null = null
+let androidDocumentIntentListeners: AndroidDocumentIntentListeners | null = null
 let pendingInlineInsertRange: Range | null = null
 
 const appLog = createLogger('app')
@@ -225,61 +253,6 @@ function getAndroidExitPromptMessage() {
   return 'MarkText could not save this file. Save a copy or keep a recovery draft before leaving.'
 }
 
-async function loadMuyaCore() {
-  if (!muyaCore) {
-    muyaCore = await import('@muyajs/core')
-  }
-
-  return muyaCore
-}
-
-async function registerMuyaPlugins() {
-  const core = await loadMuyaCore()
-  const editorPlugins = [
-    core.InlineFormatToolbar,
-    core.PreviewToolBar,
-    core.CodeBlockLanguageSelector,
-    core.EmojiSelector,
-  ] as const
-
-  editorLog.debug('register Muya plugins start', { count: editorPlugins.length })
-  for (const plugin of editorPlugins) {
-    if (!core.Muya.plugins.some(entry => entry.plugin === plugin)) {
-      core.Muya.use(plugin)
-    }
-  }
-  editorLog.debug('register Muya plugins complete', { registered: core.Muya.plugins.length })
-  return core
-}
-
-function createDocumentFromDraft(draft: LocalDraftRecord) {
-  return {
-    ...createUntitledDocument({
-      markdown: draft.markdown,
-      autosaveTarget: 'local-draft',
-      now: draft.updatedAt,
-    }),
-    id: draft.id,
-    lastSavedAt: draft.lastSavedAt,
-    updatedAt: draft.updatedAt,
-  }
-}
-
-function createDocumentFromAndroidDocument(document: OpenedAndroidDocument) {
-  const openedDocument = createUntitledDocument({
-    markdown: document.markdown,
-    displayName: document.displayName,
-    sourceUri: document.sourceUri,
-    autosaveTarget: 'android-document',
-  })
-
-  return {
-    ...openedDocument,
-    id: `android-document:${document.sourceUri}`,
-    lastSavedAt: null,
-  }
-}
-
 function normalizeEditorMarkdown(markdown: string) {
   return markdown === '\n' ? '' : markdown
 }
@@ -326,40 +299,13 @@ function getEditorCommandTarget(): MobileEditorCommandTarget | null {
   return createMuyaMobileEditorCommandTarget(editor)
 }
 
-function getEditorDomNode() {
-  return (editor as { domNode?: HTMLElement } | null)?.domNode ?? editorElement.value
-}
-
 function captureEditorSelection() {
-  const selection = window.getSelection()
-  if (!selection || selection.rangeCount === 0) {
-    return null
-  }
-
-  const range = selection.getRangeAt(0).cloneRange()
-  const editorDomNode = getEditorDomNode()
-  if (editorDomNode && !editorDomNode.contains(range.commonAncestorContainer)) {
-    return null
-  }
-
-  return range
-}
-
-function restorePendingLinkRange() {
-  const selection = window.getSelection()
-  if (!selection || !pendingInlineInsertRange) {
-    return false
-  }
-
-  selection.removeAllRanges()
-  selection.addRange(pendingInlineInsertRange)
-  return true
+  return captureSelectionWithin(resolveEditorDomNode(editor, editorElement.value))
 }
 
 function insertMarkdownAtPendingSelection(markdown: string) {
   editor?.focus()
-  restorePendingLinkRange()
-  return document.execCommand('insertText', false, markdown)
+  return insertTextAtRestoredSelection(markdown, pendingInlineInsertRange)
 }
 
 function openLinkSheet() {
@@ -559,24 +505,13 @@ function persistAndroidRecentDocuments(nextDocuments: RecentDocumentRecord[]) {
   androidRecentDocuments.value = filteredDocuments
 }
 
-function getAndroidRecoveryDraftId(sourceUri: string) {
-  return `${ANDROID_RECOVERY_DRAFT_PREFIX}${sourceUri}`
-}
-
 function persistAndroidRecoveryDraft(sourceUri: string, markdown: string) {
-  if (!markdown.trim()) {
+  const recoveryDraft = createAndroidRecoveryDraft(sourceUri, markdown, new Date().toISOString())
+  if (!recoveryDraft) {
     return
   }
 
-  const now = new Date().toISOString()
-  persistLocalDrafts(
-    upsertLocalDraft(localDrafts.value, {
-      id: getAndroidRecoveryDraftId(sourceUri),
-      markdown,
-      updatedAt: now,
-      lastSavedAt: null,
-    }),
-  )
+  persistLocalDrafts(upsertLocalDraft(localDrafts.value, recoveryDraft))
   draftLog.warn('kept Android document edits as a local recovery draft', {
     sourceUri,
     characters: markdown.length,
@@ -596,22 +531,17 @@ function markAndroidRecentDocumentSaved(savedAt: string) {
     return
   }
 
-  const existingDocument = androidRecentDocuments.value.find(record => record.sourceUri === sourceUri)
-  if (!existingDocument) {
+  const nextDocuments = markSavedAndroidRecentDocument(androidRecentDocuments.value, sourceUri, {
+    markdown: documentState.value.markdown,
+    savedAt,
+    canWrite: currentAndroidDocumentCanWrite.value,
+  })
+  if (!nextDocuments) {
     androidDocumentLog.warn('saved Android recent document not found', { sourceUri })
     return
   }
 
-  persistAndroidRecentDocuments(
-    upsertRecentDocument(
-      androidRecentDocuments.value,
-      markRecentDocumentSaved(existingDocument, {
-        markdown: documentState.value.markdown,
-        savedAt,
-        canWrite: currentAndroidDocumentCanWrite.value,
-      }),
-    ),
-  )
+  persistAndroidRecentDocuments(nextDocuments)
   removeAndroidRecoveryDraft(sourceUri)
 }
 
@@ -650,37 +580,31 @@ async function saveAndroidDocument() {
   }
 
   const value = normalizeEditorMarkdown(editor.getMarkdown())
-  const nextDocument = updateDocumentMarkdown(documentState.value, value, {
-    markDirty: documentState.value.isDirty,
-  })
-  const markdownForSave = prepareMarkdownForSave(nextDocument.markdown, nextDocument)
-  const saveMarkdown = nextDocument.markdown
+  const autosaveRequest = createAndroidDocumentAutosaveRequest(documentState.value, value)
 
   androidSaveInFlight = true
-  documentState.value = markDocumentSaving(nextDocument)
+  documentState.value = autosaveRequest.savingDocument
   status.value = 'Saving'
 
   try {
-    await writeAndroidMarkdownDocument(sourceUri, markdownForSave)
+    await writeAndroidMarkdownDocument(sourceUri, autosaveRequest.markdownForSave)
     const savedAt = new Date().toISOString()
 
-    if (
-      documentState.value.autosaveTarget === 'android-document' &&
-      documentState.value.sourceUri === sourceUri &&
-      documentState.value.markdown === saveMarkdown
-    ) {
-      documentState.value = markDocumentSaved(
-        updateDocumentMarkdown(documentState.value, saveMarkdown, {
-          markDirty: false,
-          now: savedAt,
-        }),
-        { autosaveTarget: 'android-document', now: savedAt },
+    if (canApplyAndroidDocumentAutosaveSuccess(
+      documentState.value,
+      sourceUri,
+      autosaveRequest.saveMarkdown,
+    )) {
+      documentState.value = applyAndroidDocumentAutosaveSuccess(
+        documentState.value,
+        autosaveRequest.saveMarkdown,
+        savedAt,
       )
       markAndroidRecentDocumentSaved(savedAt)
       status.value = 'Saved'
       androidDocumentLog.info('Android document autosaved', {
         sourceUri,
-        characters: saveMarkdown.length,
+        characters: autosaveRequest.saveMarkdown.length,
       })
       return true
     } else {
@@ -691,8 +615,8 @@ async function saveAndroidDocument() {
       return false
     }
   } catch (error) {
-    documentState.value = markDocumentSaveFailed(documentState.value, error)
-    persistAndroidRecoveryDraft(sourceUri, saveMarkdown)
+    documentState.value = applyAndroidDocumentAutosaveFailure(documentState.value, error)
+    persistAndroidRecoveryDraft(sourceUri, autosaveRequest.saveMarkdown)
     status.value = `${getAndroidDocumentUserMessage(error)} ${ANDROID_SAVE_RECOVERY_MESSAGE}`
     androidDocumentLog.error('Android document autosave failed', {
       sourceUri,
@@ -723,84 +647,64 @@ async function saveLocalDraftToAndroidDocument(options: { returnHomeAfterSave?: 
 
   saveDraft()
   const draftDocument = syncDocumentFromEditor(false)
-  if (!draftDocument.markdown.trim()) {
-    status.value = 'Ready'
-    return false
-  }
 
   const reopenPromptOnCancel = draftExitPromptOpen.value && options.returnHomeAfterSave === true
   draftExitPromptOpen.value = false
   savingLocalDraftToAndroid.value = true
   status.value = 'Choose a location'
 
+  const result = await saveLocalDraftToAndroidDocumentWorkflow({
+    draftDocument,
+    returnHomeAfterSave: options.returnHomeAfterSave === true,
+    reopenPromptOnCancel,
+    transientAccessMessage: TRANSIENT_ANDROID_DOCUMENT_MESSAGE,
+    createAndroidMarkdownDocument,
+    getAndroidDocumentUserMessage,
+    logger: androidDocumentLog,
+  })
+
   try {
-    const markdownForSave = prepareMarkdownForSave(draftDocument.markdown, draftDocument)
-    const suggestedName = getSuggestedMarkdownFileName(
-      draftDocument.markdown,
-      draftDocument.displayName,
-    )
-    const document = await createAndroidMarkdownDocument(markdownForSave, suggestedName)
-    if (document.canceled) {
-      status.value = 'Autosaved locally'
-      if (reopenPromptOnCancel) {
-        draftExitPromptOpen.value = true
-      }
-      androidDocumentLog.info('Android document create canceled')
+    if (result.kind === 'empty') {
+      status.value = result.status
       return false
     }
 
-    const savedAt = new Date().toISOString()
-    const createdDocument = {
-      ...document,
-      markdown: draftDocument.markdown,
+    if (result.kind === 'canceled') {
+      status.value = result.status
+      if (reopenPromptOnCancel) {
+        draftExitPromptOpen.value = true
+      }
+      return false
     }
 
-    if (!document.persisted) {
-      status.value = TRANSIENT_ANDROID_DOCUMENT_MESSAGE
-      homeNotice.value = TRANSIENT_ANDROID_DOCUMENT_MESSAGE
+    if (result.kind === 'transient') {
+      status.value = result.status
+      homeNotice.value = result.homeNotice
       currentAndroidDocumentCanWrite.value = false
-      androidDocumentLog.warn('created Android document without persisted access; kept local draft', {
-        displayName: document.displayName,
-        sourceUri: document.sourceUri,
-        characters: draftDocument.markdown.length,
-      })
-
-      if (options.returnHomeAfterSave) {
+      if (result.closeEditorToHome) {
         closeEditorToHome()
       }
       return false
     }
 
-    persistLocalDrafts(removeLocalDraft(localDrafts.value, draftDocument.id))
-    rememberAndroidDocument(createdDocument)
-    currentAndroidDocumentCanWrite.value = document.canWrite
-    promptLocalDraftSaveOnExit.value = false
-    documentState.value = markDocumentSaved(
-      {
-        ...createDocumentFromAndroidDocument(createdDocument),
-        updatedAt: savedAt,
-        lastSavedAt: savedAt,
-      },
-      { autosaveTarget: 'android-document', now: savedAt },
-    )
-    status.value = getAndroidEditorStatus()
-    androidDocumentLog.info('local draft saved as Android document', {
-      displayName: document.displayName,
-      sourceUri: document.sourceUri,
-      characters: draftDocument.markdown.length,
-    })
-
-    if (options.returnHomeAfterSave) {
-      closeEditorToHome()
+    if (result.kind === 'saved') {
+      persistLocalDrafts(removeLocalDraft(localDrafts.value, result.removeLocalDraftId))
+      rememberAndroidDocument(result.createdDocument)
+      currentAndroidDocumentCanWrite.value = result.canWrite
+      promptLocalDraftSaveOnExit.value = false
+      documentState.value = result.savedDocument
+      status.value = getAndroidEditorStatus()
+      if (result.closeEditorToHome) {
+        closeEditorToHome()
+      }
+      return true
     }
-    return true
-  } catch (error) {
-    documentState.value = markDocumentSaveFailed(documentState.value, error)
-    status.value = getAndroidDocumentUserMessage(error)
-    if (reopenPromptOnCancel) {
+
+    documentState.value = result.failedDocument
+    status.value = result.status
+    if (result.reopenPrompt) {
       draftExitPromptOpen.value = true
     }
-    androidDocumentLog.error('local draft save to Android document failed', error)
     return false
   } finally {
     savingLocalDraftToAndroid.value = false
@@ -816,82 +720,56 @@ async function saveAndroidDocumentCopy(options: { returnHomeAfterSave?: boolean 
 
   const originalSourceUri = documentState.value.sourceUri
   const copySourceDocument = syncDocumentFromEditor(documentState.value.isDirty)
-  const markdownForSave = prepareMarkdownForSave(copySourceDocument.markdown, copySourceDocument)
-  const suggestedName = getSuggestedMarkdownCopyFileName(
-    copySourceDocument.markdown,
-    copySourceDocument.displayName,
-    androidRecentDocuments.value.map(document => document.displayName),
-  )
 
   savingAndroidDocumentCopy.value = true
   status.value = 'Choose a location'
 
   try {
-    const document = await createAndroidMarkdownDocument(markdownForSave, suggestedName)
-    if (document.canceled) {
+    const result = await saveAndroidDocumentCopyWorkflow({
+      copySourceDocument,
+      originalSourceUri,
+      reservedDisplayNames: androidRecentDocuments.value.map(document => document.displayName),
+      returnHomeAfterSave: options.returnHomeAfterSave === true,
+      transientAccessMessage: TRANSIENT_ANDROID_DOCUMENT_MESSAGE,
+      createAndroidMarkdownDocument,
+      getAndroidDocumentUserMessage,
+      logger: androidDocumentLog,
+    })
+
+    if (result.kind === 'canceled') {
       status.value = getAndroidEditorStatus()
-      androidDocumentLog.info('Android document save copy canceled', {
-        sourceUri: originalSourceUri,
-      })
       return false
     }
 
-    const savedAt = new Date().toISOString()
-    const createdDocument = {
-      ...document,
-      markdown: copySourceDocument.markdown,
-    }
-
-    if (!document.persisted) {
-      if (originalSourceUri && copySourceDocument.isDirty) {
-        persistAndroidRecoveryDraft(originalSourceUri, copySourceDocument.markdown)
+    if (result.kind === 'transient') {
+      if (result.recoveryDraft) {
+        persistAndroidRecoveryDraft(result.recoveryDraft.sourceUri, result.recoveryDraft.markdown)
       }
-      status.value = TRANSIENT_ANDROID_DOCUMENT_MESSAGE
-      androidDocumentLog.warn('saved Android document copy without persisted access', {
-        originalSourceUri,
-        displayName: document.displayName,
-        sourceUri: document.sourceUri,
-        characters: copySourceDocument.markdown.length,
-      })
+      status.value = result.status
       return false
     }
 
-    if (originalSourceUri) {
-      removeAndroidRecoveryDraft(originalSourceUri)
+    if (result.kind === 'saved') {
+      if (result.removeRecoveryDraftSourceUri) {
+        removeAndroidRecoveryDraft(result.removeRecoveryDraftSourceUri)
+      }
+      rememberAndroidDocument(result.createdDocument)
+      currentAndroidDocumentCanWrite.value = result.canWrite
+      promptLocalDraftSaveOnExit.value = false
+      documentState.value = result.savedDocument
+      status.value = getAndroidEditorStatus()
+      androidExitPromptOpen.value = false
+      if (result.closeEditorToHome) {
+        closeEditorToHome()
+      }
+      return true
     }
-    rememberAndroidDocument(createdDocument)
-    currentAndroidDocumentCanWrite.value = document.canWrite
-    promptLocalDraftSaveOnExit.value = false
-    documentState.value = markDocumentSaved(
-      {
-        ...createDocumentFromAndroidDocument(createdDocument),
-        updatedAt: savedAt,
-        lastSavedAt: savedAt,
-      },
-      { autosaveTarget: 'android-document', now: savedAt },
-    )
-    status.value = getAndroidEditorStatus()
-    androidDocumentLog.info('Android document saved as copy', {
-      originalSourceUri,
-      displayName: document.displayName,
-      sourceUri: document.sourceUri,
-      characters: copySourceDocument.markdown.length,
-    })
-    androidExitPromptOpen.value = false
-    if (options.returnHomeAfterSave) {
-      closeEditorToHome()
+
+    if (result.recoveryDraft) {
+      persistAndroidRecoveryDraft(result.recoveryDraft.sourceUri, result.recoveryDraft.markdown)
     }
-    return true
-  } catch (error) {
-    if (originalSourceUri && copySourceDocument.isDirty) {
-      persistAndroidRecoveryDraft(originalSourceUri, copySourceDocument.markdown)
-    }
-    documentState.value = markDocumentSaveFailed(documentState.value, error)
-    status.value = getAndroidDocumentUserMessage(error)
-    androidDocumentLog.error('Android document save copy failed', {
-      originalSourceUri,
-      error,
-    })
+    documentState.value = result.failedDocument
+    status.value = result.status
     return false
   } finally {
     savingAndroidDocumentCopy.value = false
@@ -910,30 +788,19 @@ async function shareCurrentMarkdownDocument() {
     saveDraft()
   }
 
-  const markdownForShare = prepareMarkdownForSave(currentDocument.markdown, currentDocument)
-  const suggestedName = getSuggestedMarkdownFileName(
-    currentDocument.markdown,
-    currentDocument.displayName,
-  )
-
   sharingCurrentDocument.value = true
   status.value = 'Sharing'
 
   try {
-    const result = await shareAndroidMarkdownDocument(markdownForShare, suggestedName)
-    status.value = 'Share sheet opened'
-    androidDocumentLog.info('Android share sheet opened', {
-      displayName: result.displayName,
-      bytes: result.bytes,
-      imageCount: result.imageCount,
-      sharedFileCount: result.sharedFileCount,
-      autosaveTarget: currentDocument.autosaveTarget,
+    const result = await shareAndroidMarkdownDocumentWorkflow({
+      currentDocument,
+      shareAndroidMarkdownDocument,
+      getAndroidDocumentUserMessage,
+      logger: androidDocumentLog,
     })
-    return true
-  } catch (error) {
-    status.value = getAndroidDocumentUserMessage(error)
-    androidDocumentLog.error('Android share failed', error)
-    return false
+
+    status.value = result.status
+    return result.kind === 'shared'
   } finally {
     sharingCurrentDocument.value = false
   }
@@ -956,32 +823,17 @@ function saveDraft() {
   }
 
   const value = normalizeEditorMarkdown(editor.getMarkdown())
-  const hasContent = value.trim().length > 0
-  documentState.value = markDocumentSaving(
-    updateDocumentMarkdown(documentState.value, value, { markDirty: documentState.value.isDirty }),
+  const localDraftAutosave = createLocalDraftAutosaveResult(
+    documentState.value,
+    value,
+    localDrafts.value,
   )
+  documentState.value = localDraftAutosave.savingDocument
 
   try {
-    const savedDocument = markDocumentSaved(
-      updateDocumentMarkdown(documentState.value, value, { markDirty: false }),
-      { autosaveTarget: 'local-draft' },
-    )
-
-    if (hasContent) {
-      persistLocalDrafts(
-        upsertLocalDraft(localDrafts.value, {
-          id: savedDocument.id,
-          markdown: savedDocument.markdown,
-          updatedAt: savedDocument.updatedAt,
-          lastSavedAt: savedDocument.lastSavedAt,
-        }),
-      )
-    } else {
-      persistLocalDrafts(removeLocalDraft(localDrafts.value, savedDocument.id))
-    }
-
-    documentState.value = savedDocument
-    status.value = hasContent ? 'Autosaved locally' : 'Ready'
+    persistLocalDrafts(localDraftAutosave.nextDrafts)
+    documentState.value = localDraftAutosave.savedDocument
+    status.value = localDraftAutosave.hasContent ? 'Autosaved locally' : 'Ready'
     draftLog.debug('local draft saved', {
       characters: characterCount.value,
       words: wordCount.value,
@@ -995,7 +847,8 @@ function saveDraft() {
 }
 
 async function initEditor(initialMarkdown: string) {
-  if (!editorElement.value) {
+  const element = editorElement.value
+  if (!element) {
     return
   }
 
@@ -1006,45 +859,34 @@ async function initEditor(initialMarkdown: string) {
     } catch (error) {
       editorLog.warn('Android image resolver unavailable during editor init', error)
     }
-    const { Muya, en } = await registerMuyaPlugins()
-    if (token !== editorInitToken || !editorElement.value) {
+    const nextEditor = await createMuyaEditor({
+      element,
+      markdown: initialMarkdown,
+      onContentChange: syncMarkdown,
+      onJsonChange: syncMarkdown,
+      onFocus: () => {
+        status.value =
+          documentState.value.autosaveTarget === 'android-document' &&
+          !currentAndroidDocumentCanWrite.value
+            ? 'Read only'
+            : 'Editing'
+        editorLog.debug('editor focused')
+      },
+      onBlur: () => {
+        status.value =
+          documentState.value.autosaveTarget === 'android-document'
+            ? getAndroidEditorStatus()
+            : 'Ready'
+        editorLog.debug('editor blurred')
+      },
+      isStale: () => token !== editorInitToken || !editorElement.value,
+      logger: editorLog,
+    })
+    if (!nextEditor) {
       return
     }
 
-    editorLog.info('Muya init start', {
-      initialCharacters: initialMarkdown.length,
-    })
-
-    editor = new Muya(editorElement.value, {
-      markdown: initialMarkdown,
-      fontSize: 16,
-      lineHeight: 1.6,
-      codeBlockLineNumbers: true,
-      frontMatter: true,
-      footnote: true,
-      math: true,
-      spellcheckEnabled: true,
-      locale: en,
-    })
-
-    editor.init()
-    editor.on('content-change', syncMarkdown)
-    editor.on('json-change', syncMarkdown)
-    editor.on('focus', () => {
-      status.value =
-        documentState.value.autosaveTarget === 'android-document' &&
-        !currentAndroidDocumentCanWrite.value
-          ? 'Read only'
-          : 'Editing'
-      editorLog.debug('editor focused')
-    })
-    editor.on('blur', () => {
-      status.value =
-        documentState.value.autosaveTarget === 'android-document'
-          ? getAndroidEditorStatus()
-          : 'Ready'
-      editorLog.debug('editor blurred')
-    })
+    editor = nextEditor
     syncMarkdown('Ready')
     editorReady.value = true
     editorLog.info('Muya init complete', {
@@ -1084,122 +926,84 @@ async function openEditor(markdown: string) {
 }
 
 function rememberAndroidDocument(document: OpenedAndroidDocument) {
-  const recentDocument = createRecentDocumentFromAndroidDocument({
-    sourceUri: document.sourceUri,
-    displayName: document.displayName,
-    providerName: document.providerName,
-    pathHint: document.pathHint,
-    markdown: document.markdown,
-    canWrite: document.canWrite,
-  })
-
-  persistAndroidRecentDocuments(upsertRecentDocument(androidRecentDocuments.value, recentDocument))
+  persistAndroidRecentDocuments(rememberAndroidRecentDocument(androidRecentDocuments.value, document))
 }
 
 async function openAndroidDocumentResult(
   document: OpenedAndroidDocument,
-  options: { source?: 'picker' | 'recent' | 'open-with' | 'share'; remember?: boolean } = {},
+  options: { source?: AndroidDocumentOpenSource; remember?: boolean } = {},
 ) {
-  const source = options.source ?? 'picker'
-  const shouldRemember = options.remember ?? true
-  const temporaryAccessMessage =
-    source === 'open-with'
-      ? OPEN_WITH_TEMPORARY_ACCESS_MESSAGE
-      : source === 'share'
-        ? SHARE_TEMPORARY_ACCESS_MESSAGE
-        : null
-  homeNotice.value = temporaryAccessMessage && !document.persisted ? temporaryAccessMessage : null
-  if (shouldRemember) {
-    rememberAndroidDocument(document)
-  } else {
-    androidDocumentLog.warn('opened Android document without durable recent access', {
-      displayName: document.displayName,
-      sourceUri: document.sourceUri,
-      source,
-    })
-  }
-  promptLocalDraftSaveOnExit.value = false
-  currentAndroidDocumentCanWrite.value = document.canWrite
-  documentState.value = createDocumentFromAndroidDocument(document)
-  androidDocumentLog.info('open Android document in editor', {
-    displayName: document.displayName,
-    sourceUri: document.sourceUri,
-    canWrite: document.canWrite,
-    persisted: document.persisted,
-    source,
-    characters: document.markdown.length,
+  const openResult = createAndroidDocumentOpenResult(document, {
+    source: options.source,
+    remember: options.remember,
+    openWithTemporaryAccessMessage: OPEN_WITH_TEMPORARY_ACCESS_MESSAGE,
+    shareTemporaryAccessMessage: SHARE_TEMPORARY_ACCESS_MESSAGE,
+    logger: androidDocumentLog,
   })
-  await openEditor(document.markdown)
-  status.value = temporaryAccessMessage && !document.persisted
-    ? 'Opened temporarily'
-    : getAndroidEditorStatus()
+
+  homeNotice.value = openResult.homeNotice
+  if (openResult.rememberDocument) {
+    rememberAndroidDocument(openResult.rememberDocument)
+  }
+  promptLocalDraftSaveOnExit.value = openResult.promptLocalDraftSaveOnExit
+  currentAndroidDocumentCanWrite.value = openResult.currentAndroidDocumentCanWrite
+  documentState.value = openResult.documentState
+  await openEditor(openResult.markdown)
+  status.value = openResult.statusAfterOpen
   releaseEditorFocusAfterOpen()
 }
 
 async function openSharedTextDocument(document: SharedAndroidDocument) {
-  const draftDocument = createUntitledDocument({
-    markdown: document.markdown,
-    displayName: document.displayName,
-    autosaveTarget: 'local-draft',
+  const openResult = createSharedTextDocumentOpenResult(document, {
+    sharedTextImportedMessage: SHARED_TEXT_IMPORTED_MESSAGE,
+    logger: androidDocumentLog,
   })
 
-  persistLocalDrafts(
-    upsertLocalDraft(localDrafts.value, {
-      id: draftDocument.id,
-      markdown: draftDocument.markdown,
-      updatedAt: draftDocument.updatedAt,
-      lastSavedAt: draftDocument.lastSavedAt,
-    }),
-  )
-
-  homeNotice.value = null
-  promptLocalDraftSaveOnExit.value = true
-  currentAndroidDocumentCanWrite.value = false
-  documentState.value = draftDocument
-  androidDocumentLog.info('open Android shared text as local draft', {
-    displayName: document.displayName,
-    characters: document.markdown.length,
-  })
-  await openEditor(document.markdown)
-  status.value = SHARED_TEXT_IMPORTED_MESSAGE
+  persistLocalDrafts(upsertLocalDraft(localDrafts.value, openResult.localDraft))
+  homeNotice.value = openResult.homeNotice
+  promptLocalDraftSaveOnExit.value = openResult.promptLocalDraftSaveOnExit
+  currentAndroidDocumentCanWrite.value = openResult.currentAndroidDocumentCanWrite
+  documentState.value = openResult.documentState
+  await openEditor(openResult.markdown)
+  status.value = openResult.statusAfterOpen
   releaseEditorFocusAfterOpen()
 }
 
 async function openFileFromAndroid() {
   homeNotice.value = null
-  androidDocumentLog.info('open Android document picker')
 
-  try {
-    const document = await openAndroidMarkdownDocument()
-    if (document.canceled) {
-      androidDocumentLog.info('Android document picker canceled')
-      return
-    }
+  const result = await openAndroidMarkdownDocumentWorkflow({
+    openAndroidMarkdownDocument,
+    getAndroidDocumentErrorCode,
+    getAndroidDocumentUserMessage,
+    logger: androidDocumentLog,
+  })
 
-    await openAndroidDocumentResult(document)
-  } catch (error) {
-    const code = getAndroidDocumentErrorCode(error)
-    homeNotice.value = getAndroidDocumentUserMessage(error)
-    if (code === 'UNAVAILABLE') {
-      androidDocumentLog.warn('Android document picker unavailable', error)
-    } else {
-      androidDocumentLog.error('Android document picker failed', error)
-    }
+  if (result.kind === 'opened') {
+    await openAndroidDocumentResult(result.document)
+  } else if (result.kind === 'failed') {
+    homeNotice.value = result.homeNotice
   }
 }
 
 async function preserveCurrentDocumentBeforeIncomingOpen() {
-  if (currentScreen.value !== 'editor' || !editor) {
+  const preservationAction = getIncomingDocumentPreservationAction({
+    currentScreen: currentScreen.value,
+    hasEditor: Boolean(editor),
+    autosaveTarget: documentState.value.autosaveTarget,
+  })
+
+  if (preservationAction.kind === 'none') {
     return
   }
 
   appLog.info('preserve current document before incoming Android document')
 
-  if (documentState.value.autosaveTarget === 'android-document') {
+  if (preservationAction.kind === 'save-android-document') {
     syncDocumentFromEditor(documentState.value.isDirty)
     const sourceUri = documentState.value.sourceUri
     const saved = await saveAndroidDocument()
-    if (!saved && sourceUri && documentState.value.markdown.trim()) {
+    if (sourceUri && shouldKeepAndroidRecoveryAfterPreserveFailure(saved, sourceUri, documentState.value.markdown)) {
       persistAndroidRecoveryDraft(sourceUri, documentState.value.markdown)
     }
     return
@@ -1209,11 +1013,14 @@ async function preserveCurrentDocumentBeforeIncomingOpen() {
 }
 
 async function handleAndroidOpenWithDocumentEvent(event: AndroidOpenWithDocumentEvent) {
-  if (event.error) {
-    const message = getAndroidDocumentUserMessage(event.error)
-    homeNotice.value = message
-    status.value = message
-    androidDocumentLog.warn('Android open-with document rejected', event.error)
+  const action = createAndroidOpenWithDocumentEventAction(event, {
+    getAndroidDocumentUserMessage,
+    logger: androidDocumentLog,
+  })
+
+  if (action.kind === 'rejected') {
+    homeNotice.value = action.message
+    status.value = action.message
     return
   }
 
@@ -1222,18 +1029,21 @@ async function handleAndroidOpenWithDocumentEvent(event: AndroidOpenWithDocument
   androidExitPromptOpen.value = false
   editorMenuOpen.value = false
   closeEditorToolbar()
-  await openAndroidDocumentResult(event.document, {
-    source: 'open-with',
-    remember: event.document.persisted,
+  await openAndroidDocumentResult(action.document, {
+    source: action.source,
+    remember: action.remember,
   })
 }
 
 async function handleAndroidShareDocumentEvent(event: AndroidShareDocumentEvent) {
-  if (event.error) {
-    const message = getAndroidDocumentUserMessage(event.error)
-    homeNotice.value = message
-    status.value = message
-    androidDocumentLog.warn('Android shared document rejected', event.error)
+  const action = createAndroidShareDocumentEventAction(event, {
+    getAndroidDocumentUserMessage,
+    logger: androidDocumentLog,
+  })
+
+  if (action.kind === 'rejected') {
+    homeNotice.value = action.message
+    status.value = action.message
     return
   }
 
@@ -1243,21 +1053,15 @@ async function handleAndroidShareDocumentEvent(event: AndroidShareDocumentEvent)
   editorMenuOpen.value = false
   closeEditorToolbar()
 
-  if (event.document.sourceUri) {
-    await openAndroidDocumentResult(
-      {
-        ...event.document,
-        sourceUri: event.document.sourceUri,
-      },
-      {
-        source: 'share',
-        remember: event.document.persisted,
-      },
-    )
+  if (action.kind === 'open-document') {
+    await openAndroidDocumentResult(action.document, {
+      source: action.source,
+      remember: action.remember,
+    })
     return
   }
 
-  await openSharedTextDocument(event.document)
+  await openSharedTextDocument(action.document)
 }
 
 async function openDocument(id: string) {
@@ -1278,7 +1082,7 @@ async function openDocument(id: string) {
     androidExitPromptOpen.value = false
     promptLocalDraftSaveOnExit.value = false
     currentAndroidDocumentCanWrite.value = false
-    documentState.value = createDocumentFromDraft(draft)
+    documentState.value = createDocumentStateFromLocalDraft(draft)
     appLog.info('open recent local document', { id })
     await openEditor(draft.markdown)
     releaseEditorFocusAfterOpen()
@@ -1353,7 +1157,7 @@ function destroyEditor() {
   editorReady.value = false
   clearDraftSaveTimer()
   clearAndroidDocumentSaveTimer()
-  editor?.destroy()
+  destroyMuyaEditor(editor)
   editor = null
 }
 
@@ -1444,16 +1248,6 @@ function requestLifecycleFlush(reason: string) {
   void flushCurrentDocument(reason)
 }
 
-function handleDocumentVisibilityChange() {
-  if (document.hidden) {
-    requestLifecycleFlush('document hidden')
-  }
-}
-
-function handlePageHide() {
-  requestLifecycleFlush('page hide')
-}
-
 async function handleAppBackButton() {
   appLog.info('Android back button pressed', {
     screen: currentScreen.value,
@@ -1520,74 +1314,42 @@ async function handleAppBackButton() {
 }
 
 function installAppLifecycleListeners() {
-  if (!browserLifecycleListenersInstalled) {
-    browserLifecycleListenersInstalled = true
-    document.addEventListener('visibilitychange', handleDocumentVisibilityChange)
-    window.addEventListener('pagehide', handlePageHide)
-  }
-
-  void Promise.all([
-    App.addListener('backButton', () => {
-      void handleAppBackButton()
-    }),
-    App.addListener('pause', () => {
-      requestLifecycleFlush('app pause')
-    }),
-    App.addListener('appStateChange', ({ isActive }) => {
-      if (!isActive) {
-        requestLifecycleFlush('app inactive')
-      }
-    }),
-  ])
-    .then(handles => {
-      appLifecycleListenerHandles = handles
-      appLog.info('app lifecycle listeners installed')
-    })
-    .catch(error => {
-      appLog.warn('app lifecycle listeners unavailable', error)
-    })
-}
-
-function installAndroidDocumentIntentListeners() {
-  if (!isAndroidDocumentAccessAvailable()) {
+  if (appLifecycleListeners) {
     return
   }
 
-  Promise.all([
-    addAndroidOpenWithDocumentListener(event => {
+  appLifecycleListeners = installAppLifecycleListenerHandles({
+    onBackButton: handleAppBackButton,
+    onDocumentHidden: () => requestLifecycleFlush('document hidden'),
+    onPageHide: () => requestLifecycleFlush('page hide'),
+    onPause: () => requestLifecycleFlush('app pause'),
+    onInactive: () => requestLifecycleFlush('app inactive'),
+    logger: appLog,
+  })
+}
+
+function installAndroidDocumentIntentListeners() {
+  if (androidDocumentIntentListeners) {
+    return
+  }
+
+  androidDocumentIntentListeners = installAndroidDocumentIntentListenerHandles({
+    onOpenWithDocument: event => {
       void handleAndroidOpenWithDocumentEvent(event)
-    }),
-    addAndroidShareDocumentListener(event => {
+    },
+    onShareDocument: event => {
       void handleAndroidShareDocumentEvent(event)
-    }),
-  ])
-    .then(handles => {
-      androidDocumentListenerHandles = handles
-      androidDocumentLog.info('Android document intent listeners installed')
-    })
-    .catch(error => {
-      androidDocumentLog.warn('Android document intent listeners unavailable', error)
-    })
+    },
+    logger: androidDocumentLog,
+  })
 }
 
 function removeAppLifecycleListeners() {
-  if (browserLifecycleListenersInstalled) {
-    browserLifecycleListenersInstalled = false
-    document.removeEventListener('visibilitychange', handleDocumentVisibilityChange)
-    window.removeEventListener('pagehide', handlePageHide)
-  }
+  appLifecycleListeners?.remove()
+  appLifecycleListeners = null
 
-  const handles = appLifecycleListenerHandles
-  appLifecycleListenerHandles = []
-  for (const handle of handles) {
-    void handle.remove()
-  }
-
-  const documentHandles = androidDocumentListenerHandles
-  androidDocumentListenerHandles = []
-  for (const handle of documentHandles) {
-    void handle.remove()
-  }
+  androidDocumentIntentListeners?.remove()
+  androidDocumentIntentListeners = null
 }
 
 function keepLocalDraftAndShowHome() {
@@ -1615,7 +1377,7 @@ onMounted(() => {
 
   if (restoredDrafts.length > 0) {
     localDrafts.value = restoredDrafts
-    documentState.value = createDocumentFromDraft(restoredDrafts[0])
+    documentState.value = createDocumentStateFromLocalDraft(restoredDrafts[0])
   } else if (legacyDraft?.trim()) {
     const migratedDocument = createUntitledDocument({
       markdown: legacyDraft,

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,15 +36,16 @@ import {
   type AndroidDocumentIntentListeners,
 } from './lib/androidDocumentIntentListeners'
 import {
+  getAppBackButtonAction,
+  getShowHomeAfterAndroidSaveAction,
+  getShowHomeAfterLocalDraftSaveAction,
+  getShowHomeDocumentSaveAction,
+  type AppScreen,
+} from './lib/appExitDecisions'
+import {
   createAndroidRecoveryDraft,
   getAndroidRecoveryDraftId,
 } from './lib/androidRecoveryDrafts'
-import {
-  applyAndroidDocumentAutosaveFailure,
-  applyAndroidDocumentAutosaveSuccess,
-  canApplyAndroidDocumentAutosaveSuccess,
-  createAndroidDocumentAutosaveRequest,
-} from './lib/androidDocumentAutosave'
 import {
   markSavedAndroidRecentDocument,
   rememberAndroidRecentDocument,
@@ -67,14 +68,22 @@ import {
   shouldKeepAndroidRecoveryAfterPreserveFailure,
   type AndroidDocumentOpenSource,
 } from './lib/androidDocumentOpenWorkflow'
+import {
+  createSaveAndroidDocumentWorkflowStart,
+  saveAndroidDocumentWorkflow,
+} from './lib/saveAndroidDocumentWorkflow'
 import { saveAndroidDocumentCopyWorkflow } from './lib/saveAndroidDocumentCopyWorkflow'
 import { saveLocalDraftToAndroidDocumentWorkflow } from './lib/saveLocalDraftToAndroidDocumentWorkflow'
 import { shareAndroidMarkdownDocumentWorkflow } from './lib/shareAndroidMarkdownDocumentWorkflow'
 import {
-  buildMarkdownImage,
-  buildMarkdownLink,
-  normalizeLinkField,
-} from './lib/editorMarkdownInsert'
+  createAndroidImageInsertStart,
+  createLinkInsertSheetWorkflow,
+  insertAndroidImageWorkflow,
+  insertLinkFromSheetWorkflow,
+  normalizeToolbarSelectionText,
+  runEditorToolbarCommandWorkflow,
+  scheduleEditorToolbarSync,
+} from './lib/editorToolbarWorkflow'
 import {
   captureSelectionWithin,
   insertTextAtRestoredSelection,
@@ -96,8 +105,6 @@ import {
 } from './lib/documentStorage'
 import { createLogger, getNativeLogInfo, isNativeLoggerAvailable } from './lib/logger'
 import {
-  MOBILE_COMMANDS,
-  runMobileEditorCommand,
   type MobileCommandId,
   type MobileEditorCommandTarget,
 } from './lib/mobileCommands'
@@ -139,7 +146,7 @@ const androidRecentDocuments = ref<RecentDocumentRecord[]>([])
 const currentAndroidDocumentCanWrite = ref(false)
 const status = ref('Ready')
 const homeNotice = ref<string | null>(null)
-const currentScreen = ref<'home' | 'editor'>('home')
+const currentScreen = ref<AppScreen>('home')
 const homeTab = ref<HomeTab>(DEFAULT_HOME_TAB)
 const settingsPage = ref<SettingsPage>(DEFAULT_SETTINGS_PAGE)
 const editorReady = ref(false)
@@ -309,13 +316,20 @@ function insertMarkdownAtPendingSelection(markdown: string) {
 }
 
 function openLinkSheet() {
-  if (!editorReady.value || !editor) {
+  const hasEditor = Boolean(editor)
+  const capturedRange = editorReady.value && hasEditor ? captureEditorSelection() : null
+  const nextLinkSheet = createLinkInsertSheetWorkflow({
+    editorReady: editorReady.value,
+    hasEditor,
+    selectedText: capturedRange?.toString() ?? '',
+  })
+  if (nextLinkSheet.kind !== 'open') {
     return
   }
 
-  pendingInlineInsertRange = captureEditorSelection()
-  linkText.value = normalizeLinkField(pendingInlineInsertRange?.toString() ?? '')
-  linkUrl.value = ''
+  pendingInlineInsertRange = capturedRange
+  linkText.value = nextLinkSheet.linkText
+  linkUrl.value = nextLinkSheet.linkUrl
   editorMenuOpen.value = false
   closeEditorToolbar()
   linkSheetOpen.value = true
@@ -329,67 +343,67 @@ function closeLinkSheet() {
 }
 
 function insertLinkFromSheet() {
-  if (!editor || !linkUrl.value.trim()) {
-    return
-  }
+  const beforeMarkdown = editor?.getMarkdown() ?? ''
+  const result = insertLinkFromSheetWorkflow({
+    hasEditor: Boolean(editor),
+    linkText: linkText.value,
+    linkUrl: linkUrl.value,
+    beforeMarkdown,
+    insertMarkdown: insertMarkdownAtPendingSelection,
+    logger: editorLog,
+  })
 
-  const beforeMarkdown = editor.getMarkdown()
-  const markdownLink = buildMarkdownLink(linkText.value, linkUrl.value)
-
-  if (!insertMarkdownAtPendingSelection(markdownLink)) {
-    editorLog.warn('mobile link insert failed because text insertion was not handled')
+  if (result.kind !== 'inserted') {
     return
   }
 
   closeLinkSheet()
-  syncAfterToolbarCommand(beforeMarkdown)
+  syncAfterToolbarCommand(result.beforeMarkdown)
 }
 
 async function insertImageFromAndroidPicker() {
-  if (!editorReady.value || !editor || importingAndroidImage.value) {
+  const startResult = createAndroidImageInsertStart({
+    editorReady: editorReady.value,
+    hasEditor: Boolean(editor),
+    importing: importingAndroidImage.value,
+    isAvailable: isAndroidImageImportAvailable(),
+    unavailableStatus: getAndroidImageUserMessage({ code: 'UNAVAILABLE' }),
+    logger: editorLog,
+  })
+  if (startResult.kind === 'not-ready') {
     return
   }
 
-  if (!isAndroidImageImportAvailable()) {
-    status.value = getAndroidImageUserMessage({ code: 'UNAVAILABLE' })
-    editorLog.warn('mobile image insert skipped because Android image import is unavailable')
+  if (startResult.kind === 'unavailable') {
+    status.value = startResult.status
+    return
+  }
+
+  if (!editor) {
     return
   }
 
   const beforeMarkdown = editor.getMarkdown()
   pendingInlineInsertRange = captureEditorSelection()
-  const selectedText = normalizeLinkField(pendingInlineInsertRange?.toString() ?? '')
+  const selectedText = normalizeToolbarSelectionText(pendingInlineInsertRange?.toString() ?? '')
   editorMenuOpen.value = false
   closeEditorToolbar()
   importingAndroidImage.value = true
-  status.value = 'Choose an image'
+  status.value = startResult.status
 
   try {
-    await ensureAndroidImageResolver()
-    const image = await pickAndroidImageDocument()
-    if (image.canceled) {
-      status.value = 'Ready'
-      return
-    }
-
-    const alt = selectedText || image.displayName
-    const markdownImage = buildMarkdownImage(alt, image.markdownSrc)
-    if (!insertMarkdownAtPendingSelection(markdownImage)) {
-      status.value = 'Image insert failed'
-      editorLog.warn('mobile image insert failed because text insertion was not handled')
-      return
-    }
-
-    status.value = 'Image inserted'
-    editorLog.info('mobile image inserted', {
-      displayName: image.displayName,
-      mimeType: image.mimeType,
-      bytes: image.bytes,
+    const result = await insertAndroidImageWorkflow({
+      selectedText,
+      ensureAndroidImageResolver,
+      pickAndroidImageDocument,
+      insertMarkdown: insertMarkdownAtPendingSelection,
+      getAndroidImageUserMessage,
+      logger: editorLog,
     })
-    syncAfterToolbarCommand(beforeMarkdown)
-  } catch (error) {
-    status.value = getAndroidImageUserMessage(error)
-    editorLog.error('mobile image insert failed', error)
+    status.value = result.status
+    if (result.kind === 'inserted') {
+      syncAfterToolbarCommand(beforeMarkdown)
+    }
   } finally {
     importingAndroidImage.value = false
     pendingInlineInsertRange = null
@@ -397,55 +411,40 @@ async function insertImageFromAndroidPicker() {
 }
 
 function syncAfterToolbarCommand(beforeMarkdown: string) {
-  window.requestAnimationFrame(() => {
-    if (!editor) {
-      return
-    }
-
-    const nextMarkdown = normalizeEditorMarkdown(editor.getMarkdown())
-    if (nextMarkdown !== normalizeEditorMarkdown(beforeMarkdown)) {
-      syncMarkdown('Edited')
-      return
-    }
-
-    syncDocumentFromEditor(documentState.value.isDirty)
+  scheduleEditorToolbarSync({
+    beforeMarkdown,
+    requestFrame: callback => window.requestAnimationFrame(callback),
+    getMarkdown: () => editor?.getMarkdown() ?? null,
+    normalizeMarkdown: normalizeEditorMarkdown,
+    onEdited: () => syncMarkdown('Edited'),
+    onUnchanged: () => syncDocumentFromEditor(documentState.value.isDirty),
   })
 }
 
 function runEditorToolbarCommand(commandId: MobileCommandId) {
-  if (!editorReady.value || !editor) {
-    editorLog.warn('mobile toolbar command skipped because editor is not ready', { commandId })
-    return
-  }
+  const activeEditor = editorReady.value ? editor : null
+  const result = runEditorToolbarCommandWorkflow({
+    commandId,
+    editorReady: editorReady.value,
+    hasEditor: Boolean(activeEditor),
+    commandTarget: activeEditor ? getEditorCommandTarget() : null,
+    beforeMarkdown: activeEditor ? activeEditor.getMarkdown() : '',
+    logger: editorLog,
+  })
 
-  if (commandId === MOBILE_COMMANDS.FORMAT_HYPERLINK) {
+  if (result.kind === 'open-link-sheet') {
     openLinkSheet()
     return
   }
 
-  if (commandId === MOBILE_COMMANDS.FORMAT_IMAGE) {
+  if (result.kind === 'insert-image') {
     void insertImageFromAndroidPicker()
     return
   }
 
-  const target = getEditorCommandTarget()
-  const beforeMarkdown = editor.getMarkdown()
-  let result
-
-  try {
-    result = runMobileEditorCommand(target, commandId)
-  } catch (error) {
-    editorLog.error('mobile toolbar command failed', { commandId, error })
-    return
+  if (result.kind === 'handled') {
+    syncAfterToolbarCommand(result.beforeMarkdown)
   }
-
-  if (!result.handled) {
-    editorLog.warn('mobile toolbar command was not handled', result)
-    return
-  }
-
-  editorLog.info('mobile toolbar command handled', { commandId })
-  syncAfterToolbarCommand(beforeMarkdown)
 }
 
 function logContentSnapshot(reason: string) {
@@ -548,30 +547,36 @@ function markAndroidRecentDocumentSaved(savedAt: string) {
 async function saveAndroidDocument() {
   clearAndroidDocumentSaveTimer()
 
-  if (!editor || documentState.value.autosaveTarget !== 'android-document') {
+  if (!editor) {
     return true
   }
 
-  const sourceUri = documentState.value.sourceUri
-  if (!sourceUri) {
-    status.value = 'Save failed'
+  const value = normalizeEditorMarkdown(editor.getMarkdown())
+  const startResult = createSaveAndroidDocumentWorkflowStart({
+    documentState: documentState.value,
+    markdown: value,
+    canWrite: currentAndroidDocumentCanWrite.value,
+  })
+
+  if (startResult.kind === 'not-android-document' || startResult.kind === 'clean') {
+    return true
+  }
+
+  if (startResult.kind === 'missing-source') {
+    status.value = startResult.status
     androidDocumentLog.error('Android document save missing source URI', {
-      id: documentState.value.id,
+      id: startResult.documentId,
     })
     return false
   }
 
-  if (!currentAndroidDocumentCanWrite.value) {
-    status.value = documentState.value.isDirty ? 'This file is read-only.' : 'Read only'
+  if (startResult.kind === 'read-only') {
+    status.value = startResult.status
     androidDocumentLog.debug('skip Android document autosave without write access', {
-      id: documentState.value.id,
-      sourceUri,
+      id: startResult.documentId,
+      sourceUri: startResult.sourceUri,
     })
-    return !documentState.value.isDirty
-  }
-
-  if (!documentState.value.isDirty && documentState.value.autosaveState !== 'save-failed') {
-    return true
+    return startResult.saved
   }
 
   if (androidSaveInFlight) {
@@ -579,49 +584,35 @@ async function saveAndroidDocument() {
     return false
   }
 
-  const value = normalizeEditorMarkdown(editor.getMarkdown())
-  const autosaveRequest = createAndroidDocumentAutosaveRequest(documentState.value, value)
-
   androidSaveInFlight = true
-  documentState.value = autosaveRequest.savingDocument
-  status.value = 'Saving'
+  documentState.value = startResult.request.savingDocument
+  status.value = startResult.status
 
   try {
-    await writeAndroidMarkdownDocument(sourceUri, autosaveRequest.markdownForSave)
-    const savedAt = new Date().toISOString()
+    const result = await saveAndroidDocumentWorkflow({
+      request: startResult.request,
+      getCurrentDocumentState: () => documentState.value,
+      writeAndroidMarkdownDocument,
+      getAndroidDocumentUserMessage,
+      recoveryMessage: ANDROID_SAVE_RECOVERY_MESSAGE,
+      logger: androidDocumentLog,
+    })
 
-    if (canApplyAndroidDocumentAutosaveSuccess(
-      documentState.value,
-      sourceUri,
-      autosaveRequest.saveMarkdown,
-    )) {
-      documentState.value = applyAndroidDocumentAutosaveSuccess(
-        documentState.value,
-        autosaveRequest.saveMarkdown,
-        savedAt,
-      )
-      markAndroidRecentDocumentSaved(savedAt)
-      status.value = 'Saved'
-      androidDocumentLog.info('Android document autosaved', {
-        sourceUri,
-        characters: autosaveRequest.saveMarkdown.length,
-      })
+    if (result.kind === 'saved') {
+      documentState.value = result.savedDocument
+      markAndroidRecentDocumentSaved(result.savedAt)
+      status.value = result.status
       return true
-    } else {
+    }
+
+    if (result.kind === 'changed-during-save') {
       androidSaveRequestedAfterCurrent = true
-      androidDocumentLog.debug('Android document changed during save; scheduling another save', {
-        sourceUri,
-      })
       return false
     }
-  } catch (error) {
-    documentState.value = applyAndroidDocumentAutosaveFailure(documentState.value, error)
-    persistAndroidRecoveryDraft(sourceUri, autosaveRequest.saveMarkdown)
-    status.value = `${getAndroidDocumentUserMessage(error)} ${ANDROID_SAVE_RECOVERY_MESSAGE}`
-    androidDocumentLog.error('Android document autosave failed', {
-      sourceUri,
-      error,
-    })
+
+    documentState.value = result.failedDocument
+    persistAndroidRecoveryDraft(result.recoveryDraft.sourceUri, result.recoveryDraft.markdown)
+    status.value = result.status
     return false
   } finally {
     androidSaveInFlight = false
@@ -1186,21 +1177,35 @@ async function showHome() {
   appLog.info('show recent home')
   editorMenuOpen.value = false
   closeEditorToolbar()
-  if (documentState.value.autosaveTarget === 'android-document') {
+
+  const saveAction = getShowHomeDocumentSaveAction(documentState.value.autosaveTarget)
+  if (saveAction === 'save-android-document') {
     const saved = await saveAndroidDocument()
-    if (!saved) {
-      if (shouldPromptAndroidExitAfterSaveFailure()) {
-        androidExitPromptOpen.value = true
-      }
+    const afterSaveAction = getShowHomeAfterAndroidSaveAction({
+      saved,
+      shouldPromptAndroidExitAfterSaveFailure: shouldPromptAndroidExitAfterSaveFailure(),
+    })
+
+    if (afterSaveAction === 'open-android-exit-prompt') {
+      androidExitPromptOpen.value = true
+      return
+    }
+
+    if (afterSaveAction === 'stay-editor') {
       return
     }
   } else {
     saveDraft()
-    if (shouldPromptLocalDraftSaveToDevice()) {
+    const afterSaveAction = getShowHomeAfterLocalDraftSaveAction({
+      shouldPromptLocalDraftSaveToDevice: shouldPromptLocalDraftSaveToDevice(),
+    })
+
+    if (afterSaveAction === 'open-local-draft-exit-prompt') {
       draftExitPromptOpen.value = true
       return
     }
   }
+
   closeEditorToHome()
 }
 
@@ -1259,57 +1264,51 @@ async function handleAppBackButton() {
     toolbarOpen: editorToolbarExpanded.value,
   })
 
-  if (androidExitPromptOpen.value) {
-    androidExitPromptOpen.value = false
-    status.value = getAndroidEditorStatus()
-    return
-  }
+  const action = getAppBackButtonAction({
+    currentScreen: currentScreen.value,
+    homeTab: homeTab.value,
+    settingsPage: settingsPage.value,
+    androidExitPromptOpen: androidExitPromptOpen.value,
+    draftExitPromptOpen: draftExitPromptOpen.value,
+    linkSheetOpen: linkSheetOpen.value,
+    editorMenuOpen: editorMenuOpen.value,
+    editorToolbarExpanded: editorToolbarExpanded.value,
+  })
 
-  if (draftExitPromptOpen.value) {
-    draftExitPromptOpen.value = false
-    status.value = isLocalDraftDocument() ? 'Autosaved locally' : status.value
-    return
-  }
-
-  if (linkSheetOpen.value) {
-    closeLinkSheet()
-    return
-  }
-
-  if (editorMenuOpen.value) {
-    editorMenuOpen.value = false
-    return
-  }
-
-  if (editorToolbarExpanded.value) {
-    closeEditorToolbar()
-    return
-  }
-
-  if (currentScreen.value === 'editor') {
-    await showHome()
-    return
-  }
-
-  if (
-    currentScreen.value === 'home' &&
-    homeTab.value === HOME_TABS.SETTINGS &&
-    settingsPage.value !== SETTINGS_PAGES.INDEX
-  ) {
-    settingsPage.value = SETTINGS_PAGES.INDEX
-    return
-  }
-
-  if (currentScreen.value === 'home' && homeTab.value !== HOME_TABS.DOCUMENTS) {
-    homeTab.value = HOME_TABS.DOCUMENTS
-    settingsPage.value = DEFAULT_SETTINGS_PAGE
-    return
-  }
-
-  try {
-    await App.exitApp()
-  } catch (error) {
-    appLog.warn('Android back exit unavailable', error)
+  switch (action) {
+    case 'close-android-exit-prompt':
+      androidExitPromptOpen.value = false
+      status.value = getAndroidEditorStatus()
+      return
+    case 'close-local-draft-exit-prompt':
+      draftExitPromptOpen.value = false
+      status.value = isLocalDraftDocument() ? 'Autosaved locally' : status.value
+      return
+    case 'close-link-sheet':
+      closeLinkSheet()
+      return
+    case 'close-editor-menu':
+      editorMenuOpen.value = false
+      return
+    case 'close-editor-toolbar':
+      closeEditorToolbar()
+      return
+    case 'show-home':
+      await showHome()
+      return
+    case 'show-settings-index':
+      settingsPage.value = SETTINGS_PAGES.INDEX
+      return
+    case 'show-documents-tab':
+      homeTab.value = HOME_TABS.DOCUMENTS
+      settingsPage.value = DEFAULT_SETTINGS_PAGE
+      return
+    case 'exit-app':
+      try {
+        await App.exitApp()
+      } catch (error) {
+        appLog.warn('Android back exit unavailable', error)
+      }
   }
 }
 

--- a/src/lib/androidDocumentAutosave.test.ts
+++ b/src/lib/androidDocumentAutosave.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { createUntitledDocument, updateDocumentMarkdown } from './documentState'
+import {
+  applyAndroidDocumentAutosaveFailure,
+  applyAndroidDocumentAutosaveSuccess,
+  canApplyAndroidDocumentAutosaveSuccess,
+  createAndroidDocumentAutosaveRequest,
+} from './androidDocumentAutosave'
+
+describe('androidDocumentAutosave', () => {
+  it('creates a saving request with Markdown prepared for the current document line ending', () => {
+    const documentState = updateDocumentMarkdown(
+      createUntitledDocument({
+        markdown: 'one\r\ntwo\r\n',
+        sourceUri: 'content://provider/note.md',
+        autosaveTarget: 'android-document',
+      }),
+      'one\ntwo\nthree\n',
+    )
+
+    const request = createAndroidDocumentAutosaveRequest(documentState, 'one\ntwo\nthree\n')
+
+    expect(request.savingDocument.autosaveState).toBe('saving')
+    expect(request.saveMarkdown).toBe('one\ntwo\nthree\n')
+    expect(request.markdownForSave).toBe('one\r\ntwo\r\nthree\r\n')
+  })
+
+  it('only applies a successful save to the same Android document and Markdown snapshot', () => {
+    const documentState = createUntitledDocument({
+      markdown: '# Android note',
+      sourceUri: 'content://provider/note.md',
+      autosaveTarget: 'android-document',
+    })
+
+    expect(
+      canApplyAndroidDocumentAutosaveSuccess(
+        documentState,
+        'content://provider/note.md',
+        '# Android note',
+      ),
+    ).toBe(true)
+    expect(
+      canApplyAndroidDocumentAutosaveSuccess(
+        documentState,
+        'content://provider/other.md',
+        '# Android note',
+      ),
+    ).toBe(false)
+    expect(
+      canApplyAndroidDocumentAutosaveSuccess(
+        documentState,
+        'content://provider/note.md',
+        '# Changed while saving',
+      ),
+    ).toBe(false)
+  })
+
+  it('marks Android autosave success clean with the saved timestamp', () => {
+    const documentState = createUntitledDocument({
+      markdown: '# Android note',
+      sourceUri: 'content://provider/note.md',
+      autosaveTarget: 'android-document',
+    })
+
+    const savedDocument = applyAndroidDocumentAutosaveSuccess(
+      documentState,
+      '# Android note',
+      '2026-07-02T00:03:00.000Z',
+    )
+
+    expect(savedDocument.isDirty).toBe(false)
+    expect(savedDocument.autosaveTarget).toBe('android-document')
+    expect(savedDocument.autosaveState).toBe('clean')
+    expect(savedDocument.updatedAt).toBe('2026-07-02T00:03:00.000Z')
+    expect(savedDocument.lastSavedAt).toBe('2026-07-02T00:03:00.000Z')
+  })
+
+  it('marks Android autosave failure as dirty and failed', () => {
+    const documentState = createUntitledDocument({
+      markdown: '# Android note',
+      sourceUri: 'content://provider/note.md',
+      autosaveTarget: 'android-document',
+    })
+
+    const failedDocument = applyAndroidDocumentAutosaveFailure(
+      documentState,
+      new Error('permission lost'),
+    )
+
+    expect(failedDocument.isDirty).toBe(true)
+    expect(failedDocument.autosaveState).toBe('save-failed')
+    expect(failedDocument.lastSaveError).toBe('permission lost')
+  })
+})

--- a/src/lib/androidDocumentAutosave.ts
+++ b/src/lib/androidDocumentAutosave.ts
@@ -1,0 +1,62 @@
+import {
+  markDocumentSaved,
+  markDocumentSaveFailed,
+  markDocumentSaving,
+  prepareMarkdownForSave,
+  updateDocumentMarkdown,
+  type MarkdownDocumentState,
+} from './documentState'
+
+export interface AndroidDocumentAutosaveRequest {
+  savingDocument: MarkdownDocumentState
+  markdownForSave: string
+  saveMarkdown: string
+}
+
+export function createAndroidDocumentAutosaveRequest(
+  documentState: MarkdownDocumentState,
+  markdown: string,
+): AndroidDocumentAutosaveRequest {
+  const nextDocument = updateDocumentMarkdown(documentState, markdown, {
+    markDirty: documentState.isDirty,
+  })
+
+  return {
+    savingDocument: markDocumentSaving(nextDocument),
+    markdownForSave: prepareMarkdownForSave(nextDocument.markdown, nextDocument),
+    saveMarkdown: nextDocument.markdown,
+  }
+}
+
+export function canApplyAndroidDocumentAutosaveSuccess(
+  documentState: MarkdownDocumentState,
+  sourceUri: string,
+  saveMarkdown: string,
+) {
+  return (
+    documentState.autosaveTarget === 'android-document' &&
+    documentState.sourceUri === sourceUri &&
+    documentState.markdown === saveMarkdown
+  )
+}
+
+export function applyAndroidDocumentAutosaveSuccess(
+  documentState: MarkdownDocumentState,
+  saveMarkdown: string,
+  savedAt: string,
+) {
+  return markDocumentSaved(
+    updateDocumentMarkdown(documentState, saveMarkdown, {
+      markDirty: false,
+      now: savedAt,
+    }),
+    { autosaveTarget: 'android-document', now: savedAt },
+  )
+}
+
+export function applyAndroidDocumentAutosaveFailure(
+  documentState: MarkdownDocumentState,
+  error: unknown,
+) {
+  return markDocumentSaveFailed(documentState, error)
+}

--- a/src/lib/androidDocumentIntentListeners.ts
+++ b/src/lib/androidDocumentIntentListeners.ts
@@ -1,0 +1,58 @@
+import type { PluginListenerHandle } from '@capacitor/core'
+import {
+  addAndroidOpenWithDocumentListener,
+  addAndroidShareDocumentListener,
+  isAndroidDocumentAccessAvailable,
+  type AndroidOpenWithDocumentEvent,
+  type AndroidShareDocumentEvent,
+} from './androidDocuments'
+
+interface AndroidDocumentIntentLogger {
+  info(message: string, context?: unknown): void
+  warn(message: string, context?: unknown): void
+}
+
+interface AndroidDocumentIntentListenerOptions {
+  onOpenWithDocument: (event: AndroidOpenWithDocumentEvent) => void
+  onShareDocument: (event: AndroidShareDocumentEvent) => void
+  logger?: AndroidDocumentIntentLogger
+}
+
+export interface AndroidDocumentIntentListeners {
+  remove(): void
+}
+
+export function installAndroidDocumentIntentListeners({
+  onOpenWithDocument,
+  onShareDocument,
+  logger,
+}: AndroidDocumentIntentListenerOptions): AndroidDocumentIntentListeners {
+  if (!isAndroidDocumentAccessAvailable()) {
+    return {
+      remove() {},
+    }
+  }
+
+  let listenerHandles: PluginListenerHandle[] = []
+  Promise.all([
+    addAndroidOpenWithDocumentListener(onOpenWithDocument),
+    addAndroidShareDocumentListener(onShareDocument),
+  ])
+    .then(handles => {
+      listenerHandles = handles
+      logger?.info('Android document intent listeners installed')
+    })
+    .catch(error => {
+      logger?.warn('Android document intent listeners unavailable', error)
+    })
+
+  return {
+    remove() {
+      const handles = listenerHandles
+      listenerHandles = []
+      for (const handle of handles) {
+        void handle.remove()
+      }
+    },
+  }
+}

--- a/src/lib/androidDocumentOpenWorkflow.test.ts
+++ b/src/lib/androidDocumentOpenWorkflow.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AndroidDocumentError, type OpenedAndroidDocument, type SharedAndroidDocument } from './androidDocuments'
+import {
+  createAndroidDocumentOpenResult,
+  createAndroidOpenWithDocumentEventAction,
+  createAndroidShareDocumentEventAction,
+  createSharedTextDocumentOpenResult,
+  getIncomingDocumentPreservationAction,
+  openAndroidMarkdownDocumentWorkflow,
+  shouldKeepAndroidRecoveryAfterPreserveFailure,
+} from './androidDocumentOpenWorkflow'
+
+const openedDocument: OpenedAndroidDocument = {
+  canceled: false,
+  sourceUri: 'content://provider/opened.md',
+  displayName: 'Opened.md',
+  providerName: 'Documents',
+  pathHint: 'Documents/Opened.md',
+  mimeType: 'text/markdown',
+  markdown: '# Opened\n\nbody',
+  canWrite: true,
+  persisted: true,
+}
+
+const sharedTextDocument: SharedAndroidDocument = {
+  canceled: false,
+  sourceUri: null,
+  displayName: 'Shared Text.md',
+  providerName: null,
+  pathHint: null,
+  mimeType: 'text/plain',
+  markdown: '# Shared Text\n\nbody',
+  canWrite: false,
+  persisted: false,
+  shareKind: 'text',
+}
+
+describe('androidDocumentOpenWorkflow', () => {
+  it('creates an opened Android document session result for durable documents', () => {
+    const result = createAndroidDocumentOpenResult(openedDocument, {
+      source: 'picker',
+      openWithTemporaryAccessMessage: 'open-with temporary',
+      shareTemporaryAccessMessage: 'share temporary',
+    })
+
+    expect(result).toMatchObject({
+      markdown: '# Opened\n\nbody',
+      homeNotice: null,
+      rememberDocument: openedDocument,
+      promptLocalDraftSaveOnExit: false,
+      currentAndroidDocumentCanWrite: true,
+      statusAfterOpen: 'Saved',
+      documentState: {
+        id: 'android-document:content://provider/opened.md',
+        autosaveTarget: 'android-document',
+        displayName: 'Opened.md',
+        sourceUri: 'content://provider/opened.md',
+      },
+    })
+  })
+
+  it('marks temporary open-with documents as non-recent and opened temporarily', () => {
+    const temporaryDocument = {
+      ...openedDocument,
+      persisted: false,
+      canWrite: false,
+    }
+
+    const result = createAndroidDocumentOpenResult(temporaryDocument, {
+      source: 'open-with',
+      remember: false,
+      openWithTemporaryAccessMessage: 'Opened temporarily from Android',
+      shareTemporaryAccessMessage: 'share temporary',
+    })
+
+    expect(result).toMatchObject({
+      homeNotice: 'Opened temporarily from Android',
+      rememberDocument: null,
+      currentAndroidDocumentCanWrite: false,
+      statusAfterOpen: 'Opened temporarily',
+    })
+  })
+
+  it('creates a local draft session result for shared text', () => {
+    const result = createSharedTextDocumentOpenResult(sharedTextDocument, {
+      sharedTextImportedMessage: 'Imported shared text as a local draft.',
+      now: () => '2026-07-02T00:00:00.000Z',
+    })
+
+    expect(result).toMatchObject({
+      markdown: '# Shared Text\n\nbody',
+      homeNotice: null,
+      promptLocalDraftSaveOnExit: true,
+      currentAndroidDocumentCanWrite: false,
+      statusAfterOpen: 'Imported shared text as a local draft.',
+      documentState: {
+        markdown: '# Shared Text\n\nbody',
+        autosaveTarget: 'local-draft',
+        displayName: 'Shared Text.md',
+        updatedAt: '2026-07-02T00:00:00.000Z',
+      },
+    })
+    expect(result.localDraft).toEqual({
+      id: result.documentState.id,
+      markdown: '# Shared Text\n\nbody',
+      updatedAt: '2026-07-02T00:00:00.000Z',
+      lastSavedAt: '2026-07-02T00:00:00.000Z',
+    })
+  })
+
+  it('opens, cancels, and reports picker failures through an explicit result', async () => {
+    await expect(
+      openAndroidMarkdownDocumentWorkflow({
+        openAndroidMarkdownDocument: vi.fn().mockResolvedValue(openedDocument),
+        getAndroidDocumentErrorCode: () => 'UNKNOWN',
+        getAndroidDocumentUserMessage: () => 'failed',
+      }),
+    ).resolves.toMatchObject({
+      kind: 'opened',
+      document: openedDocument,
+    })
+
+    await expect(
+      openAndroidMarkdownDocumentWorkflow({
+        openAndroidMarkdownDocument: vi.fn().mockResolvedValue({ canceled: true }),
+        getAndroidDocumentErrorCode: () => 'UNKNOWN',
+        getAndroidDocumentUserMessage: () => 'failed',
+      }),
+    ).resolves.toEqual({
+      kind: 'canceled',
+    })
+
+    await expect(
+      openAndroidMarkdownDocumentWorkflow({
+        openAndroidMarkdownDocument: vi.fn().mockRejectedValue(new AndroidDocumentError('UNAVAILABLE', 'no bridge')),
+        getAndroidDocumentErrorCode: error => (error as AndroidDocumentError).code,
+        getAndroidDocumentUserMessage: () => 'Open Markdown files from the Android app build.',
+      }),
+    ).resolves.toMatchObject({
+      kind: 'failed',
+      homeNotice: 'Open Markdown files from the Android app build.',
+    })
+  })
+
+  it('maps incoming open-with and share events to open actions or rejections', () => {
+    expect(
+      createAndroidOpenWithDocumentEventAction(
+        {
+          document: openedDocument,
+          error: null,
+        },
+        {
+          getAndroidDocumentUserMessage: () => 'failed',
+        },
+      ),
+    ).toMatchObject({
+      kind: 'open-document',
+      source: 'open-with',
+      remember: true,
+      document: openedDocument,
+    })
+
+    expect(
+      createAndroidShareDocumentEventAction(
+        {
+          document: sharedTextDocument,
+          error: null,
+        },
+        {
+          getAndroidDocumentUserMessage: () => 'failed',
+        },
+      ),
+    ).toMatchObject({
+      kind: 'open-shared-text',
+      document: sharedTextDocument,
+    })
+
+    expect(
+      createAndroidShareDocumentEventAction(
+        {
+          document: null,
+          error: new AndroidDocumentError('UNSUPPORTED_SHARE_DOCUMENT', 'bad share'),
+        },
+        {
+          getAndroidDocumentUserMessage: () => 'Share Markdown text or a Markdown file.',
+        },
+      ),
+    ).toMatchObject({
+      kind: 'rejected',
+      message: 'Share Markdown text or a Markdown file.',
+    })
+  })
+
+  it('selects the preservation action before replacing the active editor document', () => {
+    expect(
+      getIncomingDocumentPreservationAction({
+        currentScreen: 'home',
+        hasEditor: false,
+        autosaveTarget: 'local-draft',
+      }),
+    ).toEqual({ kind: 'none' })
+
+    expect(
+      getIncomingDocumentPreservationAction({
+        currentScreen: 'editor',
+        hasEditor: true,
+        autosaveTarget: 'android-document',
+      }),
+    ).toEqual({ kind: 'save-android-document' })
+
+    expect(
+      getIncomingDocumentPreservationAction({
+        currentScreen: 'editor',
+        hasEditor: true,
+        autosaveTarget: 'local-draft',
+      }),
+    ).toEqual({ kind: 'save-local-draft' })
+  })
+
+  it('keeps Android recovery only after failed preservation with non-empty content', () => {
+    expect(shouldKeepAndroidRecoveryAfterPreserveFailure(false, 'content://provider/doc.md', 'body')).toBe(true)
+    expect(shouldKeepAndroidRecoveryAfterPreserveFailure(true, 'content://provider/doc.md', 'body')).toBe(false)
+    expect(shouldKeepAndroidRecoveryAfterPreserveFailure(false, null, 'body')).toBe(false)
+    expect(shouldKeepAndroidRecoveryAfterPreserveFailure(false, 'content://provider/doc.md', '  ')).toBe(false)
+  })
+})

--- a/src/lib/androidDocumentOpenWorkflow.ts
+++ b/src/lib/androidDocumentOpenWorkflow.ts
@@ -1,0 +1,334 @@
+import { createUntitledDocument, type AutosaveTarget } from './documentState'
+import { createDocumentStateFromAndroidDocument } from './documentSessionState'
+import type {
+  AndroidOpenWithDocumentEvent,
+  AndroidShareDocumentEvent,
+  OpenedAndroidDocument,
+  SharedAndroidDocument,
+} from './androidDocuments'
+import type { LocalDraftRecord } from './localDrafts'
+
+export type AndroidDocumentOpenSource = 'picker' | 'recent' | 'open-with' | 'share'
+
+interface CanceledAndroidDocumentOpen {
+  canceled: true
+}
+
+type AndroidDocumentOpenResult = OpenedAndroidDocument | CanceledAndroidDocumentOpen
+
+interface WorkflowLogger {
+  info(message: string, data?: unknown): void
+  warn(message: string, data?: unknown): void
+  error(message: string, data?: unknown): void
+}
+
+interface CreateAndroidDocumentOpenResultOptions {
+  source?: AndroidDocumentOpenSource
+  remember?: boolean
+  openWithTemporaryAccessMessage: string
+  shareTemporaryAccessMessage: string
+  logger?: WorkflowLogger
+}
+
+interface CreateSharedTextDocumentOpenResultOptions {
+  sharedTextImportedMessage: string
+  now?: () => string
+  logger?: WorkflowLogger
+}
+
+export interface CreatedAndroidDocumentOpenResult {
+  markdown: string
+  documentState: ReturnType<typeof createDocumentStateFromAndroidDocument>
+  homeNotice: string | null
+  rememberDocument: OpenedAndroidDocument | null
+  promptLocalDraftSaveOnExit: false
+  currentAndroidDocumentCanWrite: boolean
+  statusAfterOpen: 'Opened temporarily' | 'Read only' | 'Saved'
+}
+
+export interface CreatedSharedTextDocumentOpenResult {
+  markdown: string
+  documentState: ReturnType<typeof createUntitledDocument>
+  localDraft: LocalDraftRecord
+  homeNotice: null
+  promptLocalDraftSaveOnExit: true
+  currentAndroidDocumentCanWrite: false
+  statusAfterOpen: string
+}
+
+export type AndroidDocumentPickerWorkflowResult =
+  | {
+      kind: 'canceled'
+    }
+  | {
+      kind: 'opened'
+      document: OpenedAndroidDocument
+    }
+  | {
+      kind: 'failed'
+      homeNotice: string
+      error: unknown
+    }
+
+interface OpenAndroidMarkdownDocumentWorkflowOptions {
+  openAndroidMarkdownDocument: () => Promise<AndroidDocumentOpenResult>
+  getAndroidDocumentErrorCode: (error: unknown) => string
+  getAndroidDocumentUserMessage: (error: unknown) => string
+  logger?: WorkflowLogger
+}
+
+export type AndroidIncomingDocumentAction =
+  | {
+      kind: 'rejected'
+      message: string
+      error: unknown
+    }
+  | {
+      kind: 'open-document'
+      document: OpenedAndroidDocument
+      source: Extract<AndroidDocumentOpenSource, 'open-with' | 'share'>
+      remember: boolean
+    }
+  | {
+      kind: 'open-shared-text'
+      document: SharedAndroidDocument
+    }
+
+export type AndroidOpenWithDocumentAction = Extract<
+  AndroidIncomingDocumentAction,
+  { kind: 'rejected' } | { kind: 'open-document' }
+>
+
+interface IncomingDocumentActionOptions {
+  getAndroidDocumentUserMessage: (error: unknown) => string
+  logger?: WorkflowLogger
+}
+
+export type IncomingDocumentPreservationAction =
+  | {
+      kind: 'none'
+    }
+  | {
+      kind: 'save-android-document'
+    }
+  | {
+      kind: 'save-local-draft'
+    }
+
+interface IncomingDocumentPreservationActionOptions {
+  currentScreen: 'home' | 'editor'
+  hasEditor: boolean
+  autosaveTarget: AutosaveTarget
+}
+
+export function createAndroidDocumentOpenResult(
+  document: OpenedAndroidDocument,
+  {
+    source = 'picker',
+    remember = true,
+    openWithTemporaryAccessMessage,
+    shareTemporaryAccessMessage,
+    logger,
+  }: CreateAndroidDocumentOpenResultOptions,
+): CreatedAndroidDocumentOpenResult {
+  const temporaryAccessMessage =
+    source === 'open-with'
+      ? openWithTemporaryAccessMessage
+      : source === 'share'
+        ? shareTemporaryAccessMessage
+        : null
+  const openedTemporarily = Boolean(temporaryAccessMessage && !document.persisted)
+  const shouldRemember = remember
+
+  if (!shouldRemember) {
+    logger?.warn('opened Android document without durable recent access', {
+      displayName: document.displayName,
+      sourceUri: document.sourceUri,
+      source,
+    })
+  }
+
+  logger?.info('open Android document in editor', {
+    displayName: document.displayName,
+    sourceUri: document.sourceUri,
+    canWrite: document.canWrite,
+    persisted: document.persisted,
+    source,
+    characters: document.markdown.length,
+  })
+
+  return {
+    markdown: document.markdown,
+    documentState: createDocumentStateFromAndroidDocument(document),
+    homeNotice: openedTemporarily ? temporaryAccessMessage : null,
+    rememberDocument: shouldRemember ? document : null,
+    promptLocalDraftSaveOnExit: false,
+    currentAndroidDocumentCanWrite: document.canWrite,
+    statusAfterOpen: openedTemporarily ? 'Opened temporarily' : document.canWrite ? 'Saved' : 'Read only',
+  }
+}
+
+export function createSharedTextDocumentOpenResult(
+  document: SharedAndroidDocument,
+  {
+    sharedTextImportedMessage,
+    now = () => new Date().toISOString(),
+    logger,
+  }: CreateSharedTextDocumentOpenResultOptions,
+): CreatedSharedTextDocumentOpenResult {
+  const openedAt = now()
+  const draftDocument = createUntitledDocument({
+    markdown: document.markdown,
+    displayName: document.displayName,
+    autosaveTarget: 'local-draft',
+    now: openedAt,
+  })
+
+  logger?.info('open Android shared text as local draft', {
+    displayName: document.displayName,
+    characters: document.markdown.length,
+  })
+
+  return {
+    markdown: document.markdown,
+    documentState: draftDocument,
+    localDraft: {
+      id: draftDocument.id,
+      markdown: draftDocument.markdown,
+      updatedAt: draftDocument.updatedAt,
+      lastSavedAt: draftDocument.lastSavedAt,
+    },
+    homeNotice: null,
+    promptLocalDraftSaveOnExit: true,
+    currentAndroidDocumentCanWrite: false,
+    statusAfterOpen: sharedTextImportedMessage,
+  }
+}
+
+export async function openAndroidMarkdownDocumentWorkflow({
+  openAndroidMarkdownDocument,
+  getAndroidDocumentErrorCode,
+  getAndroidDocumentUserMessage,
+  logger,
+}: OpenAndroidMarkdownDocumentWorkflowOptions): Promise<AndroidDocumentPickerWorkflowResult> {
+  logger?.info('open Android document picker')
+
+  try {
+    const document = await openAndroidMarkdownDocument()
+    if (document.canceled) {
+      logger?.info('Android document picker canceled')
+      return {
+        kind: 'canceled',
+      }
+    }
+
+    return {
+      kind: 'opened',
+      document,
+    }
+  } catch (error) {
+    const code = getAndroidDocumentErrorCode(error)
+    if (code === 'UNAVAILABLE') {
+      logger?.warn('Android document picker unavailable', error)
+    } else {
+      logger?.error('Android document picker failed', error)
+    }
+
+    return {
+      kind: 'failed',
+      homeNotice: getAndroidDocumentUserMessage(error),
+      error,
+    }
+  }
+}
+
+export function createAndroidOpenWithDocumentEventAction(
+  event: AndroidOpenWithDocumentEvent,
+  { getAndroidDocumentUserMessage, logger }: IncomingDocumentActionOptions,
+): AndroidOpenWithDocumentAction {
+  if (event.error) {
+    const message = getAndroidDocumentUserMessage(event.error)
+    logger?.warn('Android open-with document rejected', event.error)
+    return {
+      kind: 'rejected',
+      message,
+      error: event.error,
+    }
+  }
+
+  return {
+    kind: 'open-document',
+    document: event.document,
+    source: 'open-with',
+    remember: event.document.persisted,
+  }
+}
+
+export function createAndroidShareDocumentEventAction(
+  event: AndroidShareDocumentEvent,
+  { getAndroidDocumentUserMessage, logger }: IncomingDocumentActionOptions,
+): AndroidIncomingDocumentAction {
+  if (event.error) {
+    const message = getAndroidDocumentUserMessage(event.error)
+    logger?.warn('Android shared document rejected', event.error)
+    return {
+      kind: 'rejected',
+      message,
+      error: event.error,
+    }
+  }
+
+  if (event.document.sourceUri) {
+    return {
+      kind: 'open-document',
+      document: {
+        canceled: false,
+        sourceUri: event.document.sourceUri,
+        displayName: event.document.displayName,
+        providerName: event.document.providerName,
+        pathHint: event.document.pathHint,
+        mimeType: event.document.mimeType,
+        markdown: event.document.markdown,
+        canWrite: event.document.canWrite,
+        persisted: event.document.persisted,
+      },
+      source: 'share',
+      remember: event.document.persisted,
+    }
+  }
+
+  return {
+    kind: 'open-shared-text',
+    document: event.document,
+  }
+}
+
+export function getIncomingDocumentPreservationAction({
+  currentScreen,
+  hasEditor,
+  autosaveTarget,
+}: IncomingDocumentPreservationActionOptions): IncomingDocumentPreservationAction {
+  if (currentScreen !== 'editor' || !hasEditor) {
+    return {
+      kind: 'none',
+    }
+  }
+
+  if (autosaveTarget === 'android-document') {
+    return {
+      kind: 'save-android-document',
+    }
+  }
+
+  return {
+    kind: 'save-local-draft',
+  }
+}
+
+export function shouldKeepAndroidRecoveryAfterPreserveFailure(
+  saved: boolean,
+  sourceUri: string | null,
+  markdown: string,
+) {
+  return !saved && Boolean(sourceUri) && markdown.trim().length > 0
+}

--- a/src/lib/androidRecentDocuments.test.ts
+++ b/src/lib/androidRecentDocuments.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import {
+  markSavedAndroidRecentDocument,
+  rememberAndroidRecentDocument,
+} from './androidRecentDocuments'
+import type { RecentDocumentRecord } from './recentDocuments'
+
+const existingAndroidDocument: RecentDocumentRecord = {
+  id: 'android-document:content://provider/old.md',
+  kind: 'android-document',
+  displayName: 'old.md',
+  title: 'Old',
+  sourceUri: 'content://provider/old.md',
+  providerName: 'Documents',
+  pathHint: 'Documents/old.md',
+  markdownPreview: null,
+  updatedAt: '2026-07-02T00:00:00.000Z',
+  lastOpenedAt: '2026-07-02T00:00:00.000Z',
+  lastSavedAt: null,
+  autosaveState: 'dirty',
+  canWrite: false,
+}
+
+describe('androidRecentDocuments', () => {
+  it('remembers Android documents without storing their Markdown content', () => {
+    const records = rememberAndroidRecentDocument([], {
+      sourceUri: 'content://provider/note.md',
+      displayName: 'note.md',
+      providerName: 'Documents',
+      pathHint: 'Documents/note.md',
+      markdown: '# Android note\n\nbody',
+      canWrite: true,
+    })
+
+    expect(records).toHaveLength(1)
+    expect(records[0]).toMatchObject({
+      id: 'android-document:content://provider/note.md',
+      kind: 'android-document',
+      title: 'Android note',
+      sourceUri: 'content://provider/note.md',
+      markdownPreview: null,
+      canWrite: true,
+      autosaveState: 'clean',
+    })
+  })
+
+  it('updates saved Android recent metadata by source URI', () => {
+    const records = markSavedAndroidRecentDocument(
+      [existingAndroidDocument],
+      'content://provider/old.md',
+      {
+        markdown: '# Saved title\n\nbody',
+        savedAt: '2026-07-02T00:03:00.000Z',
+        canWrite: true,
+      },
+    )
+
+    expect(records).not.toBeNull()
+    expect(records?.[0]).toMatchObject({
+      title: 'Saved title',
+      updatedAt: '2026-07-02T00:03:00.000Z',
+      lastSavedAt: '2026-07-02T00:03:00.000Z',
+      autosaveState: 'clean',
+      markdownPreview: null,
+      canWrite: true,
+    })
+  })
+
+  it('returns null when the saved Android recent record is missing', () => {
+    expect(
+      markSavedAndroidRecentDocument([existingAndroidDocument], 'content://provider/missing.md', {
+        markdown: '# Missing',
+        savedAt: '2026-07-02T00:03:00.000Z',
+        canWrite: true,
+      }),
+    ).toBeNull()
+  })
+})

--- a/src/lib/androidRecentDocuments.ts
+++ b/src/lib/androidRecentDocuments.ts
@@ -1,0 +1,58 @@
+import {
+  createRecentDocumentFromAndroidDocument,
+  markRecentDocumentSaved,
+  upsertRecentDocument,
+  type RecentDocumentRecord,
+} from './recentDocuments'
+
+interface AndroidRecentDocumentSource {
+  sourceUri: string
+  displayName: string
+  providerName: string | null
+  pathHint: string | null
+  markdown: string
+  canWrite: boolean
+}
+
+interface SavedAndroidRecentDocumentOptions {
+  markdown: string
+  savedAt: string
+  canWrite: boolean
+}
+
+export function rememberAndroidRecentDocument(
+  records: RecentDocumentRecord[],
+  document: AndroidRecentDocumentSource,
+) {
+  return upsertRecentDocument(
+    records,
+    createRecentDocumentFromAndroidDocument({
+      sourceUri: document.sourceUri,
+      displayName: document.displayName,
+      providerName: document.providerName,
+      pathHint: document.pathHint,
+      markdown: document.markdown,
+      canWrite: document.canWrite,
+    }),
+  )
+}
+
+export function markSavedAndroidRecentDocument(
+  records: RecentDocumentRecord[],
+  sourceUri: string,
+  options: SavedAndroidRecentDocumentOptions,
+) {
+  const existingDocument = records.find(record => record.sourceUri === sourceUri)
+  if (!existingDocument) {
+    return null
+  }
+
+  return upsertRecentDocument(
+    records,
+    markRecentDocumentSaved(existingDocument, {
+      markdown: options.markdown,
+      savedAt: options.savedAt,
+      canWrite: options.canWrite,
+    }),
+  )
+}

--- a/src/lib/androidRecoveryDrafts.test.ts
+++ b/src/lib/androidRecoveryDrafts.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { createAndroidRecoveryDraft, getAndroidRecoveryDraftId } from './androidRecoveryDrafts'
+
+describe('androidRecoveryDrafts', () => {
+  it('uses a stable draft id derived from the Android source URI', () => {
+    expect(getAndroidRecoveryDraftId('content://test/document')).toBe(
+      'android-recovery:content://test/document',
+    )
+  })
+
+  it('creates local draft records for non-empty Android recovery content', () => {
+    expect(
+      createAndroidRecoveryDraft('content://test/document', '# Kept edits', '2026-07-02T00:00:00Z'),
+    ).toEqual({
+      id: 'android-recovery:content://test/document',
+      markdown: '# Kept edits',
+      updatedAt: '2026-07-02T00:00:00Z',
+      lastSavedAt: null,
+    })
+  })
+
+  it('does not create recovery drafts for blank Markdown', () => {
+    expect(createAndroidRecoveryDraft('content://test/document', '  \n', '2026-07-02T00:00:00Z'))
+      .toBeNull()
+  })
+})

--- a/src/lib/androidRecoveryDrafts.ts
+++ b/src/lib/androidRecoveryDrafts.ts
@@ -1,0 +1,24 @@
+import type { LocalDraftRecord } from './localDrafts'
+
+const ANDROID_RECOVERY_DRAFT_PREFIX = 'android-recovery:'
+
+export function getAndroidRecoveryDraftId(sourceUri: string) {
+  return `${ANDROID_RECOVERY_DRAFT_PREFIX}${sourceUri}`
+}
+
+export function createAndroidRecoveryDraft(
+  sourceUri: string,
+  markdown: string,
+  updatedAt: string,
+): LocalDraftRecord | null {
+  if (!markdown.trim()) {
+    return null
+  }
+
+  return {
+    id: getAndroidRecoveryDraftId(sourceUri),
+    markdown,
+    updatedAt,
+    lastSavedAt: null,
+  }
+}

--- a/src/lib/appExitDecisions.test.ts
+++ b/src/lib/appExitDecisions.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { HOME_TABS } from './homeNavigation'
+import { SETTINGS_PAGES } from './settingsNavigation'
+import {
+  getAppBackButtonAction,
+  getShowHomeAfterAndroidSaveAction,
+  getShowHomeAfterLocalDraftSaveAction,
+  getShowHomeDocumentSaveAction,
+  type AppBackButtonState,
+} from './appExitDecisions'
+
+const baseBackState: AppBackButtonState = {
+  currentScreen: 'home',
+  homeTab: HOME_TABS.DOCUMENTS,
+  settingsPage: SETTINGS_PAGES.INDEX,
+  androidExitPromptOpen: false,
+  draftExitPromptOpen: false,
+  linkSheetOpen: false,
+  editorMenuOpen: false,
+  editorToolbarExpanded: false,
+}
+
+describe('appExitDecisions', () => {
+  it('selects the save flow before leaving the editor', () => {
+    expect(getShowHomeDocumentSaveAction('android-document')).toBe('save-android-document')
+    expect(getShowHomeDocumentSaveAction('local-draft')).toBe('save-local-draft')
+  })
+
+  it('decides the post-save editor exit action for Android documents', () => {
+    expect(getShowHomeAfterAndroidSaveAction({
+      saved: true,
+      shouldPromptAndroidExitAfterSaveFailure: true,
+    })).toBe('close-editor')
+
+    expect(getShowHomeAfterAndroidSaveAction({
+      saved: false,
+      shouldPromptAndroidExitAfterSaveFailure: true,
+    })).toBe('open-android-exit-prompt')
+
+    expect(getShowHomeAfterAndroidSaveAction({
+      saved: false,
+      shouldPromptAndroidExitAfterSaveFailure: false,
+    })).toBe('stay-editor')
+  })
+
+  it('decides the post-save editor exit action for local drafts', () => {
+    expect(getShowHomeAfterLocalDraftSaveAction({
+      shouldPromptLocalDraftSaveToDevice: true,
+    })).toBe('open-local-draft-exit-prompt')
+
+    expect(getShowHomeAfterLocalDraftSaveAction({
+      shouldPromptLocalDraftSaveToDevice: false,
+    })).toBe('close-editor')
+  })
+
+  it('preserves Android back priority for prompts, sheets, menu, toolbar, and editor exit', () => {
+    expect(getAppBackButtonAction({
+      ...baseBackState,
+      currentScreen: 'editor',
+      androidExitPromptOpen: true,
+      draftExitPromptOpen: true,
+      linkSheetOpen: true,
+      editorMenuOpen: true,
+      editorToolbarExpanded: true,
+    })).toBe('close-android-exit-prompt')
+
+    expect(getAppBackButtonAction({
+      ...baseBackState,
+      currentScreen: 'editor',
+      draftExitPromptOpen: true,
+      linkSheetOpen: true,
+      editorMenuOpen: true,
+      editorToolbarExpanded: true,
+    })).toBe('close-local-draft-exit-prompt')
+
+    expect(getAppBackButtonAction({
+      ...baseBackState,
+      currentScreen: 'editor',
+      linkSheetOpen: true,
+      editorMenuOpen: true,
+      editorToolbarExpanded: true,
+    })).toBe('close-link-sheet')
+
+    expect(getAppBackButtonAction({
+      ...baseBackState,
+      currentScreen: 'editor',
+      editorMenuOpen: true,
+      editorToolbarExpanded: true,
+    })).toBe('close-editor-menu')
+
+    expect(getAppBackButtonAction({
+      ...baseBackState,
+      currentScreen: 'editor',
+      editorToolbarExpanded: true,
+    })).toBe('close-editor-toolbar')
+
+    expect(getAppBackButtonAction({
+      ...baseBackState,
+      currentScreen: 'editor',
+    })).toBe('show-home')
+  })
+
+  it('preserves Android back priority on home settings and document tabs', () => {
+    expect(getAppBackButtonAction({
+      ...baseBackState,
+      homeTab: HOME_TABS.SETTINGS,
+      settingsPage: SETTINGS_PAGES.ABOUT,
+    })).toBe('show-settings-index')
+
+    expect(getAppBackButtonAction({
+      ...baseBackState,
+      homeTab: HOME_TABS.SETTINGS,
+      settingsPage: SETTINGS_PAGES.INDEX,
+    })).toBe('show-documents-tab')
+
+    expect(getAppBackButtonAction(baseBackState)).toBe('exit-app')
+  })
+})

--- a/src/lib/appExitDecisions.ts
+++ b/src/lib/appExitDecisions.ts
@@ -1,0 +1,108 @@
+import { HOME_TABS, type HomeTab } from './homeNavigation'
+import { SETTINGS_PAGES, type SettingsPage } from './settingsNavigation'
+import type { AutosaveTarget } from './documentState'
+
+export type AppScreen = 'home' | 'editor'
+
+export type ShowHomeDocumentSaveAction = 'save-android-document' | 'save-local-draft'
+
+export type ShowHomeAfterSaveAction =
+  | 'close-editor'
+  | 'open-android-exit-prompt'
+  | 'open-local-draft-exit-prompt'
+  | 'stay-editor'
+
+export interface AppBackButtonState {
+  currentScreen: AppScreen
+  homeTab: HomeTab
+  settingsPage: SettingsPage
+  androidExitPromptOpen: boolean
+  draftExitPromptOpen: boolean
+  linkSheetOpen: boolean
+  editorMenuOpen: boolean
+  editorToolbarExpanded: boolean
+}
+
+export type AppBackButtonAction =
+  | 'close-android-exit-prompt'
+  | 'close-local-draft-exit-prompt'
+  | 'close-link-sheet'
+  | 'close-editor-menu'
+  | 'close-editor-toolbar'
+  | 'show-home'
+  | 'show-settings-index'
+  | 'show-documents-tab'
+  | 'exit-app'
+
+export function getShowHomeDocumentSaveAction(
+  autosaveTarget: AutosaveTarget,
+): ShowHomeDocumentSaveAction {
+  return autosaveTarget === 'android-document' ? 'save-android-document' : 'save-local-draft'
+}
+
+export function getShowHomeAfterAndroidSaveAction({
+  saved,
+  shouldPromptAndroidExitAfterSaveFailure,
+}: {
+  saved: boolean
+  shouldPromptAndroidExitAfterSaveFailure: boolean
+}): ShowHomeAfterSaveAction {
+  if (saved) {
+    return 'close-editor'
+  }
+
+  return shouldPromptAndroidExitAfterSaveFailure ? 'open-android-exit-prompt' : 'stay-editor'
+}
+
+export function getShowHomeAfterLocalDraftSaveAction({
+  shouldPromptLocalDraftSaveToDevice,
+}: {
+  shouldPromptLocalDraftSaveToDevice: boolean
+}): ShowHomeAfterSaveAction {
+  return shouldPromptLocalDraftSaveToDevice ? 'open-local-draft-exit-prompt' : 'close-editor'
+}
+
+export function getAppBackButtonAction({
+  currentScreen,
+  homeTab,
+  settingsPage,
+  androidExitPromptOpen,
+  draftExitPromptOpen,
+  linkSheetOpen,
+  editorMenuOpen,
+  editorToolbarExpanded,
+}: AppBackButtonState): AppBackButtonAction {
+  if (androidExitPromptOpen) {
+    return 'close-android-exit-prompt'
+  }
+
+  if (draftExitPromptOpen) {
+    return 'close-local-draft-exit-prompt'
+  }
+
+  if (linkSheetOpen) {
+    return 'close-link-sheet'
+  }
+
+  if (editorMenuOpen) {
+    return 'close-editor-menu'
+  }
+
+  if (editorToolbarExpanded) {
+    return 'close-editor-toolbar'
+  }
+
+  if (currentScreen === 'editor') {
+    return 'show-home'
+  }
+
+  if (homeTab === HOME_TABS.SETTINGS && settingsPage !== SETTINGS_PAGES.INDEX) {
+    return 'show-settings-index'
+  }
+
+  if (homeTab !== HOME_TABS.DOCUMENTS) {
+    return 'show-documents-tab'
+  }
+
+  return 'exit-app'
+}

--- a/src/lib/appLifecycleListeners.ts
+++ b/src/lib/appLifecycleListeners.ts
@@ -1,0 +1,76 @@
+import { App } from '@capacitor/app'
+import type { PluginListenerHandle } from '@capacitor/core'
+
+interface AppLifecycleLogger {
+  info(message: string, context?: unknown): void
+  warn(message: string, context?: unknown): void
+}
+
+interface AppLifecycleListenerOptions {
+  onBackButton: () => void | Promise<void>
+  onDocumentHidden: () => void
+  onPageHide: () => void
+  onPause: () => void
+  onInactive: () => void
+  logger?: AppLifecycleLogger
+}
+
+export interface AppLifecycleListeners {
+  remove(): void
+}
+
+export function installAppLifecycleListeners({
+  onBackButton,
+  onDocumentHidden,
+  onPageHide,
+  onPause,
+  onInactive,
+  logger,
+}: AppLifecycleListenerOptions): AppLifecycleListeners {
+  const handleDocumentVisibilityChange = () => {
+    if (document.hidden) {
+      onDocumentHidden()
+    }
+  }
+  const handlePageHide = () => {
+    onPageHide()
+  }
+
+  document.addEventListener('visibilitychange', handleDocumentVisibilityChange)
+  window.addEventListener('pagehide', handlePageHide)
+
+  let appHandles: PluginListenerHandle[] = []
+  void Promise.all([
+    App.addListener('backButton', () => {
+      void onBackButton()
+    }),
+    App.addListener('pause', () => {
+      onPause()
+    }),
+    App.addListener('appStateChange', ({ isActive }) => {
+      if (!isActive) {
+        onInactive()
+      }
+    }),
+  ])
+    .then(handles => {
+      appHandles = handles
+      logger?.info('app lifecycle listeners installed')
+    })
+    .catch(error => {
+      logger?.warn('app lifecycle listeners unavailable', error)
+    })
+
+  return {
+    remove() {
+      document.removeEventListener('visibilitychange', handleDocumentVisibilityChange)
+      window.removeEventListener('pagehide', handlePageHide)
+
+      const handles = appHandles
+      appHandles = []
+      for (const handle of handles) {
+        void handle.remove()
+      }
+    },
+  }
+}

--- a/src/lib/documentSessionState.test.ts
+++ b/src/lib/documentSessionState.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createDocumentStateFromAndroidDocument,
+  createDocumentStateFromLocalDraft,
+  createSavedDocumentStateFromAndroidDocument,
+} from './documentSessionState'
+import type { OpenedAndroidDocument } from './androidDocuments'
+import type { LocalDraftRecord } from './localDrafts'
+
+const localDraft: LocalDraftRecord = {
+  id: 'draft-1',
+  markdown: '# Local draft\n\nbody',
+  updatedAt: '2026-07-02T00:01:00.000Z',
+  lastSavedAt: '2026-07-02T00:00:00.000Z',
+}
+
+const androidDocument: OpenedAndroidDocument = {
+  canceled: false,
+  sourceUri: 'content://provider/note.md',
+  displayName: 'note.md',
+  providerName: 'Documents',
+  pathHint: 'Documents/note.md',
+  mimeType: 'text/markdown',
+  markdown: '# Android note\n\nbody',
+  canWrite: true,
+  persisted: true,
+}
+
+describe('documentSessionState', () => {
+  it('creates editable document state from a local draft record', () => {
+    const documentState = createDocumentStateFromLocalDraft(localDraft)
+
+    expect(documentState).toMatchObject({
+      id: 'draft-1',
+      markdown: '# Local draft\n\nbody',
+      title: 'Local draft',
+      autosaveTarget: 'local-draft',
+      lastSavedAt: '2026-07-02T00:00:00.000Z',
+      updatedAt: '2026-07-02T00:01:00.000Z',
+      sourceUri: null,
+      isDirty: false,
+      autosaveState: 'clean',
+    })
+  })
+
+  it('creates Android document state without marking it saved locally', () => {
+    const documentState = createDocumentStateFromAndroidDocument(androidDocument)
+
+    expect(documentState).toMatchObject({
+      id: 'android-document:content://provider/note.md',
+      markdown: '# Android note\n\nbody',
+      displayName: 'note.md',
+      title: 'Android note',
+      sourceUri: 'content://provider/note.md',
+      autosaveTarget: 'android-document',
+      lastSavedAt: null,
+      isDirty: false,
+      autosaveState: 'clean',
+    })
+  })
+
+  it('creates saved Android document state for documents created by save-copy flows', () => {
+    const documentState = createSavedDocumentStateFromAndroidDocument(
+      androidDocument,
+      '2026-07-02T00:03:00.000Z',
+    )
+
+    expect(documentState).toMatchObject({
+      id: 'android-document:content://provider/note.md',
+      markdown: '# Android note\n\nbody',
+      displayName: 'note.md',
+      sourceUri: 'content://provider/note.md',
+      autosaveTarget: 'android-document',
+      updatedAt: '2026-07-02T00:03:00.000Z',
+      lastSavedAt: '2026-07-02T00:03:00.000Z',
+      isDirty: false,
+      autosaveState: 'clean',
+      lastSaveError: null,
+    })
+  })
+})

--- a/src/lib/documentSessionState.ts
+++ b/src/lib/documentSessionState.ts
@@ -1,0 +1,47 @@
+import { createUntitledDocument, markDocumentSaved } from './documentState'
+import type { OpenedAndroidDocument } from './androidDocuments'
+import type { LocalDraftRecord } from './localDrafts'
+
+export type SavedAndroidDocumentStateSource = OpenedAndroidDocument
+
+export function createDocumentStateFromLocalDraft(draft: LocalDraftRecord) {
+  return {
+    ...createUntitledDocument({
+      markdown: draft.markdown,
+      autosaveTarget: 'local-draft',
+      now: draft.updatedAt,
+    }),
+    id: draft.id,
+    lastSavedAt: draft.lastSavedAt,
+    updatedAt: draft.updatedAt,
+  }
+}
+
+export function createDocumentStateFromAndroidDocument(document: OpenedAndroidDocument) {
+  const openedDocument = createUntitledDocument({
+    markdown: document.markdown,
+    displayName: document.displayName,
+    sourceUri: document.sourceUri,
+    autosaveTarget: 'android-document',
+  })
+
+  return {
+    ...openedDocument,
+    id: `android-document:${document.sourceUri}`,
+    lastSavedAt: null,
+  }
+}
+
+export function createSavedDocumentStateFromAndroidDocument(
+  document: SavedAndroidDocumentStateSource,
+  savedAt: string,
+) {
+  return markDocumentSaved(
+    {
+      ...createDocumentStateFromAndroidDocument(document),
+      updatedAt: savedAt,
+      lastSavedAt: savedAt,
+    },
+    { autosaveTarget: 'android-document', now: savedAt },
+  )
+}

--- a/src/lib/editorInlineInsert.ts
+++ b/src/lib/editorInlineInsert.ts
@@ -1,0 +1,34 @@
+interface EditorDomHost {
+  domNode?: HTMLElement
+}
+
+export function resolveEditorDomNode(
+  editor: unknown,
+  fallback: HTMLElement | null,
+) {
+  return (editor as EditorDomHost | null)?.domNode ?? fallback
+}
+
+export function captureSelectionWithin(root: HTMLElement | null) {
+  const selection = window.getSelection()
+  if (!selection || selection.rangeCount === 0) {
+    return null
+  }
+
+  const range = selection.getRangeAt(0).cloneRange()
+  if (root && !root.contains(range.commonAncestorContainer)) {
+    return null
+  }
+
+  return range
+}
+
+export function insertTextAtRestoredSelection(text: string, range: Range | null) {
+  const selection = window.getSelection()
+  if (selection && range) {
+    selection.removeAllRanges()
+    selection.addRange(range)
+  }
+
+  return document.execCommand('insertText', false, text)
+}

--- a/src/lib/editorRuntime.ts
+++ b/src/lib/editorRuntime.ts
@@ -1,0 +1,92 @@
+type MuyaCoreModule = typeof import('@muyajs/core')
+
+export type MuyaEditor = InstanceType<MuyaCoreModule['Muya']>
+
+interface EditorRuntimeLogger {
+  debug(message: string, context?: Record<string, unknown>): void
+  info?(message: string, context?: Record<string, unknown>): void
+}
+
+interface CreateMuyaEditorOptions {
+  element: HTMLElement
+  markdown: string
+  onContentChange: (...args: unknown[]) => void
+  onJsonChange: (...args: unknown[]) => void
+  onFocus: (...args: unknown[]) => void
+  onBlur: (...args: unknown[]) => void
+  isStale?: () => boolean
+  logger?: EditorRuntimeLogger
+}
+
+let muyaCore: MuyaCoreModule | null = null
+
+async function loadMuyaCore() {
+  if (!muyaCore) {
+    muyaCore = await import('@muyajs/core')
+  }
+
+  return muyaCore
+}
+
+async function registerMuyaPlugins(logger?: EditorRuntimeLogger) {
+  const core = await loadMuyaCore()
+  const editorPlugins = [
+    core.InlineFormatToolbar,
+    core.PreviewToolBar,
+    core.CodeBlockLanguageSelector,
+    core.EmojiSelector,
+  ] as const
+
+  logger?.debug('register Muya plugins start', { count: editorPlugins.length })
+  for (const plugin of editorPlugins) {
+    if (!core.Muya.plugins.some(entry => entry.plugin === plugin)) {
+      core.Muya.use(plugin)
+    }
+  }
+  logger?.debug('register Muya plugins complete', { registered: core.Muya.plugins.length })
+
+  return core
+}
+
+export async function createMuyaEditor({
+  element,
+  markdown,
+  onContentChange,
+  onJsonChange,
+  onFocus,
+  onBlur,
+  isStale,
+  logger,
+}: CreateMuyaEditorOptions) {
+  const { Muya, en } = await registerMuyaPlugins(logger)
+  if (isStale?.()) {
+    return null
+  }
+
+  logger?.info?.('Muya init start', {
+    initialCharacters: markdown.length,
+  })
+  const editor = new Muya(element, {
+    markdown,
+    fontSize: 16,
+    lineHeight: 1.6,
+    codeBlockLineNumbers: true,
+    frontMatter: true,
+    footnote: true,
+    math: true,
+    spellcheckEnabled: true,
+    locale: en,
+  })
+
+  editor.init()
+  editor.on('content-change', onContentChange)
+  editor.on('json-change', onJsonChange)
+  editor.on('focus', onFocus)
+  editor.on('blur', onBlur)
+
+  return editor
+}
+
+export function destroyMuyaEditor(editor: MuyaEditor | null) {
+  editor?.destroy()
+}

--- a/src/lib/editorToolbarWorkflow.test.ts
+++ b/src/lib/editorToolbarWorkflow.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ImportedAndroidImage } from './androidImages'
+import { MOBILE_COMMANDS, type MobileEditorCommandTarget } from './mobileCommands'
+import {
+  createAndroidImageInsertStart,
+  createLinkInsertSheetWorkflow,
+  insertAndroidImageWorkflow,
+  insertLinkFromSheetWorkflow,
+  normalizeToolbarSelectionText,
+  runEditorToolbarCommandWorkflow,
+  scheduleEditorToolbarSync,
+} from './editorToolbarWorkflow'
+
+function createCommandTarget(): MobileEditorCommandTarget {
+  return {
+    undo: vi.fn(),
+    redo: vi.fn(),
+    format: vi.fn().mockReturnValue(true),
+    updateParagraph: vi.fn().mockReturnValue(true),
+  }
+}
+
+const pickedImage: ImportedAndroidImage = {
+  canceled: false,
+  sourceUri: 'content://images/photo.png',
+  displayName: 'Photo.png',
+  mimeType: 'image/png',
+  markdownSrc: 'marktext-image://local/photo.png',
+  fileUri: 'file:///images/photo.png',
+  bytes: 42,
+}
+
+describe('editorToolbarWorkflow', () => {
+  it('routes toolbar commands to link, image, or Muya command execution', () => {
+    const target = createCommandTarget()
+
+    expect(runEditorToolbarCommandWorkflow({
+      commandId: MOBILE_COMMANDS.FORMAT_HYPERLINK,
+      editorReady: true,
+      hasEditor: true,
+      commandTarget: target,
+      beforeMarkdown: 'before',
+    })).toEqual({ kind: 'open-link-sheet' })
+
+    expect(runEditorToolbarCommandWorkflow({
+      commandId: MOBILE_COMMANDS.FORMAT_IMAGE,
+      editorReady: true,
+      hasEditor: true,
+      commandTarget: target,
+      beforeMarkdown: 'before',
+    })).toEqual({ kind: 'insert-image' })
+
+    expect(runEditorToolbarCommandWorkflow({
+      commandId: MOBILE_COMMANDS.FORMAT_STRONG,
+      editorReady: true,
+      hasEditor: true,
+      commandTarget: target,
+      beforeMarkdown: 'before',
+    })).toEqual({
+      kind: 'handled',
+      commandId: MOBILE_COMMANDS.FORMAT_STRONG,
+      beforeMarkdown: 'before',
+    })
+    expect(target.format).toHaveBeenCalledWith('strong')
+  })
+
+  it('keeps toolbar commands inert when the editor is unavailable or command execution fails', () => {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }
+    const throwingTarget = {
+      ...createCommandTarget(),
+      format: vi.fn(() => {
+        throw new Error('format failed')
+      }),
+    }
+
+    expect(runEditorToolbarCommandWorkflow({
+      commandId: MOBILE_COMMANDS.FORMAT_STRONG,
+      editorReady: false,
+      hasEditor: false,
+      commandTarget: null,
+      beforeMarkdown: 'before',
+      logger,
+    })).toMatchObject({
+      kind: 'not-ready',
+      commandId: MOBILE_COMMANDS.FORMAT_STRONG,
+    })
+
+    expect(runEditorToolbarCommandWorkflow({
+      commandId: MOBILE_COMMANDS.FORMAT_STRONG,
+      editorReady: true,
+      hasEditor: true,
+      commandTarget: throwingTarget,
+      beforeMarkdown: 'before',
+      logger,
+    })).toMatchObject({
+      kind: 'failed',
+      commandId: MOBILE_COMMANDS.FORMAT_STRONG,
+    })
+  })
+
+  it('prepares and inserts Markdown links from the sheet state', () => {
+    expect(createLinkInsertSheetWorkflow({
+      editorReady: true,
+      hasEditor: true,
+      selectedText: '  selected   text  ',
+    })).toEqual({
+      kind: 'open',
+      linkText: 'selected text',
+      linkUrl: '',
+    })
+
+    const insertMarkdown = vi.fn().mockReturnValue(true)
+    const result = insertLinkFromSheetWorkflow({
+      hasEditor: true,
+      linkText: 'selected text',
+      linkUrl: 'https://example.com/a)b',
+      beforeMarkdown: 'before',
+      insertMarkdown,
+    })
+
+    expect(result).toEqual({
+      kind: 'inserted',
+      beforeMarkdown: 'before',
+    })
+    expect(insertMarkdown).toHaveBeenCalledWith('[selected text](https://example.com/a\\)b)')
+  })
+
+  it('prepares Android image insertion and inserts selected text as alt text', async () => {
+    expect(createAndroidImageInsertStart({
+      editorReady: true,
+      hasEditor: true,
+      importing: false,
+      isAvailable: true,
+      unavailableStatus: 'unavailable',
+    })).toEqual({
+      kind: 'ready',
+      status: 'Choose an image',
+    })
+
+    const insertMarkdown = vi.fn().mockReturnValue(true)
+    const result = await insertAndroidImageWorkflow({
+      selectedText: normalizeToolbarSelectionText('  alt   text  '),
+      ensureAndroidImageResolver: vi.fn().mockResolvedValue(undefined),
+      pickAndroidImageDocument: vi.fn().mockResolvedValue(pickedImage),
+      insertMarkdown,
+      getAndroidImageUserMessage: () => 'failed',
+    })
+
+    expect(result).toEqual({
+      kind: 'inserted',
+      status: 'Image inserted',
+    })
+    expect(insertMarkdown).toHaveBeenCalledWith('![alt text](marktext-image://local/photo.png)')
+  })
+
+  it('returns Android image cancellation, insertion failure, and picker failure as explicit results', async () => {
+    await expect(insertAndroidImageWorkflow({
+      selectedText: '',
+      ensureAndroidImageResolver: vi.fn().mockResolvedValue(undefined),
+      pickAndroidImageDocument: vi.fn().mockResolvedValue({ canceled: true }),
+      insertMarkdown: vi.fn(),
+      getAndroidImageUserMessage: () => 'failed',
+    })).resolves.toEqual({
+      kind: 'canceled',
+      status: 'Ready',
+    })
+
+    await expect(insertAndroidImageWorkflow({
+      selectedText: '',
+      ensureAndroidImageResolver: vi.fn().mockResolvedValue(undefined),
+      pickAndroidImageDocument: vi.fn().mockResolvedValue(pickedImage),
+      insertMarkdown: vi.fn().mockReturnValue(false),
+      getAndroidImageUserMessage: () => 'failed',
+    })).resolves.toEqual({
+      kind: 'insert-failed',
+      status: 'Image insert failed',
+    })
+
+    await expect(insertAndroidImageWorkflow({
+      selectedText: '',
+      ensureAndroidImageResolver: vi.fn().mockRejectedValue(new Error('resolver failed')),
+      pickAndroidImageDocument: vi.fn(),
+      insertMarkdown: vi.fn(),
+      getAndroidImageUserMessage: error => `message: ${(error as Error).message}`,
+    })).resolves.toMatchObject({
+      kind: 'failed',
+      status: 'message: resolver failed',
+    })
+  })
+
+  it('schedules editor sync only when normalized Markdown changes', () => {
+    const edited = vi.fn()
+    const unchanged = vi.fn()
+
+    scheduleEditorToolbarSync({
+      beforeMarkdown: '\n',
+      requestFrame: callback => callback(),
+      getMarkdown: () => '',
+      normalizeMarkdown: markdown => markdown === '\n' ? '' : markdown,
+      onEdited: edited,
+      onUnchanged: unchanged,
+    })
+
+    expect(edited).not.toHaveBeenCalled()
+    expect(unchanged).toHaveBeenCalledOnce()
+
+    scheduleEditorToolbarSync({
+      beforeMarkdown: 'before',
+      requestFrame: callback => callback(),
+      getMarkdown: () => 'after',
+      normalizeMarkdown: markdown => markdown,
+      onEdited: edited,
+      onUnchanged: unchanged,
+    })
+
+    expect(edited).toHaveBeenCalledOnce()
+  })
+})

--- a/src/lib/editorToolbarWorkflow.ts
+++ b/src/lib/editorToolbarWorkflow.ts
@@ -1,0 +1,332 @@
+import type { ImportedAndroidImage } from './androidImages'
+import {
+  buildMarkdownImage,
+  buildMarkdownLink,
+  normalizeLinkField,
+} from './editorMarkdownInsert'
+import {
+  MOBILE_COMMANDS,
+  runMobileEditorCommand,
+  type MobileCommandId,
+  type MobileCommandResult,
+  type MobileEditorCommandTarget,
+} from './mobileCommands'
+
+interface WorkflowLogger {
+  info(message: string, data?: unknown): void
+  warn(message: string, data?: unknown): void
+  error(message: string, data?: unknown): void
+}
+
+type AndroidImagePickResult = ImportedAndroidImage | { canceled: true }
+
+export type EditorToolbarCommandWorkflowResult =
+  | {
+      kind: 'not-ready'
+      commandId: MobileCommandId
+    }
+  | {
+      kind: 'open-link-sheet'
+    }
+  | {
+      kind: 'insert-image'
+    }
+  | {
+      kind: 'handled'
+      commandId: MobileCommandId
+      beforeMarkdown: string
+    }
+  | {
+      kind: 'not-handled'
+      result: MobileCommandResult
+    }
+  | {
+      kind: 'failed'
+      commandId: MobileCommandId
+      error: unknown
+    }
+
+interface RunEditorToolbarCommandWorkflowOptions {
+  commandId: MobileCommandId
+  editorReady: boolean
+  hasEditor: boolean
+  commandTarget: MobileEditorCommandTarget | null
+  beforeMarkdown: string
+  logger?: WorkflowLogger
+}
+
+export function runEditorToolbarCommandWorkflow({
+  commandId,
+  editorReady,
+  hasEditor,
+  commandTarget,
+  beforeMarkdown,
+  logger,
+}: RunEditorToolbarCommandWorkflowOptions): EditorToolbarCommandWorkflowResult {
+  if (!editorReady || !hasEditor) {
+    logger?.warn('mobile toolbar command skipped because editor is not ready', { commandId })
+    return {
+      kind: 'not-ready',
+      commandId,
+    }
+  }
+
+  if (commandId === MOBILE_COMMANDS.FORMAT_HYPERLINK) {
+    return { kind: 'open-link-sheet' }
+  }
+
+  if (commandId === MOBILE_COMMANDS.FORMAT_IMAGE) {
+    return { kind: 'insert-image' }
+  }
+
+  try {
+    const result = runMobileEditorCommand(commandTarget, commandId)
+    if (!result.handled) {
+      logger?.warn('mobile toolbar command was not handled', result)
+      return {
+        kind: 'not-handled',
+        result,
+      }
+    }
+
+    logger?.info('mobile toolbar command handled', { commandId })
+    return {
+      kind: 'handled',
+      commandId,
+      beforeMarkdown,
+    }
+  } catch (error) {
+    logger?.error('mobile toolbar command failed', { commandId, error })
+    return {
+      kind: 'failed',
+      commandId,
+      error,
+    }
+  }
+}
+
+export type LinkInsertSheetWorkflowResult =
+  | {
+      kind: 'not-ready'
+    }
+  | {
+      kind: 'open'
+      linkText: string
+      linkUrl: ''
+    }
+
+export function createLinkInsertSheetWorkflow({
+  editorReady,
+  hasEditor,
+  selectedText,
+}: {
+  editorReady: boolean
+  hasEditor: boolean
+  selectedText: string
+}): LinkInsertSheetWorkflowResult {
+  if (!editorReady || !hasEditor) {
+    return { kind: 'not-ready' }
+  }
+
+  return {
+    kind: 'open',
+    linkText: normalizeLinkField(selectedText),
+    linkUrl: '',
+  }
+}
+
+export type InsertLinkFromSheetWorkflowResult =
+  | {
+      kind: 'not-ready'
+    }
+  | {
+      kind: 'insert-failed'
+    }
+  | {
+      kind: 'inserted'
+      beforeMarkdown: string
+    }
+
+export function insertLinkFromSheetWorkflow({
+  hasEditor,
+  linkText,
+  linkUrl,
+  beforeMarkdown,
+  insertMarkdown,
+  logger,
+}: {
+  hasEditor: boolean
+  linkText: string
+  linkUrl: string
+  beforeMarkdown: string
+  insertMarkdown: (markdown: string) => boolean
+  logger?: WorkflowLogger
+}): InsertLinkFromSheetWorkflowResult {
+  if (!hasEditor || !linkUrl.trim()) {
+    return { kind: 'not-ready' }
+  }
+
+  if (!insertMarkdown(buildMarkdownLink(linkText, linkUrl))) {
+    logger?.warn('mobile link insert failed because text insertion was not handled')
+    return { kind: 'insert-failed' }
+  }
+
+  return {
+    kind: 'inserted',
+    beforeMarkdown,
+  }
+}
+
+export type AndroidImageInsertStartResult =
+  | {
+      kind: 'not-ready'
+    }
+  | {
+      kind: 'unavailable'
+      status: string
+    }
+  | {
+      kind: 'ready'
+      status: 'Choose an image'
+    }
+
+export function createAndroidImageInsertStart({
+  editorReady,
+  hasEditor,
+  importing,
+  isAvailable,
+  unavailableStatus,
+  logger,
+}: {
+  editorReady: boolean
+  hasEditor: boolean
+  importing: boolean
+  isAvailable: boolean
+  unavailableStatus: string
+  logger?: WorkflowLogger
+}): AndroidImageInsertStartResult {
+  if (!editorReady || !hasEditor || importing) {
+    return { kind: 'not-ready' }
+  }
+
+  if (!isAvailable) {
+    logger?.warn('mobile image insert skipped because Android image import is unavailable')
+    return {
+      kind: 'unavailable',
+      status: unavailableStatus,
+    }
+  }
+
+  return {
+    kind: 'ready',
+    status: 'Choose an image',
+  }
+}
+
+export type InsertAndroidImageWorkflowResult =
+  | {
+      kind: 'canceled'
+      status: 'Ready'
+    }
+  | {
+      kind: 'insert-failed'
+      status: 'Image insert failed'
+    }
+  | {
+      kind: 'inserted'
+      status: 'Image inserted'
+    }
+  | {
+      kind: 'failed'
+      status: string
+      error: unknown
+    }
+
+export async function insertAndroidImageWorkflow({
+  selectedText,
+  ensureAndroidImageResolver,
+  pickAndroidImageDocument,
+  insertMarkdown,
+  getAndroidImageUserMessage,
+  logger,
+}: {
+  selectedText: string
+  ensureAndroidImageResolver: () => Promise<void>
+  pickAndroidImageDocument: () => Promise<AndroidImagePickResult>
+  insertMarkdown: (markdown: string) => boolean
+  getAndroidImageUserMessage: (error: unknown) => string
+  logger?: WorkflowLogger
+}): Promise<InsertAndroidImageWorkflowResult> {
+  try {
+    await ensureAndroidImageResolver()
+    const image = await pickAndroidImageDocument()
+    if (image.canceled) {
+      return {
+        kind: 'canceled',
+        status: 'Ready',
+      }
+    }
+
+    const alt = selectedText || image.displayName
+    const markdownImage = buildMarkdownImage(alt, image.markdownSrc)
+    if (!insertMarkdown(markdownImage)) {
+      logger?.warn('mobile image insert failed because text insertion was not handled')
+      return {
+        kind: 'insert-failed',
+        status: 'Image insert failed',
+      }
+    }
+
+    logger?.info('mobile image inserted', {
+      displayName: image.displayName,
+      mimeType: image.mimeType,
+      bytes: image.bytes,
+    })
+
+    return {
+      kind: 'inserted',
+      status: 'Image inserted',
+    }
+  } catch (error) {
+    logger?.error('mobile image insert failed', error)
+    return {
+      kind: 'failed',
+      status: getAndroidImageUserMessage(error),
+      error,
+    }
+  }
+}
+
+export function normalizeToolbarSelectionText(value: string) {
+  return normalizeLinkField(value)
+}
+
+export function scheduleEditorToolbarSync({
+  beforeMarkdown,
+  requestFrame,
+  getMarkdown,
+  normalizeMarkdown,
+  onEdited,
+  onUnchanged,
+}: {
+  beforeMarkdown: string
+  requestFrame: (callback: () => void) => void
+  getMarkdown: () => string | null
+  normalizeMarkdown: (markdown: string) => string
+  onEdited: () => void
+  onUnchanged: () => void
+}) {
+  requestFrame(() => {
+    const nextMarkdown = getMarkdown()
+    if (nextMarkdown === null) {
+      return
+    }
+
+    if (normalizeMarkdown(nextMarkdown) !== normalizeMarkdown(beforeMarkdown)) {
+      onEdited()
+      return
+    }
+
+    onUnchanged()
+  })
+}

--- a/src/lib/localDraftAutosave.test.ts
+++ b/src/lib/localDraftAutosave.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { createUntitledDocument, updateDocumentMarkdown } from './documentState'
+import { createLocalDraftAutosaveResult } from './localDraftAutosave'
+import type { LocalDraftRecord } from './localDrafts'
+
+const existingDraft: LocalDraftRecord = {
+  id: 'draft-1',
+  markdown: '# Existing',
+  updatedAt: '2026-07-02T00:00:00.000Z',
+  lastSavedAt: '2026-07-02T00:00:00.000Z',
+}
+
+describe('localDraftAutosave', () => {
+  it('creates a saved document and upserts non-empty local draft content', () => {
+    const documentState = updateDocumentMarkdown(
+      createUntitledDocument({
+        markdown: '# Existing',
+        now: '2026-07-02T00:00:00.000Z',
+      }),
+      '# Updated draft\n\nbody',
+    )
+    const result = createLocalDraftAutosaveResult(documentState, '# Updated draft\n\nbody', [
+      existingDraft,
+    ])
+
+    expect(result.hasContent).toBe(true)
+    expect(result.savingDocument.autosaveState).toBe('saving')
+    expect(result.savedDocument.autosaveTarget).toBe('local-draft')
+    expect(result.savedDocument.autosaveState).toBe('clean')
+    expect(result.savedDocument.isDirty).toBe(false)
+    expect(result.nextDrafts[0]).toMatchObject({
+      id: documentState.id,
+      markdown: '# Updated draft\n\nbody',
+      lastSavedAt: result.savedDocument.lastSavedAt,
+    })
+  })
+
+  it('removes the local draft when autosaved Markdown is blank', () => {
+    const documentState = createUntitledDocument({
+      markdown: '# Existing',
+      now: '2026-07-02T00:00:00.000Z',
+    })
+    const result = createLocalDraftAutosaveResult(documentState, '   ', [
+      { ...existingDraft, id: documentState.id },
+    ])
+
+    expect(result.hasContent).toBe(false)
+    expect(result.savedDocument.markdown).toBe('   ')
+    expect(result.nextDrafts).toEqual([])
+  })
+})

--- a/src/lib/localDraftAutosave.ts
+++ b/src/lib/localDraftAutosave.ts
@@ -1,0 +1,48 @@
+import {
+  markDocumentSaved,
+  markDocumentSaving,
+  updateDocumentMarkdown,
+  type MarkdownDocumentState,
+} from './documentState'
+import {
+  removeLocalDraft,
+  upsertLocalDraft,
+  type LocalDraftRecord,
+} from './localDrafts'
+
+export interface LocalDraftAutosaveResult {
+  savingDocument: MarkdownDocumentState
+  savedDocument: MarkdownDocumentState
+  nextDrafts: LocalDraftRecord[]
+  hasContent: boolean
+}
+
+export function createLocalDraftAutosaveResult(
+  documentState: MarkdownDocumentState,
+  markdown: string,
+  drafts: LocalDraftRecord[],
+): LocalDraftAutosaveResult {
+  const hasContent = markdown.trim().length > 0
+  const savingDocument = markDocumentSaving(
+    updateDocumentMarkdown(documentState, markdown, { markDirty: documentState.isDirty }),
+  )
+  const savedDocument = markDocumentSaved(
+    updateDocumentMarkdown(savingDocument, markdown, { markDirty: false }),
+    { autosaveTarget: 'local-draft' },
+  )
+  const nextDrafts = hasContent
+    ? upsertLocalDraft(drafts, {
+        id: savedDocument.id,
+        markdown: savedDocument.markdown,
+        updatedAt: savedDocument.updatedAt,
+        lastSavedAt: savedDocument.lastSavedAt,
+      })
+    : removeLocalDraft(drafts, savedDocument.id)
+
+  return {
+    savingDocument,
+    savedDocument,
+    nextDrafts,
+    hasContent,
+  }
+}

--- a/src/lib/saveAndroidDocumentCopyWorkflow.test.ts
+++ b/src/lib/saveAndroidDocumentCopyWorkflow.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createUntitledDocument, updateDocumentMarkdown } from './documentState'
+import { saveAndroidDocumentCopyWorkflow } from './saveAndroidDocumentCopyWorkflow'
+import type { OpenedAndroidDocument } from './androidDocuments'
+
+function createAndroidDocumentState(markdown = '# Original\n\nbody') {
+  return createUntitledDocument({
+    markdown,
+    displayName: 'Original.md',
+    sourceUri: 'content://provider/original.md',
+    autosaveTarget: 'android-document',
+    now: '2026-07-02T00:00:00.000Z',
+  })
+}
+
+function createDirtyAndroidDocumentState(markdown = '# Original\n\nbody\n\nchanged') {
+  return updateDocumentMarkdown(createAndroidDocumentState(), markdown, {
+    markDirty: true,
+    now: '2026-07-02T00:01:00.000Z',
+  })
+}
+
+const persistedDocument: OpenedAndroidDocument = {
+  canceled: false,
+  sourceUri: 'content://provider/original-copy.md',
+  displayName: 'Original copy.md',
+  providerName: 'Documents',
+  pathHint: 'Documents/Original copy.md',
+  mimeType: 'text/markdown',
+  markdown: 'plugin markdown',
+  canWrite: true,
+  persisted: true,
+}
+
+describe('saveAndroidDocumentCopyWorkflow', () => {
+  it('creates Android Markdown copy with an incremented suggested file name and handles cancelation', async () => {
+    const createAndroidMarkdownDocument = vi.fn().mockResolvedValue({ canceled: true })
+
+    const result = await saveAndroidDocumentCopyWorkflow({
+      copySourceDocument: createAndroidDocumentState('# Original Save Copy\n\nbody'),
+      originalSourceUri: 'content://provider/original.md',
+      reservedDisplayNames: ['Original Save Copy copy.md'],
+      returnHomeAfterSave: true,
+      transientAccessMessage: 'transient',
+      createAndroidMarkdownDocument,
+      getAndroidDocumentUserMessage: () => 'failed',
+    })
+
+    expect(createAndroidMarkdownDocument).toHaveBeenCalledWith(
+      '# Original Save Copy\n\nbody',
+      'Original Save Copy copy 2.md',
+    )
+    expect(result).toEqual({
+      kind: 'canceled',
+    })
+  })
+
+  it('keeps a recovery draft request when the copy is created without persisted access', async () => {
+    const transientDocument = {
+      ...persistedDocument,
+      sourceUri: 'content://provider/transient-copy.md',
+      displayName: 'Transient copy.md',
+      persisted: false,
+    }
+
+    const result = await saveAndroidDocumentCopyWorkflow({
+      copySourceDocument: createDirtyAndroidDocumentState(),
+      originalSourceUri: 'content://provider/original.md',
+      reservedDisplayNames: [],
+      returnHomeAfterSave: true,
+      transientAccessMessage: 'Saved transiently',
+      createAndroidMarkdownDocument: vi.fn().mockResolvedValue(transientDocument),
+      getAndroidDocumentUserMessage: () => 'failed',
+    })
+
+    expect(result).toMatchObject({
+      kind: 'transient',
+      status: 'Saved transiently',
+      createdDocument: {
+        sourceUri: 'content://provider/transient-copy.md',
+        markdown: '# Original\n\nbody\n\nchanged',
+      },
+      recoveryDraft: {
+        sourceUri: 'content://provider/original.md',
+        markdown: '# Original\n\nbody\n\nchanged',
+      },
+    })
+  })
+
+  it('returns the saved copy state and recovery draft removal source', async () => {
+    const result = await saveAndroidDocumentCopyWorkflow({
+      copySourceDocument: createDirtyAndroidDocumentState(),
+      originalSourceUri: 'content://provider/original.md',
+      reservedDisplayNames: [],
+      returnHomeAfterSave: true,
+      transientAccessMessage: 'transient',
+      createAndroidMarkdownDocument: vi.fn().mockResolvedValue(persistedDocument),
+      getAndroidDocumentUserMessage: () => 'failed',
+      now: () => '2026-07-02T00:03:00.000Z',
+    })
+
+    expect(result).toMatchObject({
+      kind: 'saved',
+      canWrite: true,
+      removeRecoveryDraftSourceUri: 'content://provider/original.md',
+      closeEditorToHome: true,
+      createdDocument: {
+        sourceUri: 'content://provider/original-copy.md',
+        markdown: '# Original\n\nbody\n\nchanged',
+      },
+      savedDocument: {
+        id: 'android-document:content://provider/original-copy.md',
+        autosaveTarget: 'android-document',
+        autosaveState: 'clean',
+        isDirty: false,
+        lastSavedAt: '2026-07-02T00:03:00.000Z',
+      },
+    })
+  })
+
+  it('returns failed document state, status, and recovery draft request on save-copy failure', async () => {
+    const result = await saveAndroidDocumentCopyWorkflow({
+      copySourceDocument: createDirtyAndroidDocumentState(),
+      originalSourceUri: 'content://provider/original.md',
+      reservedDisplayNames: [],
+      returnHomeAfterSave: false,
+      transientAccessMessage: 'transient',
+      createAndroidMarkdownDocument: vi.fn().mockRejectedValue(new Error('creator failed')),
+      getAndroidDocumentUserMessage: error => `message: ${(error as Error).message}`,
+    })
+
+    expect(result).toMatchObject({
+      kind: 'failed',
+      status: 'message: creator failed',
+      failedDocument: {
+        isDirty: true,
+        autosaveState: 'save-failed',
+        lastSaveError: 'creator failed',
+      },
+      recoveryDraft: {
+        sourceUri: 'content://provider/original.md',
+        markdown: '# Original\n\nbody\n\nchanged',
+      },
+    })
+  })
+})

--- a/src/lib/saveAndroidDocumentCopyWorkflow.ts
+++ b/src/lib/saveAndroidDocumentCopyWorkflow.ts
@@ -1,0 +1,165 @@
+import {
+  getSuggestedMarkdownCopyFileName,
+  markDocumentSaveFailed,
+  prepareMarkdownForSave,
+  type MarkdownDocumentState,
+} from './documentState'
+import {
+  createSavedDocumentStateFromAndroidDocument,
+  type SavedAndroidDocumentStateSource,
+} from './documentSessionState'
+import type { OpenedAndroidDocument } from './androidDocuments'
+
+interface CanceledAndroidDocumentCreate {
+  canceled: true
+}
+
+type AndroidDocumentCreateResult = OpenedAndroidDocument | CanceledAndroidDocumentCreate
+
+interface WorkflowLogger {
+  info(message: string, data?: unknown): void
+  warn(message: string, data?: unknown): void
+  error(message: string, data?: unknown): void
+}
+
+interface AndroidRecoveryDraftRequest {
+  sourceUri: string
+  markdown: string
+}
+
+export type SaveAndroidDocumentCopyResult =
+  | {
+      kind: 'canceled'
+    }
+  | {
+      kind: 'transient'
+      status: string
+      createdDocument: OpenedAndroidDocument
+      recoveryDraft: AndroidRecoveryDraftRequest | null
+    }
+  | {
+      kind: 'saved'
+      savedDocument: MarkdownDocumentState
+      createdDocument: SavedAndroidDocumentStateSource
+      canWrite: boolean
+      removeRecoveryDraftSourceUri: string | null
+      closeEditorToHome: boolean
+    }
+  | {
+      kind: 'failed'
+      failedDocument: MarkdownDocumentState
+      status: string
+      recoveryDraft: AndroidRecoveryDraftRequest | null
+      error: unknown
+    }
+
+interface SaveAndroidDocumentCopyWorkflowOptions {
+  copySourceDocument: MarkdownDocumentState
+  originalSourceUri: string | null
+  reservedDisplayNames: string[]
+  returnHomeAfterSave: boolean
+  transientAccessMessage: string
+  createAndroidMarkdownDocument: (
+    markdown: string,
+    suggestedName: string,
+  ) => Promise<AndroidDocumentCreateResult>
+  getAndroidDocumentUserMessage: (error: unknown) => string
+  now?: () => string
+  logger?: WorkflowLogger
+}
+
+function createRecoveryDraftRequest(
+  originalSourceUri: string | null,
+  copySourceDocument: MarkdownDocumentState,
+): AndroidRecoveryDraftRequest | null {
+  if (!originalSourceUri || !copySourceDocument.isDirty || !copySourceDocument.markdown.trim()) {
+    return null
+  }
+
+  return {
+    sourceUri: originalSourceUri,
+    markdown: copySourceDocument.markdown,
+  }
+}
+
+export async function saveAndroidDocumentCopyWorkflow({
+  copySourceDocument,
+  originalSourceUri,
+  reservedDisplayNames,
+  returnHomeAfterSave,
+  transientAccessMessage,
+  createAndroidMarkdownDocument,
+  getAndroidDocumentUserMessage,
+  now = () => new Date().toISOString(),
+  logger,
+}: SaveAndroidDocumentCopyWorkflowOptions): Promise<SaveAndroidDocumentCopyResult> {
+  const markdownForSave = prepareMarkdownForSave(copySourceDocument.markdown, copySourceDocument)
+  const suggestedName = getSuggestedMarkdownCopyFileName(
+    copySourceDocument.markdown,
+    copySourceDocument.displayName,
+    reservedDisplayNames,
+  )
+
+  try {
+    const document = await createAndroidMarkdownDocument(markdownForSave, suggestedName)
+    if (document.canceled) {
+      logger?.info('Android document save copy canceled', {
+        sourceUri: originalSourceUri,
+      })
+      return {
+        kind: 'canceled',
+      }
+    }
+
+    const createdDocument = {
+      ...document,
+      markdown: copySourceDocument.markdown,
+    }
+
+    if (!document.persisted) {
+      logger?.warn('saved Android document copy without persisted access', {
+        originalSourceUri,
+        displayName: document.displayName,
+        sourceUri: document.sourceUri,
+        characters: copySourceDocument.markdown.length,
+      })
+
+      return {
+        kind: 'transient',
+        status: transientAccessMessage,
+        createdDocument,
+        recoveryDraft: createRecoveryDraftRequest(originalSourceUri, copySourceDocument),
+      }
+    }
+
+    const savedAt = now()
+    logger?.info('Android document saved as copy', {
+      originalSourceUri,
+      displayName: document.displayName,
+      sourceUri: document.sourceUri,
+      characters: copySourceDocument.markdown.length,
+    })
+
+    return {
+      kind: 'saved',
+      savedDocument: createSavedDocumentStateFromAndroidDocument(createdDocument, savedAt),
+      createdDocument,
+      canWrite: document.canWrite,
+      removeRecoveryDraftSourceUri: originalSourceUri,
+      closeEditorToHome: returnHomeAfterSave,
+    }
+  } catch (error) {
+    logger?.error('Android document save copy failed', {
+      originalSourceUri,
+      error,
+    })
+
+    return {
+      kind: 'failed',
+      failedDocument: markDocumentSaveFailed(copySourceDocument, error),
+      status: getAndroidDocumentUserMessage(error),
+      recoveryDraft: createRecoveryDraftRequest(originalSourceUri, copySourceDocument),
+      error,
+    }
+  }
+}

--- a/src/lib/saveAndroidDocumentWorkflow.test.ts
+++ b/src/lib/saveAndroidDocumentWorkflow.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createUntitledDocument, updateDocumentMarkdown } from './documentState'
+import {
+  createSaveAndroidDocumentWorkflowStart,
+  saveAndroidDocumentWorkflow,
+  type SaveAndroidDocumentWorkflowRequest,
+} from './saveAndroidDocumentWorkflow'
+
+function createAndroidDocumentState(markdown = '# Android\n\nbody') {
+  return createUntitledDocument({
+    markdown,
+    displayName: 'Android.md',
+    sourceUri: 'content://provider/android.md',
+    autosaveTarget: 'android-document',
+    now: '2026-07-02T00:00:00.000Z',
+  })
+}
+
+function createDirtyAndroidDocumentState(markdown = '# Android\n\nbody\n\nchanged') {
+  return updateDocumentMarkdown(createAndroidDocumentState(), markdown, {
+    markDirty: true,
+    now: '2026-07-02T00:01:00.000Z',
+  })
+}
+
+function createWorkflowRequest(
+  documentState = createDirtyAndroidDocumentState(),
+): SaveAndroidDocumentWorkflowRequest {
+  const start = createSaveAndroidDocumentWorkflowStart({
+    documentState,
+    markdown: documentState.markdown,
+    canWrite: true,
+  })
+
+  if (start.kind !== 'ready') {
+    throw new Error(`unexpected start result: ${start.kind}`)
+  }
+
+  return start.request
+}
+
+describe('saveAndroidDocumentWorkflow', () => {
+  it('returns explicit preflight results for missing source, read-only, and clean documents', () => {
+    const missingSource = createUntitledDocument({
+      markdown: '# Missing source',
+      autosaveTarget: 'android-document',
+      sourceUri: null,
+    })
+    const readOnlyDirty = createDirtyAndroidDocumentState()
+    const cleanDocument = createAndroidDocumentState()
+
+    expect(createSaveAndroidDocumentWorkflowStart({
+      documentState: missingSource,
+      markdown: missingSource.markdown,
+      canWrite: true,
+    })).toMatchObject({
+      kind: 'missing-source',
+      saved: false,
+      status: 'Save failed',
+    })
+
+    expect(createSaveAndroidDocumentWorkflowStart({
+      documentState: readOnlyDirty,
+      markdown: readOnlyDirty.markdown,
+      canWrite: false,
+    })).toMatchObject({
+      kind: 'read-only',
+      saved: false,
+      status: 'This file is read-only.',
+    })
+
+    expect(createSaveAndroidDocumentWorkflowStart({
+      documentState: cleanDocument,
+      markdown: cleanDocument.markdown,
+      canWrite: true,
+    })).toEqual({
+      kind: 'clean',
+      saved: true,
+    })
+  })
+
+  it('writes prepared Markdown and returns a saved document result', async () => {
+    const documentState = updateDocumentMarkdown(
+      createAndroidDocumentState('# Android\r\n\r\nbody\r\n'),
+      '# Android\n\nbody\n\nchanged\n',
+      { markDirty: true, now: '2026-07-02T00:01:00.000Z' },
+    )
+    const request = createWorkflowRequest(documentState)
+    const writeAndroidMarkdownDocument = vi.fn().mockResolvedValue(undefined)
+
+    const result = await saveAndroidDocumentWorkflow({
+      request,
+      getCurrentDocumentState: () => request.savingDocument,
+      writeAndroidMarkdownDocument,
+      getAndroidDocumentUserMessage: () => 'Save failed',
+      recoveryMessage: 'A recovery draft was kept.',
+      now: () => '2026-07-02T00:02:00.000Z',
+    })
+
+    expect(writeAndroidMarkdownDocument).toHaveBeenCalledWith(
+      'content://provider/android.md',
+      '# Android\r\n\r\nbody\r\n\r\nchanged\r\n',
+    )
+    expect(result).toMatchObject({
+      kind: 'saved',
+      saved: true,
+      savedAt: '2026-07-02T00:02:00.000Z',
+      sourceUri: 'content://provider/android.md',
+      status: 'Saved',
+      savedDocument: {
+        isDirty: false,
+        autosaveState: 'clean',
+        lastSavedAt: '2026-07-02T00:02:00.000Z',
+      },
+    })
+  })
+
+  it('requests another save when the active document changes during the write', async () => {
+    const request = createWorkflowRequest()
+    const changedDocument = updateDocumentMarkdown(
+      request.savingDocument,
+      '# Android\n\nchanged again',
+      { markDirty: true, now: '2026-07-02T00:03:00.000Z' },
+    )
+
+    const result = await saveAndroidDocumentWorkflow({
+      request,
+      getCurrentDocumentState: () => changedDocument,
+      writeAndroidMarkdownDocument: vi.fn().mockResolvedValue(undefined),
+      getAndroidDocumentUserMessage: () => 'Save failed',
+      recoveryMessage: 'A recovery draft was kept.',
+    })
+
+    expect(result).toEqual({
+      kind: 'changed-during-save',
+      saved: false,
+      sourceUri: 'content://provider/android.md',
+      scheduleAnotherSave: true,
+    })
+  })
+
+  it('returns a failed document, user status, and recovery draft request on write failure', async () => {
+    const request = createWorkflowRequest()
+
+    const result = await saveAndroidDocumentWorkflow({
+      request,
+      getCurrentDocumentState: () => request.savingDocument,
+      writeAndroidMarkdownDocument: vi.fn().mockRejectedValue(new Error('permission lost')),
+      getAndroidDocumentUserMessage: error => `message: ${(error as Error).message}`,
+      recoveryMessage: 'A recovery draft was kept.',
+    })
+
+    expect(result).toMatchObject({
+      kind: 'failed',
+      saved: false,
+      sourceUri: 'content://provider/android.md',
+      status: 'message: permission lost A recovery draft was kept.',
+      failedDocument: {
+        isDirty: true,
+        autosaveState: 'save-failed',
+        lastSaveError: 'permission lost',
+      },
+      recoveryDraft: {
+        sourceUri: 'content://provider/android.md',
+        markdown: '# Android\n\nbody\n\nchanged',
+      },
+    })
+  })
+})

--- a/src/lib/saveAndroidDocumentWorkflow.ts
+++ b/src/lib/saveAndroidDocumentWorkflow.ts
@@ -1,0 +1,214 @@
+import {
+  applyAndroidDocumentAutosaveFailure,
+  applyAndroidDocumentAutosaveSuccess,
+  canApplyAndroidDocumentAutosaveSuccess,
+  createAndroidDocumentAutosaveRequest,
+  type AndroidDocumentAutosaveRequest,
+} from './androidDocumentAutosave'
+import type { MarkdownDocumentState } from './documentState'
+
+interface WorkflowLogger {
+  debug(message: string, data?: unknown): void
+  info(message: string, data?: unknown): void
+  error(message: string, data?: unknown): void
+}
+
+interface AndroidRecoveryDraftRequest {
+  sourceUri: string
+  markdown: string
+}
+
+export interface SaveAndroidDocumentWorkflowRequest extends AndroidDocumentAutosaveRequest {
+  sourceUri: string
+}
+
+export type SaveAndroidDocumentWorkflowStartResult =
+  | {
+      kind: 'not-android-document'
+      saved: true
+    }
+  | {
+      kind: 'missing-source'
+      saved: false
+      status: 'Save failed'
+      documentId: string
+    }
+  | {
+      kind: 'read-only'
+      saved: boolean
+      status: string
+      documentId: string
+      sourceUri: string
+    }
+  | {
+      kind: 'clean'
+      saved: true
+    }
+  | {
+      kind: 'ready'
+      saved: false
+      status: 'Saving'
+      request: SaveAndroidDocumentWorkflowRequest
+    }
+
+export type SaveAndroidDocumentWorkflowResult =
+  | {
+      kind: 'saved'
+      saved: true
+      savedDocument: MarkdownDocumentState
+      savedAt: string
+      sourceUri: string
+      saveMarkdown: string
+      status: 'Saved'
+    }
+  | {
+      kind: 'changed-during-save'
+      saved: false
+      sourceUri: string
+      scheduleAnotherSave: true
+    }
+  | {
+      kind: 'failed'
+      saved: false
+      failedDocument: MarkdownDocumentState
+      sourceUri: string
+      recoveryDraft: AndroidRecoveryDraftRequest
+      status: string
+      error: unknown
+    }
+
+interface CreateSaveAndroidDocumentWorkflowStartOptions {
+  documentState: MarkdownDocumentState
+  markdown: string
+  canWrite: boolean
+}
+
+interface SaveAndroidDocumentWorkflowOptions {
+  request: SaveAndroidDocumentWorkflowRequest
+  getCurrentDocumentState: () => MarkdownDocumentState
+  writeAndroidMarkdownDocument: (sourceUri: string, markdown: string) => Promise<unknown>
+  getAndroidDocumentUserMessage: (error: unknown) => string
+  recoveryMessage: string
+  now?: () => string
+  logger?: WorkflowLogger
+}
+
+export function createSaveAndroidDocumentWorkflowStart({
+  documentState,
+  markdown,
+  canWrite,
+}: CreateSaveAndroidDocumentWorkflowStartOptions): SaveAndroidDocumentWorkflowStartResult {
+  if (documentState.autosaveTarget !== 'android-document') {
+    return {
+      kind: 'not-android-document',
+      saved: true,
+    }
+  }
+
+  const sourceUri = documentState.sourceUri
+  if (!sourceUri) {
+    return {
+      kind: 'missing-source',
+      saved: false,
+      status: 'Save failed',
+      documentId: documentState.id,
+    }
+  }
+
+  if (!canWrite) {
+    return {
+      kind: 'read-only',
+      saved: !documentState.isDirty,
+      status: documentState.isDirty ? 'This file is read-only.' : 'Read only',
+      documentId: documentState.id,
+      sourceUri,
+    }
+  }
+
+  if (!documentState.isDirty && documentState.autosaveState !== 'save-failed') {
+    return {
+      kind: 'clean',
+      saved: true,
+    }
+  }
+
+  return {
+    kind: 'ready',
+    saved: false,
+    status: 'Saving',
+    request: {
+      ...createAndroidDocumentAutosaveRequest(documentState, markdown),
+      sourceUri,
+    },
+  }
+}
+
+export async function saveAndroidDocumentWorkflow({
+  request,
+  getCurrentDocumentState,
+  writeAndroidMarkdownDocument,
+  getAndroidDocumentUserMessage,
+  recoveryMessage,
+  now = () => new Date().toISOString(),
+  logger,
+}: SaveAndroidDocumentWorkflowOptions): Promise<SaveAndroidDocumentWorkflowResult> {
+  try {
+    await writeAndroidMarkdownDocument(request.sourceUri, request.markdownForSave)
+    const savedAt = now()
+    const currentDocument = getCurrentDocumentState()
+
+    if (canApplyAndroidDocumentAutosaveSuccess(
+      currentDocument,
+      request.sourceUri,
+      request.saveMarkdown,
+    )) {
+      logger?.info('Android document autosaved', {
+        sourceUri: request.sourceUri,
+        characters: request.saveMarkdown.length,
+      })
+
+      return {
+        kind: 'saved',
+        saved: true,
+        savedDocument: applyAndroidDocumentAutosaveSuccess(
+          currentDocument,
+          request.saveMarkdown,
+          savedAt,
+        ),
+        savedAt,
+        sourceUri: request.sourceUri,
+        saveMarkdown: request.saveMarkdown,
+        status: 'Saved',
+      }
+    }
+
+    logger?.debug('Android document changed during save; scheduling another save', {
+      sourceUri: request.sourceUri,
+    })
+
+    return {
+      kind: 'changed-during-save',
+      saved: false,
+      sourceUri: request.sourceUri,
+      scheduleAnotherSave: true,
+    }
+  } catch (error) {
+    logger?.error('Android document autosave failed', {
+      sourceUri: request.sourceUri,
+      error,
+    })
+
+    return {
+      kind: 'failed',
+      saved: false,
+      failedDocument: applyAndroidDocumentAutosaveFailure(getCurrentDocumentState(), error),
+      sourceUri: request.sourceUri,
+      recoveryDraft: {
+        sourceUri: request.sourceUri,
+        markdown: request.saveMarkdown,
+      },
+      status: `${getAndroidDocumentUserMessage(error)} ${recoveryMessage}`,
+      error,
+    }
+  }
+}

--- a/src/lib/saveLocalDraftToAndroidDocumentWorkflow.test.ts
+++ b/src/lib/saveLocalDraftToAndroidDocumentWorkflow.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createUntitledDocument, updateDocumentMarkdown } from './documentState'
+import { saveLocalDraftToAndroidDocumentWorkflow } from './saveLocalDraftToAndroidDocumentWorkflow'
+import type { OpenedAndroidDocument } from './androidDocuments'
+
+function createDraftDocument(markdown = '# Draft\n\nbody') {
+  return updateDocumentMarkdown(
+    createUntitledDocument({
+      markdown,
+      displayName: 'Draft.md',
+      autosaveTarget: 'local-draft',
+      now: '2026-07-02T00:00:00.000Z',
+    }),
+    markdown,
+    { markDirty: false, now: '2026-07-02T00:01:00.000Z' },
+  )
+}
+
+const persistedDocument: OpenedAndroidDocument = {
+  canceled: false,
+  sourceUri: 'content://provider/draft.md',
+  displayName: 'Draft.md',
+  providerName: 'Documents',
+  pathHint: 'Documents/Draft.md',
+  mimeType: 'text/markdown',
+  markdown: '# Draft\n\nbody',
+  canWrite: true,
+  persisted: true,
+}
+
+describe('saveLocalDraftToAndroidDocumentWorkflow', () => {
+  it('returns empty without opening Android create when the draft has no content', async () => {
+    const createAndroidMarkdownDocument = vi.fn()
+
+    const result = await saveLocalDraftToAndroidDocumentWorkflow({
+      draftDocument: createDraftDocument('   \n'),
+      returnHomeAfterSave: false,
+      reopenPromptOnCancel: false,
+      transientAccessMessage: 'transient',
+      createAndroidMarkdownDocument,
+      getAndroidDocumentUserMessage: () => 'failed',
+    })
+
+    expect(result).toEqual({
+      kind: 'empty',
+      status: 'Ready',
+    })
+    expect(createAndroidMarkdownDocument).not.toHaveBeenCalled()
+  })
+
+  it('creates Android Markdown with the suggested file name and handles cancelation', async () => {
+    const createAndroidMarkdownDocument = vi.fn().mockResolvedValue({ canceled: true })
+
+    const result = await saveLocalDraftToAndroidDocumentWorkflow({
+      draftDocument: createDraftDocument('# Saved Draft\r\n\r\nbody\r\n'),
+      returnHomeAfterSave: true,
+      reopenPromptOnCancel: true,
+      transientAccessMessage: 'transient',
+      createAndroidMarkdownDocument,
+      getAndroidDocumentUserMessage: () => 'failed',
+    })
+
+    expect(createAndroidMarkdownDocument).toHaveBeenCalledWith(
+      '# Saved Draft\r\n\r\nbody\r\n',
+      'Saved Draft.md',
+    )
+    expect(result).toEqual({
+      kind: 'canceled',
+      status: 'Autosaved locally',
+      reopenPrompt: true,
+    })
+  })
+
+  it('keeps the local draft when Android does not grant persisted access', async () => {
+    const transientDocument = {
+      ...persistedDocument,
+      sourceUri: 'content://provider/transient.md',
+      persisted: false,
+    }
+
+    const result = await saveLocalDraftToAndroidDocumentWorkflow({
+      draftDocument: createDraftDocument(),
+      returnHomeAfterSave: true,
+      reopenPromptOnCancel: false,
+      transientAccessMessage: 'Saved transiently',
+      createAndroidMarkdownDocument: vi.fn().mockResolvedValue(transientDocument),
+      getAndroidDocumentUserMessage: () => 'failed',
+    })
+
+    expect(result).toMatchObject({
+      kind: 'transient',
+      status: 'Saved transiently',
+      homeNotice: 'Saved transiently',
+      closeEditorToHome: true,
+      createdDocument: {
+        sourceUri: 'content://provider/transient.md',
+        markdown: '# Draft\n\nbody',
+      },
+    })
+  })
+
+  it('returns the saved Android document state and local draft removal id', async () => {
+    const draftDocument = createDraftDocument()
+
+    const result = await saveLocalDraftToAndroidDocumentWorkflow({
+      draftDocument,
+      returnHomeAfterSave: false,
+      reopenPromptOnCancel: false,
+      transientAccessMessage: 'transient',
+      createAndroidMarkdownDocument: vi.fn().mockResolvedValue(persistedDocument),
+      getAndroidDocumentUserMessage: () => 'failed',
+      now: () => '2026-07-02T00:03:00.000Z',
+    })
+
+    expect(result).toMatchObject({
+      kind: 'saved',
+      removeLocalDraftId: draftDocument.id,
+      canWrite: true,
+      closeEditorToHome: false,
+      createdDocument: {
+        sourceUri: 'content://provider/draft.md',
+        markdown: '# Draft\n\nbody',
+      },
+      savedDocument: {
+        id: 'android-document:content://provider/draft.md',
+        autosaveTarget: 'android-document',
+        autosaveState: 'clean',
+        isDirty: false,
+        lastSavedAt: '2026-07-02T00:03:00.000Z',
+      },
+    })
+  })
+
+  it('returns failed document state and user-facing error status', async () => {
+    const result = await saveLocalDraftToAndroidDocumentWorkflow({
+      draftDocument: createDraftDocument(),
+      returnHomeAfterSave: true,
+      reopenPromptOnCancel: true,
+      transientAccessMessage: 'transient',
+      createAndroidMarkdownDocument: vi.fn().mockRejectedValue(new Error('permission lost')),
+      getAndroidDocumentUserMessage: error => `message: ${(error as Error).message}`,
+    })
+
+    expect(result).toMatchObject({
+      kind: 'failed',
+      status: 'message: permission lost',
+      reopenPrompt: true,
+      failedDocument: {
+        isDirty: true,
+        autosaveState: 'save-failed',
+        lastSaveError: 'permission lost',
+      },
+    })
+  })
+})

--- a/src/lib/saveLocalDraftToAndroidDocumentWorkflow.ts
+++ b/src/lib/saveLocalDraftToAndroidDocumentWorkflow.ts
@@ -1,0 +1,151 @@
+import {
+  getSuggestedMarkdownFileName,
+  markDocumentSaveFailed,
+  prepareMarkdownForSave,
+  type MarkdownDocumentState,
+} from './documentState'
+import {
+  createSavedDocumentStateFromAndroidDocument,
+  type SavedAndroidDocumentStateSource,
+} from './documentSessionState'
+import type { OpenedAndroidDocument } from './androidDocuments'
+
+interface CanceledAndroidDocumentCreate {
+  canceled: true
+}
+
+type AndroidDocumentCreateResult = OpenedAndroidDocument | CanceledAndroidDocumentCreate
+
+interface WorkflowLogger {
+  info(message: string, data?: unknown): void
+  warn(message: string, data?: unknown): void
+  error(message: string, data?: unknown): void
+}
+
+export type SaveLocalDraftToAndroidDocumentResult =
+  | {
+      kind: 'empty'
+      status: 'Ready'
+    }
+  | {
+      kind: 'canceled'
+      status: 'Autosaved locally'
+      reopenPrompt: boolean
+    }
+  | {
+      kind: 'transient'
+      status: string
+      homeNotice: string
+      createdDocument: OpenedAndroidDocument
+      closeEditorToHome: boolean
+    }
+  | {
+      kind: 'saved'
+      savedDocument: MarkdownDocumentState
+      createdDocument: SavedAndroidDocumentStateSource
+      removeLocalDraftId: string
+      canWrite: boolean
+      closeEditorToHome: boolean
+    }
+  | {
+      kind: 'failed'
+      failedDocument: MarkdownDocumentState
+      status: string
+      reopenPrompt: boolean
+      error: unknown
+    }
+
+interface SaveLocalDraftToAndroidDocumentWorkflowOptions {
+  draftDocument: MarkdownDocumentState
+  returnHomeAfterSave: boolean
+  reopenPromptOnCancel: boolean
+  transientAccessMessage: string
+  createAndroidMarkdownDocument: (
+    markdown: string,
+    suggestedName: string,
+  ) => Promise<AndroidDocumentCreateResult>
+  getAndroidDocumentUserMessage: (error: unknown) => string
+  now?: () => string
+  logger?: WorkflowLogger
+}
+
+export async function saveLocalDraftToAndroidDocumentWorkflow({
+  draftDocument,
+  returnHomeAfterSave,
+  reopenPromptOnCancel,
+  transientAccessMessage,
+  createAndroidMarkdownDocument,
+  getAndroidDocumentUserMessage,
+  now = () => new Date().toISOString(),
+  logger,
+}: SaveLocalDraftToAndroidDocumentWorkflowOptions): Promise<SaveLocalDraftToAndroidDocumentResult> {
+  if (!draftDocument.markdown.trim()) {
+    return {
+      kind: 'empty',
+      status: 'Ready',
+    }
+  }
+
+  try {
+    const markdownForSave = prepareMarkdownForSave(draftDocument.markdown, draftDocument)
+    const suggestedName = getSuggestedMarkdownFileName(
+      draftDocument.markdown,
+      draftDocument.displayName,
+    )
+    const document = await createAndroidMarkdownDocument(markdownForSave, suggestedName)
+    if (document.canceled) {
+      logger?.info('Android document create canceled')
+      return {
+        kind: 'canceled',
+        status: 'Autosaved locally',
+        reopenPrompt: reopenPromptOnCancel,
+      }
+    }
+
+    const createdDocument = {
+      ...document,
+      markdown: draftDocument.markdown,
+    }
+
+    if (!document.persisted) {
+      logger?.warn('created Android document without persisted access; kept local draft', {
+        displayName: document.displayName,
+        sourceUri: document.sourceUri,
+        characters: draftDocument.markdown.length,
+      })
+
+      return {
+        kind: 'transient',
+        status: transientAccessMessage,
+        homeNotice: transientAccessMessage,
+        createdDocument,
+        closeEditorToHome: returnHomeAfterSave,
+      }
+    }
+
+    const savedAt = now()
+    logger?.info('local draft saved as Android document', {
+      displayName: document.displayName,
+      sourceUri: document.sourceUri,
+      characters: draftDocument.markdown.length,
+    })
+
+    return {
+      kind: 'saved',
+      savedDocument: createSavedDocumentStateFromAndroidDocument(createdDocument, savedAt),
+      createdDocument,
+      removeLocalDraftId: draftDocument.id,
+      canWrite: document.canWrite,
+      closeEditorToHome: returnHomeAfterSave,
+    }
+  } catch (error) {
+    logger?.error('local draft save to Android document failed', error)
+    return {
+      kind: 'failed',
+      failedDocument: markDocumentSaveFailed(draftDocument, error),
+      status: getAndroidDocumentUserMessage(error),
+      reopenPrompt: reopenPromptOnCancel,
+      error,
+    }
+  }
+}

--- a/src/lib/shareAndroidMarkdownDocumentWorkflow.test.ts
+++ b/src/lib/shareAndroidMarkdownDocumentWorkflow.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createUntitledDocument, updateDocumentMarkdown } from './documentState'
+import { shareAndroidMarkdownDocumentWorkflow } from './shareAndroidMarkdownDocumentWorkflow'
+import type { AndroidShareResult } from './androidDocuments'
+
+function createCurrentDocument(markdown = '# Share Out Note\n\nbody') {
+  return updateDocumentMarkdown(
+    createUntitledDocument({
+      markdown,
+      displayName: 'Draft.md',
+      autosaveTarget: 'local-draft',
+      now: '2026-07-02T00:00:00.000Z',
+    }),
+    markdown,
+    { markDirty: false, now: '2026-07-02T00:01:00.000Z' },
+  )
+}
+
+const shareResult: AndroidShareResult = {
+  displayName: 'Share Out Note.md',
+  mimeType: 'text/markdown',
+  bytes: 24,
+  imageCount: 0,
+  sharedFileCount: 1,
+}
+
+describe('shareAndroidMarkdownDocumentWorkflow', () => {
+  it('shares prepared Markdown with the suggested file name', async () => {
+    const shareAndroidMarkdownDocument = vi.fn().mockResolvedValue(shareResult)
+
+    const result = await shareAndroidMarkdownDocumentWorkflow({
+      currentDocument: createCurrentDocument(),
+      shareAndroidMarkdownDocument,
+      getAndroidDocumentUserMessage: () => 'failed',
+    })
+
+    expect(shareAndroidMarkdownDocument).toHaveBeenCalledWith(
+      '# Share Out Note\n\nbody',
+      'Share Out Note.md',
+    )
+    expect(result).toEqual({
+      kind: 'shared',
+      status: 'Share sheet opened',
+      shareResult,
+    })
+  })
+
+  it('returns a user-facing status when sharing fails', async () => {
+    const result = await shareAndroidMarkdownDocumentWorkflow({
+      currentDocument: createCurrentDocument(),
+      shareAndroidMarkdownDocument: vi.fn().mockRejectedValue(new Error('share target missing')),
+      getAndroidDocumentUserMessage: error => `message: ${(error as Error).message}`,
+    })
+
+    expect(result).toMatchObject({
+      kind: 'failed',
+      status: 'message: share target missing',
+    })
+  })
+})

--- a/src/lib/shareAndroidMarkdownDocumentWorkflow.ts
+++ b/src/lib/shareAndroidMarkdownDocumentWorkflow.ts
@@ -1,0 +1,71 @@
+import {
+  getSuggestedMarkdownFileName,
+  prepareMarkdownForSave,
+  type MarkdownDocumentState,
+} from './documentState'
+import type { AndroidShareResult } from './androidDocuments'
+
+interface WorkflowLogger {
+  info(message: string, data?: unknown): void
+  error(message: string, data?: unknown): void
+}
+
+export type ShareAndroidMarkdownDocumentResult =
+  | {
+      kind: 'shared'
+      status: 'Share sheet opened'
+      shareResult: AndroidShareResult
+    }
+  | {
+      kind: 'failed'
+      status: string
+      error: unknown
+    }
+
+interface ShareAndroidMarkdownDocumentWorkflowOptions {
+  currentDocument: MarkdownDocumentState
+  shareAndroidMarkdownDocument: (
+    markdown: string,
+    suggestedName: string,
+  ) => Promise<AndroidShareResult>
+  getAndroidDocumentUserMessage: (error: unknown) => string
+  logger?: WorkflowLogger
+}
+
+export async function shareAndroidMarkdownDocumentWorkflow({
+  currentDocument,
+  shareAndroidMarkdownDocument,
+  getAndroidDocumentUserMessage,
+  logger,
+}: ShareAndroidMarkdownDocumentWorkflowOptions): Promise<ShareAndroidMarkdownDocumentResult> {
+  const markdownForShare = prepareMarkdownForSave(currentDocument.markdown, currentDocument)
+  const suggestedName = getSuggestedMarkdownFileName(
+    currentDocument.markdown,
+    currentDocument.displayName,
+  )
+
+  try {
+    const result = await shareAndroidMarkdownDocument(markdownForShare, suggestedName)
+    logger?.info('Android share sheet opened', {
+      displayName: result.displayName,
+      bytes: result.bytes,
+      imageCount: result.imageCount,
+      sharedFileCount: result.sharedFileCount,
+      autosaveTarget: currentDocument.autosaveTarget,
+    })
+
+    return {
+      kind: 'shared',
+      status: 'Share sheet opened',
+      shareResult: result,
+    }
+  } catch (error) {
+    logger?.error('Android share failed', error)
+
+    return {
+      kind: 'failed',
+      status: getAndroidDocumentUserMessage(error),
+      error,
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Split Android autosave, editor toolbar/link/image, and exit/back decision workflows out of App.vue.
- Keep Vue state mutation, prompts, and native side effects in App.vue while moving pure workflow decisions into focused modules.
- Add unit coverage for the extracted workflow modules.

## Validation

- pnpm test src/lib/saveAndroidDocumentWorkflow.test.ts
- pnpm test src/lib/editorToolbarWorkflow.test.ts
- pnpm test src/lib/appExitDecisions.test.ts
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm test:e2e tests/e2e/mobile-recent-home.spec.ts
- pnpm test:e2e tests/e2e/mobile-share-intent.spec.ts
- pnpm test:e2e tests/e2e/mobile-editor-toolbar.spec.ts
- pnpm test:e2e tests/e2e/mobile-markdown-editing.spec.ts
- pnpm test:e2e tests/e2e/mobile-home-navigation.spec.ts
- pnpm test:e2e
- git diff --check