### PR TITLE
test: stabilize mobile e2e readiness

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests/e2e',
+  workers: 1,
   timeout: 30_000,
   expect: {
     timeout: 5_000,
@@ -14,7 +15,9 @@ export default defineConfig({
     command: 'pnpm dev --host 127.0.0.1 --port 5174 --strictPort',
     url: 'http://127.0.0.1:5174',
     reuseExistingServer: !process.env.CI,
-    timeout: 30_000,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
   },
   projects: [
     {

--- a/tests/e2e/helpers/editor.ts
+++ b/tests/e2e/helpers/editor.ts
@@ -1,0 +1,26 @@
+import { expect, type Page } from '@playwright/test'
+
+const MUYA_READY_SELECTOR = [
+  '.mu-editor .mu-paragraph',
+  '.mu-editor .mu-atx-heading',
+  '.mu-editor .mu-setext-heading',
+  '.mu-editor .mu-block-quote',
+  '.mu-editor .mu-bullet-list',
+  '.mu-editor .mu-order-list',
+  '.mu-editor .mu-task-list',
+  '.mu-editor .mu-code-block',
+  '.mu-editor .mu-math-block',
+  '.mu-editor .mu-diagram-block',
+  '.mu-editor .mu-html-block',
+  '.mu-editor pre.mu-frontmatter',
+  '.mu-editor figure.mu-table',
+].join(', ')
+
+export async function expectEditorReady(page: Page, timeout = 30000) {
+  await expect(page.getByTestId('editor-loading-host')).toBeHidden({ timeout })
+
+  const host = page.getByTestId('editor-host')
+  await expect(host).toBeVisible({ timeout })
+  await expect(host.locator('.mu-editor')).toBeVisible({ timeout })
+  await expect(host.locator(MUYA_READY_SELECTOR).first()).toBeAttached({ timeout })
+}

--- a/tests/e2e/mobile-editor-capabilities.spec.ts
+++ b/tests/e2e/mobile-editor-capabilities.spec.ts
@@ -1,12 +1,9 @@
 import { expect, test, type Page } from '@playwright/test'
+import { expectEditorReady } from './helpers/editor'
 
 test.describe.configure({ timeout: 60000 })
 
 const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
-
-async function expectEditorReady(page: Page) {
-  await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
-}
 
 async function openLocalDraft(page: Page, markdown: string, title: RegExp) {
   const now = '2026-07-01T08:00:00.000Z'

--- a/tests/e2e/mobile-editor-toolbar.spec.ts
+++ b/tests/e2e/mobile-editor-toolbar.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test'
+import { expectEditorReady } from './helpers/editor'
 
 test.describe.configure({ timeout: 60000 })
 
@@ -21,10 +22,6 @@ interface MockCapacitorWindow {
       callback?: (data: unknown) => void,
     ) => Promise<string>
   }
-}
-
-async function expectEditorReady(page: Page) {
-  await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
 }
 
 async function newBlankDocument(page: Page) {

--- a/tests/e2e/mobile-markdown-editing.spec.ts
+++ b/tests/e2e/mobile-markdown-editing.spec.ts
@@ -1,12 +1,9 @@
 import { expect, test, type Page } from '@playwright/test'
+import { expectEditorReady } from './helpers/editor'
 
 test.describe.configure({ timeout: 60000 })
 
 const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
-
-async function expectEditorReady(page: Page) {
-  await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
-}
 
 async function newBlankDocument(page: Page) {
   await page.goto('/')

--- a/tests/e2e/mobile-markdown-rendering.spec.ts
+++ b/tests/e2e/mobile-markdown-rendering.spec.ts
@@ -1,12 +1,9 @@
 import { expect, test, type Page } from '@playwright/test'
+import { expectEditorReady } from './helpers/editor'
 
 test.describe.configure({ timeout: 60000 })
 
 const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
-
-async function expectEditorReady(page: Page) {
-  await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
-}
 
 async function openLocalDraft(page: Page, markdown: string, title: RegExp) {
   const now = '2026-07-01T10:00:00.000Z'

--- a/tests/e2e/mobile-recent-home.spec.ts
+++ b/tests/e2e/mobile-recent-home.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test'
+import { expectEditorReady } from './helpers/editor'
 
 test.describe.configure({ timeout: 60000 })
 
@@ -72,10 +73,6 @@ interface MockAndroidDocument {
 
 interface MockAndroidAppOptions {
   pendingOpenWithEvent?: MockAndroidOpenWithEvent
-}
-
-async function expectEditorReady(page: Page) {
-  await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
 }
 
 async function installTransientAndroidCreateMock(page: Page) {

--- a/tests/e2e/mobile-share-intent.spec.ts
+++ b/tests/e2e/mobile-share-intent.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test'
+import { expectEditorReady } from './helpers/editor'
 
 test.describe.configure({ timeout: 60000 })
 
@@ -44,10 +45,6 @@ interface MockAndroidShareEvent {
 
 interface MockAndroidShareOptions {
   pendingShareEvent?: MockAndroidShareEvent
-}
-
-async function expectEditorReady(page: Page) {
-  await expect(page.getByTestId('editor-host')).toBeVisible({ timeout: 30000 })
 }
 
 async function installAndroidShareAppMock(


### PR DESCRIPTION
## Summary
- Run the mobile Playwright suite serially and give the Vite web server a longer startup window.
- Add a shared editor readiness helper that waits for the loading host to disappear, the Muya editor root to render, and a real Muya block to attach.
- Replace duplicated per-spec editor readiness checks with the shared helper.

## Verification
- pnpm test:e2e
- pnpm lint