### PR TITLE
fix: add webview-safe theme fallbacks

### DIFF
--- a/src/features/editor/components/MobileEditorToolbar.vue
+++ b/src/features/editor/components/MobileEditorToolbar.vue
@@ -224,7 +224,7 @@ function selectPanel(panel: MobileEditorToolbarPanel) {
   z-index: 18;
   border-top: 1px solid var(--border);
   background: var(--surface);
-  box-shadow: 0 -6px 18px oklch(0.25 0.02 255 / 0.06);
+  box-shadow: var(--shadow-toolbar);
 }
 
 .toolbar-collapsed {
@@ -376,7 +376,7 @@ function selectPanel(panel: MobileEditorToolbarPanel) {
 }
 
 .toolbar-button[data-command-id='format.highlight'] {
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  background: var(--accent-tint-10);
   color: var(--accent-strong);
 }
 
@@ -399,7 +399,7 @@ function selectPanel(panel: MobileEditorToolbarPanel) {
 .toolbar-expand-handle:active,
 .toolbar-group-switcher:active,
 .toolbar-group-option:active {
-  background: color-mix(in srgb, var(--accent) 11%, transparent);
+  background: var(--accent-tint-11);
 }
 
 .toolbar-button:disabled {
@@ -448,7 +448,7 @@ function selectPanel(panel: MobileEditorToolbarPanel) {
   border: 1px solid var(--border);
   border-radius: var(--radius, 14px);
   background: var(--surface);
-  box-shadow: 0 14px 36px oklch(0.25 0.02 255 / 0.14);
+  box-shadow: var(--shadow-toolbar-menu);
 }
 
 .toolbar-group-option {
@@ -461,7 +461,7 @@ function selectPanel(panel: MobileEditorToolbarPanel) {
 }
 
 .toolbar-group-option.is-active {
-  background: color-mix(in srgb, var(--accent) 12%, var(--surface));
+  background: var(--toolbar-active-panel-bg);
   color: var(--accent-strong);
 }
 

--- a/src/features/home/components/AppBottomNavigation.vue
+++ b/src/features/home/components/AppBottomNavigation.vue
@@ -80,7 +80,7 @@ function selectTab(tab: HomeTab) {
   position: absolute;
   inset: 0 16px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--accent-soft) 72%, var(--surface) 28%);
+  background: var(--bottom-nav-indicator-bg);
   content: '';
 }
 

--- a/src/features/settings/components/SettingsChoiceRow.vue
+++ b/src/features/settings/components/SettingsChoiceRow.vue
@@ -92,7 +92,7 @@ defineEmits<{
 }
 
 .settings-choice-option.is-active {
-  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+  border-color: var(--settings-choice-active-border);
   background: var(--accent-soft);
   color: var(--accent-strong);
 }
@@ -102,7 +102,7 @@ defineEmits<{
 }
 
 .settings-choice-option:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  outline: 2px solid var(--focus-ring-22);
   outline-offset: 1px;
 }
 </style>

--- a/src/features/settings/components/SettingsRow.vue
+++ b/src/features/settings/components/SettingsRow.vue
@@ -80,8 +80,8 @@ const hasChevron = computed(() => Boolean(props.chevron || props.href))
   right: 20px;
   width: 9px;
   height: 9px;
-  border-top: 1.4px solid color-mix(in srgb, var(--text-faint) 70%, var(--surface));
-  border-right: 1.4px solid color-mix(in srgb, var(--text-faint) 70%, var(--surface));
+  border-top: 1.4px solid var(--settings-chevron-border);
+  border-right: 1.4px solid var(--settings-chevron-border);
   content: '';
   transform: translateY(-50%) rotate(45deg);
   pointer-events: none;
@@ -94,7 +94,7 @@ const hasChevron = computed(() => Boolean(props.chevron || props.href))
 
 .settings-row.is-link:focus-visible,
 .settings-row.is-action:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  outline: 2px solid var(--focus-ring-22);
   outline-offset: -2px;
 }
 

--- a/src/features/settings/components/SettingsSelectRow.vue
+++ b/src/features/settings/components/SettingsSelectRow.vue
@@ -70,7 +70,7 @@ defineEmits<{
 
 .settings-select:focus-visible {
   border-color: var(--accent);
-  outline: 2px solid color-mix(in srgb, var(--accent) 18%, transparent);
+  outline: 2px solid var(--focus-ring-18);
   outline-offset: 1px;
 }
 

--- a/src/features/settings/components/SettingsSliderRow.vue
+++ b/src/features/settings/components/SettingsSliderRow.vue
@@ -77,7 +77,7 @@ function updateValue(value: string) {
 }
 
 .settings-slider:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  outline: 2px solid var(--focus-ring-22);
   outline-offset: 4px;
 }
 </style>

--- a/src/features/settings/components/SettingsTextRow.vue
+++ b/src/features/settings/components/SettingsTextRow.vue
@@ -75,7 +75,7 @@ defineEmits<{
 
 .settings-text-input:focus-visible {
   border-color: var(--accent);
-  outline: 2px solid color-mix(in srgb, var(--accent) 18%, transparent);
+  outline: 2px solid var(--focus-ring-18);
   outline-offset: 1px;
 }
 </style>

--- a/src/features/settings/components/SettingsToggleRow.vue
+++ b/src/features/settings/components/SettingsToggleRow.vue
@@ -50,7 +50,7 @@ defineEmits<{
 }
 
 .settings-toggle-row:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  outline: 2px solid var(--focus-ring-22);
   outline-offset: -2px;
 }
 
@@ -83,7 +83,7 @@ defineEmits<{
   height: 22px;
   border-radius: 999px;
   background: var(--surface);
-  box-shadow: 0 2px 6px oklch(0.25 0.02 255 / 0.18);
+  box-shadow: var(--shadow-toggle-thumb);
   transition: transform 180ms var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,32 +1,4 @@
-:root {
-  --app-bg: oklch(0.965 0.004 255);
-  --surface: oklch(0.985 0.003 255);
-  --surface-muted: oklch(0.955 0.005 255);
-  --surface-sunken: oklch(0.935 0.006 255);
-  --text: oklch(0.23 0.014 255);
-  --text-muted: oklch(0.52 0.02 255);
-  --text-faint: oklch(0.63 0.018 255);
-  --border: oklch(0.9 0.008 255);
-  --border-strong: oklch(0.86 0.011 255);
-  --accent: oklch(0.52 0.06 255);
-  --accent-strong: oklch(0.45 0.065 255);
-  --accent-soft: oklch(0.93 0.035 255);
-  --danger: oklch(0.5 0.13 25);
-  --shadow-sm: 0 1px 2px oklch(0.25 0.02 255 / 0.05);
-  --shadow: 0 8px 28px oklch(0.25 0.02 255 / 0.07);
-  --radius: 14px;
-  --radius-sm: 10px;
-  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
-
-  color: var(--text);
-  background: var(--app-bg);
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+@import './styles/theme-tokens.css';
 
 * {
   box-sizing: border-box;
@@ -102,9 +74,7 @@ body {
   font-size: 14px;
   font-weight: 600;
   letter-spacing: -0.006em;
-  box-shadow:
-    0 1px 2px oklch(0.25 0.02 255 / 0.04),
-    inset 0 1px 0 oklch(1 0 0 / 0.6);
+  box-shadow: var(--shadow-home-open-button);
   transition:
     border-color 160ms var(--ease-out),
     background 160ms var(--ease-out),
@@ -130,7 +100,7 @@ body {
 .home-open-button:active {
   background: var(--surface-sunken);
   transform: translateY(0.5px);
-  box-shadow: 0 1px 1px oklch(0.25 0.02 255 / 0.03);
+  box-shadow: var(--shadow-home-open-button-active);
 }
 
 .home-new-button {
@@ -144,9 +114,7 @@ body {
   background: var(--accent);
   color: var(--surface);
   font: inherit;
-  box-shadow:
-    0 2px 8px oklch(0.52 0.06 255 / 0.28),
-    inset 0 1px 0 oklch(1 0 0 / 0.22);
+  box-shadow: var(--shadow-home-new-button);
   transition:
     background 160ms var(--ease-out),
     box-shadow 160ms var(--ease-out),
@@ -164,15 +132,13 @@ body {
 }
 
 .home-new-button:hover {
-  background: color-mix(in srgb, var(--accent) 88%, var(--accent-strong) 12%);
+  background: var(--accent-hover);
 }
 
 .home-new-button:active {
   background: var(--accent-strong);
   transform: translateY(0.5px);
-  box-shadow:
-    0 1px 3px oklch(0.52 0.06 255 / 0.2),
-    inset 0 1px 0 oklch(1 0 0 / 0.16);
+  box-shadow: var(--shadow-home-new-button-active);
 }
 
 .home-open-button:active,
@@ -232,7 +198,7 @@ body {
 
 .continue-card:hover {
   border-color: var(--border-strong);
-  box-shadow: 0 4px 16px oklch(0.25 0.02 255 / 0.07);
+  box-shadow: var(--shadow-card-hover);
 }
 
 .continue-card:active {
@@ -517,7 +483,7 @@ body {
   z-index: 40;
   display: grid;
   align-items: end;
-  background: oklch(0.23 0.02 255 / 0.5);
+  background: var(--editor-scrim);
 }
 
 .editor-sheet-enter-active,
@@ -602,7 +568,7 @@ body {
 }
 
 .editor-action-row:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  outline: 2px solid var(--focus-ring-22);
   outline-offset: -2px;
 }
 
@@ -728,7 +694,7 @@ body {
   display: grid;
   align-items: end;
   padding: 18px;
-  background: oklch(0.23 0.02 255 / 0.42);
+  background: var(--draft-scrim);
 }
 
 .draft-save-panel {
@@ -790,7 +756,7 @@ body {
 
 .link-field input:focus {
   border-color: var(--accent);
-  outline: 2px solid color-mix(in srgb, var(--accent) 18%, transparent);
+  outline: 2px solid var(--focus-ring-18);
   outline-offset: 1px;
 }
 

--- a/src/styles/theme-tokens.css
+++ b/src/styles/theme-tokens.css
@@ -1,0 +1,104 @@
+:root {
+  --app-bg: #f2f4f6;
+  --surface: #f9fafc;
+  --surface-muted: #eef0f3;
+  --surface-sunken: #e7eaed;
+  --text: #191d24;
+  --text-muted: #616a75;
+  --text-faint: #828a94;
+  --border: #dadee3;
+  --border-strong: #ccd1d8;
+  --accent: #516b8b;
+  --accent-strong: #3c5779;
+  --accent-soft: #d9eaff;
+  --danger: #a03f3c;
+  --accent-hover: #4e6989;
+  --accent-tint-10: rgba(81, 107, 139, 0.1);
+  --accent-tint-11: rgba(81, 107, 139, 0.11);
+  --focus-ring-18: rgba(81, 107, 139, 0.18);
+  --focus-ring-22: rgba(81, 107, 139, 0.22);
+  --bottom-nav-indicator-bg: #e2eefe;
+  --settings-choice-active-border: #a0aebe;
+  --settings-chevron-border: #a6acb3;
+  --toolbar-active-panel-bg: #e5e9ee;
+  --editor-scrim: rgba(23, 29, 38, 0.5);
+  --draft-scrim: rgba(23, 29, 38, 0.42);
+  --shadow-sm: 0 1px 2px rgba(27, 34, 43, 0.05);
+  --shadow: 0 8px 28px rgba(27, 34, 43, 0.07);
+  --shadow-home-open-button:
+    0 1px 2px rgba(27, 34, 43, 0.04),
+    inset 0 1px 0 rgba(251, 253, 255, 0.6);
+  --shadow-home-open-button-active: 0 1px 1px rgba(27, 34, 43, 0.03);
+  --shadow-home-new-button:
+    0 2px 8px rgba(81, 107, 139, 0.28),
+    inset 0 1px 0 rgba(251, 253, 255, 0.22);
+  --shadow-home-new-button-active:
+    0 1px 3px rgba(81, 107, 139, 0.2),
+    inset 0 1px 0 rgba(251, 253, 255, 0.16);
+  --shadow-card-hover: 0 4px 16px rgba(27, 34, 43, 0.07);
+  --shadow-toolbar: 0 -6px 18px rgba(27, 34, 43, 0.06);
+  --shadow-toolbar-menu: 0 14px 36px rgba(27, 34, 43, 0.14);
+  --shadow-toggle-thumb: 0 2px 6px rgba(27, 34, 43, 0.18);
+  --radius: 14px;
+  --radius-sm: 10px;
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+
+  color: var(--text);
+  background: var(--app-bg);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+@supports (color: oklch(0.52 0.06 255)) {
+  :root {
+    --app-bg: oklch(0.965 0.004 255);
+    --surface: oklch(0.985 0.003 255);
+    --surface-muted: oklch(0.955 0.005 255);
+    --surface-sunken: oklch(0.935 0.006 255);
+    --text: oklch(0.23 0.014 255);
+    --text-muted: oklch(0.52 0.02 255);
+    --text-faint: oklch(0.63 0.018 255);
+    --border: oklch(0.9 0.008 255);
+    --border-strong: oklch(0.86 0.011 255);
+    --accent: oklch(0.52 0.06 255);
+    --accent-strong: oklch(0.45 0.065 255);
+    --accent-soft: oklch(0.93 0.035 255);
+    --danger: oklch(0.5 0.13 25);
+    --editor-scrim: oklch(0.23 0.02 255 / 0.5);
+    --draft-scrim: oklch(0.23 0.02 255 / 0.42);
+    --shadow-sm: 0 1px 2px oklch(0.25 0.02 255 / 0.05);
+    --shadow: 0 8px 28px oklch(0.25 0.02 255 / 0.07);
+    --shadow-home-open-button:
+      0 1px 2px oklch(0.25 0.02 255 / 0.04),
+      inset 0 1px 0 oklch(1 0 0 / 0.6);
+    --shadow-home-open-button-active: 0 1px 1px oklch(0.25 0.02 255 / 0.03);
+    --shadow-home-new-button:
+      0 2px 8px oklch(0.52 0.06 255 / 0.28),
+      inset 0 1px 0 oklch(1 0 0 / 0.22);
+    --shadow-home-new-button-active:
+      0 1px 3px oklch(0.52 0.06 255 / 0.2),
+      inset 0 1px 0 oklch(1 0 0 / 0.16);
+    --shadow-card-hover: 0 4px 16px oklch(0.25 0.02 255 / 0.07);
+    --shadow-toolbar: 0 -6px 18px oklch(0.25 0.02 255 / 0.06);
+    --shadow-toolbar-menu: 0 14px 36px oklch(0.25 0.02 255 / 0.14);
+    --shadow-toggle-thumb: 0 2px 6px oklch(0.25 0.02 255 / 0.18);
+  }
+}
+
+@supports (background: color-mix(in srgb, red 50%, blue 50%)) {
+  :root {
+    --accent-hover: color-mix(in srgb, var(--accent) 88%, var(--accent-strong) 12%);
+    --accent-tint-10: color-mix(in srgb, var(--accent) 10%, transparent);
+    --accent-tint-11: color-mix(in srgb, var(--accent) 11%, transparent);
+    --focus-ring-18: color-mix(in srgb, var(--accent) 18%, transparent);
+    --focus-ring-22: color-mix(in srgb, var(--accent) 22%, transparent);
+    --bottom-nav-indicator-bg: color-mix(in srgb, var(--accent-soft) 72%, var(--surface) 28%);
+    --settings-choice-active-border: color-mix(in srgb, var(--accent) 42%, var(--border));
+    --settings-chevron-border: color-mix(in srgb, var(--text-faint) 70%, var(--surface));
+    --toolbar-active-panel-bg: color-mix(in srgb, var(--accent) 12%, var(--surface));
+  }
+}

--- a/src/styles/themeTokens.test.ts
+++ b/src/styles/themeTokens.test.ts
@@ -1,0 +1,43 @@
+/// <reference types="node" />
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const modernColorFunctionPattern = /\b(?:oklch|color-mix)\(/
+const sourceRoot = join(process.cwd(), 'src')
+const themeTokensPath = join(sourceRoot, 'styles', 'theme-tokens.css')
+
+function collectStyleFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name)
+
+    if (entry.isDirectory()) {
+      return collectStyleFiles(path)
+    }
+
+    return entry.name.endsWith('.css') || entry.name.endsWith('.vue') ? [path] : []
+  })
+}
+
+describe('theme webview fallbacks', () => {
+  it('keeps modern color functions inside guarded theme tokens', () => {
+    const offenders = collectStyleFiles(sourceRoot)
+      .filter(path => path !== themeTokensPath)
+      .filter(path => modernColorFunctionPattern.test(readFileSync(path, 'utf8')))
+      .map(path => relative(process.cwd(), path))
+
+    expect(offenders).toEqual([])
+  })
+
+  it('declares legacy-safe color tokens before progressive enhancements', () => {
+    const css = readFileSync(themeTokensPath, 'utf8')
+    const fallbackRoot = css.slice(css.indexOf(':root'), css.indexOf('@supports'))
+
+    expect(fallbackRoot).toContain('--app-bg: #f2f4f6;')
+    expect(fallbackRoot).toContain('--accent: #516b8b;')
+    expect(fallbackRoot).not.toMatch(modernColorFunctionPattern)
+    expect(css).toContain('@supports (color: oklch(0.52 0.06 255))')
+    expect(css).toContain('@supports (background: color-mix(in srgb, red 50%, blue 50%))')
+  })
+})


### PR DESCRIPTION
## Summary

- Move theme color and shadow values into centralized theme tokens with legacy-safe sRGB/rgba defaults.
- Keep the existing OKLCH and color-mix visual design behind @supports so newer WebView rendering remains unchanged.
- Replace component-level direct OKLCH/color-mix usage with token references so older WebViews do not collapse to black/transparent styles.
- Add a regression test that prevents future component styles from reintroducing unguarded modern color functions.

## Compatibility strategy

Default tokens are parseable by older Android WebView/Chrome 110. Modern OKLCH/color-mix values are still present, but only as progressive enhancement guarded by @supports. This keeps the current official API 35 visual style while allowing MuMu/older WebView to render a complete styled UI.

## Verification

- pnpm test: 25 files, 115 tests passed
- pnpm lint: passed
- pnpm build: passed
- pnpm test:e2e: 49 passed
- pnpm android:sync: passed
- android/gradlew assembleDebug: BUILD SUCCESSFUL

Debug APK produced locally:

E:\marktext_for_android\android\app\build\outputs\apk\debug\app-debug.apk