### PR TITLE
Wire advanced settings backend

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidAppInfoPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidAppInfoPlugin.java
@@ -1,0 +1,50 @@
+package io.github.renakoni.marktextandroid;
+
+import android.content.pm.PackageInfo;
+import android.os.Build;
+import android.webkit.WebView;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+@CapacitorPlugin(name = "AndroidAppInfo")
+public class AndroidAppInfoPlugin extends Plugin {
+
+    @PluginMethod
+    public void getDiagnostics(PluginCall call) {
+        JSObject result = new JSObject();
+        result.put("deviceInfo", buildDeviceInfo());
+        result.put("webViewInfo", buildWebViewInfo());
+        call.resolve(result);
+    }
+
+    private String buildDeviceInfo() {
+        String manufacturer = safeValue(Build.MANUFACTURER);
+        String model = safeValue(Build.MODEL);
+        String release = safeValue(Build.VERSION.RELEASE);
+        return manufacturer + " " + model + " / Android " + release + " (API " + Build.VERSION.SDK_INT + ")";
+    }
+
+    private String buildWebViewInfo() {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                PackageInfo packageInfo = WebView.getCurrentWebViewPackage();
+                if (packageInfo != null) {
+                    return packageInfo.packageName + " " + packageInfo.versionName;
+                }
+            }
+        } catch (RuntimeException ex) {
+            return "Android WebView";
+        }
+        return "Android WebView";
+    }
+
+    private String safeValue(String value) {
+        if (value == null || value.trim().length() == 0) {
+            return "Unknown";
+        }
+        return value.trim();
+    }
+}

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -29,6 +29,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -52,11 +57,18 @@ public class AndroidDocumentsPlugin extends Plugin {
     private static final String EVENT_SHARE_DOCUMENT = "shareDocument";
     private static final String IMPORTED_IMAGE_DIRECTORY = "images";
     private static final String SHARE_CACHE_DIRECTORY = "shared-markdown";
+    private static final byte[] UTF8_BOM = new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+    private static final byte[] UTF16BE_BOM = new byte[] { (byte) 0xFE, (byte) 0xFF };
+    private static final byte[] UTF16LE_BOM = new byte[] { (byte) 0xFF, (byte) 0xFE };
+    private static final byte[] UTF32BE_BOM = new byte[] { 0x00, 0x00, (byte) 0xFE, (byte) 0xFF };
+    private static final byte[] UTF32LE_BOM = new byte[] { (byte) 0xFF, (byte) 0xFE, 0x00, 0x00 };
     private static final Pattern MARKTEXT_IMAGE_SOURCE_PATTERN = Pattern.compile(
         "marktext-image://local/([^\\s)]+)",
         Pattern.CASE_INSENSITIVE
     );
     private String lastHandledIncomingIntentId = "";
+    private String defaultMarkdownEncoding = "utf8";
+    private boolean autoDetectMarkdownEncoding = true;
 
     @Override
     public void load() {
@@ -74,7 +86,17 @@ public class AndroidDocumentsPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void configureMarkdownSettings(PluginCall call) {
+        applyMarkdownSettingsFromCall(call);
+        JSObject result = new JSObject();
+        result.put("defaultEncoding", defaultMarkdownEncoding);
+        result.put("autoDetectEncoding", autoDetectMarkdownEncoding);
+        call.resolve(result);
+    }
+
+    @PluginMethod
     public void openMarkdownDocument(PluginCall call) {
+        applyMarkdownSettingsFromCall(call);
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*");
@@ -109,8 +131,9 @@ public class AndroidDocumentsPlugin extends Plugin {
             return;
         }
 
+        MarkdownWriteOptions writeOptions = getMarkdownWriteOptions(call);
         try {
-            validateMarkdownBytes(markdown);
+            validateMarkdownBytes(markdown, writeOptions);
         } catch (DocumentReadException ex) {
             Log.w(TAG, "Android document create rejected: " + ex.getMessage());
             call.reject(ex.getMessage(), ex.code, ex);
@@ -159,12 +182,13 @@ public class AndroidDocumentsPlugin extends Plugin {
 
         String suggestedName = normalizeSuggestedMarkdownName(call.getString("suggestedName", ""));
         boolean attachImages = call.getBoolean("attachImages", true);
+        MarkdownWriteOptions writeOptions = getMarkdownWriteOptions(call);
         ShareMarkdownPayload sharePayload = attachImages
             ? buildShareMarkdownPayload(markdown)
             : new ShareMarkdownPayload(markdown, new LinkedHashMap<>());
         byte[] bytes;
         try {
-            bytes = validateMarkdownBytes(sharePayload.markdown);
+            bytes = validateMarkdownBytes(sharePayload.markdown, writeOptions);
         } catch (DocumentReadException ex) {
             Log.w(TAG, "Android share rejected: " + ex.getMessage());
             call.reject(ex.getMessage(), ex.code, ex);
@@ -266,6 +290,7 @@ public class AndroidDocumentsPlugin extends Plugin {
 
     @PluginMethod
     public void readMarkdownDocument(PluginCall call) {
+        applyMarkdownSettingsFromCall(call);
         String sourceUri = call.getString("sourceUri", "");
         Uri uri = parseContentUri(sourceUri);
         if (uri == null) {
@@ -307,7 +332,7 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
 
         try {
-            JSObject result = writeDocumentResult(uri, markdown);
+            JSObject result = writeDocumentResult(uri, markdown, getMarkdownWriteOptions(call));
             Log.i(TAG, "Wrote Android document: " + safeForLog(result.getString("displayName")));
             call.resolve(result);
         } catch (DocumentReadException ex) {
@@ -518,6 +543,7 @@ public class AndroidDocumentsPlugin extends Plugin {
             document.put("pathHint", displayName);
             document.put("mimeType", mimeType.length() > 0 ? mimeType : "text/plain");
             document.put("markdown", markdown);
+            putMarkdownEncodingMetadata(document, defaultMarkdownEncoding, false);
             document.put("canWrite", false);
             document.put("persisted", false);
             document.put("shareKind", "text");
@@ -561,7 +587,7 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
 
         try {
-            JSObject document = createDocumentResult(uri, data, markdown);
+            JSObject document = createDocumentResult(uri, data, markdown, getMarkdownWriteOptions(call));
             persistUriPermission(uri, data);
             document.put("persisted", hasPersistedReadPermission(uri));
             document.put("canWrite", canWrite(uri, data));
@@ -673,7 +699,7 @@ public class AndroidDocumentsPlugin extends Plugin {
             );
         }
 
-        String markdown = readText(uri);
+        DecodedMarkdown decoded = readText(uri);
         JSObject result = new JSObject();
         result.put("canceled", false);
         result.put("sourceUri", uri.toString());
@@ -681,7 +707,8 @@ public class AndroidDocumentsPlugin extends Plugin {
         result.put("providerName", getProviderName(uri));
         result.put("pathHint", displayName);
         result.put("mimeType", mimeType);
-        result.put("markdown", markdown);
+        result.put("markdown", decoded.markdown);
+        putMarkdownEncodingMetadata(result, decoded);
         result.put("canWrite", canWrite(uri, grantIntent));
         result.put("persisted", hasPersistedReadPermission(uri));
         return result;
@@ -748,7 +775,7 @@ public class AndroidDocumentsPlugin extends Plugin {
             );
         }
 
-        String markdown = readText(uri);
+        DecodedMarkdown decoded = readText(uri);
         JSObject result = new JSObject();
         result.put("canceled", false);
         result.put("sourceUri", uri.toString());
@@ -756,7 +783,8 @@ public class AndroidDocumentsPlugin extends Plugin {
         result.put("providerName", getProviderName(uri));
         result.put("pathHint", displayName);
         result.put("mimeType", mimeType);
-        result.put("markdown", markdown);
+        result.put("markdown", decoded.markdown);
+        putMarkdownEncodingMetadata(result, decoded);
         result.put("canWrite", canWrite(uri, grantIntent));
         result.put("persisted", hasPersistedReadPermission(uri));
         return result;
@@ -772,7 +800,7 @@ public class AndroidDocumentsPlugin extends Plugin {
             );
         }
 
-        String markdown = readText(uri);
+        DecodedMarkdown decoded = readText(uri);
         JSObject result = new JSObject();
         result.put("canceled", false);
         result.put("sourceUri", uri.toString());
@@ -780,15 +808,21 @@ public class AndroidDocumentsPlugin extends Plugin {
         result.put("providerName", getProviderName(uri));
         result.put("pathHint", displayName);
         result.put("mimeType", mimeType);
-        result.put("markdown", markdown);
+        result.put("markdown", decoded.markdown);
+        putMarkdownEncodingMetadata(result, decoded);
         result.put("canWrite", canWrite(uri, grantIntent));
         result.put("persisted", hasPersistedReadPermission(uri));
         result.put("shareKind", "stream");
         return result;
     }
 
-    private JSObject createDocumentResult(Uri uri, Intent grantIntent, String markdown) throws IOException, DocumentReadException {
-        byte[] bytes = validateMarkdownBytes(markdown);
+    private JSObject createDocumentResult(
+        Uri uri,
+        Intent grantIntent,
+        String markdown,
+        MarkdownWriteOptions writeOptions
+    ) throws IOException, DocumentReadException {
+        byte[] bytes = validateMarkdownBytes(markdown, writeOptions);
         writeText(uri, bytes);
 
         String displayName = getDisplayName(uri);
@@ -801,12 +835,17 @@ public class AndroidDocumentsPlugin extends Plugin {
         result.put("pathHint", displayName);
         result.put("mimeType", mimeType);
         result.put("markdown", markdown);
+        putMarkdownEncodingMetadata(result, writeOptions.encoding, writeOptions.writeBom);
         result.put("canWrite", canWrite(uri, grantIntent));
         result.put("persisted", hasPersistedReadPermission(uri));
         return result;
     }
 
-    private JSObject writeDocumentResult(Uri uri, String markdown) throws IOException, DocumentReadException {
+    private JSObject writeDocumentResult(
+        Uri uri,
+        String markdown,
+        MarkdownWriteOptions writeOptions
+    ) throws IOException, DocumentReadException {
         String displayName = getDisplayName(uri);
         String mimeType = getMimeType(uri);
         if (!isMarkdownCandidate(displayName, mimeType)) {
@@ -816,7 +855,7 @@ public class AndroidDocumentsPlugin extends Plugin {
             );
         }
 
-        byte[] bytes = validateMarkdownBytes(markdown);
+        byte[] bytes = validateMarkdownBytes(markdown, writeOptions);
         writeText(uri, bytes);
         JSObject result = new JSObject();
         result.put("sourceUri", uri.toString());
@@ -824,6 +863,7 @@ public class AndroidDocumentsPlugin extends Plugin {
         result.put("providerName", getProviderName(uri));
         result.put("pathHint", displayName);
         result.put("mimeType", mimeType);
+        putMarkdownEncodingMetadata(result, writeOptions.encoding, writeOptions.writeBom);
         result.put("canWrite", canWrite(uri, null));
         result.put("persisted", hasPersistedReadPermission(uri));
         return result;
@@ -842,13 +882,46 @@ public class AndroidDocumentsPlugin extends Plugin {
     }
 
     private byte[] validateMarkdownBytes(String markdown) throws DocumentReadException {
-        byte[] bytes = markdown.getBytes(StandardCharsets.UTF_8);
+        return validateMarkdownBytes(markdown, new MarkdownWriteOptions("utf8", false));
+    }
+
+    private byte[] validateMarkdownBytes(String markdown, MarkdownWriteOptions writeOptions) throws DocumentReadException {
+        byte[] bytes = encodeMarkdown(markdown, writeOptions);
         if (bytes.length > MAX_MARKDOWN_BYTES) {
             throw new DocumentReadException(
                 "DOCUMENT_TOO_LARGE",
                 "Markdown document is larger than the current 5 MB limit"
             );
         }
+        return bytes;
+    }
+
+    private byte[] encodeMarkdown(String markdown, MarkdownWriteOptions writeOptions) throws DocumentReadException {
+        Charset charset = getMarkdownCharset(writeOptions.encoding);
+        byte[] body;
+        try {
+            ByteBuffer buffer = charset
+                .newEncoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .encode(CharBuffer.wrap(markdown));
+            body = new byte[buffer.remaining()];
+            buffer.get(body);
+        } catch (CharacterCodingException ex) {
+            throw new DocumentReadException(
+                "DOCUMENT_ENCODING_FAILED",
+                "Could not encode Markdown with the selected encoding"
+            );
+        }
+
+        byte[] bom = getEncodingBom(writeOptions);
+        if (bom.length == 0) {
+            return body;
+        }
+
+        byte[] bytes = new byte[bom.length + body.length];
+        System.arraycopy(bom, 0, bytes, 0, bom.length);
+        System.arraycopy(body, 0, bytes, bom.length, body.length);
         return bytes;
     }
 
@@ -1043,7 +1116,7 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
     }
 
-    private String readText(Uri uri) throws IOException, DocumentReadException {
+    private DecodedMarkdown readText(Uri uri) throws IOException, DocumentReadException {
         ContentResolver resolver = getContext().getContentResolver();
         try (InputStream input = resolver.openInputStream(uri)) {
             if (input == null) {
@@ -1064,8 +1137,242 @@ public class AndroidDocumentsPlugin extends Plugin {
                 }
                 output.write(buffer, 0, read);
             }
-            return output.toString(StandardCharsets.UTF_8.name());
+            return decodeMarkdown(output.toByteArray());
         }
+    }
+
+    private DecodedMarkdown decodeMarkdown(byte[] bytes) throws DocumentReadException {
+        MarkdownBom bom = detectMarkdownBom(bytes);
+        boolean useBom = bom.hasBom && (
+            autoDetectMarkdownEncoding ||
+            normalizeMarkdownEncoding(defaultMarkdownEncoding).equals(bom.encoding)
+        );
+        String encoding = useBom ? bom.encoding : normalizeMarkdownEncoding(defaultMarkdownEncoding);
+        int offset = useBom ? bom.offset : 0;
+        Charset charset = getMarkdownCharset(encoding);
+
+        try {
+            String markdown = charset
+                .newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(bytes, offset, bytes.length - offset))
+                .toString();
+            // TODO: Add full non-BOM charset detection for Advanced > Encoding.
+            return new DecodedMarkdown(markdown, encoding, useBom);
+        } catch (CharacterCodingException | IndexOutOfBoundsException ex) {
+            throw new DocumentReadException(
+                "DOCUMENT_ENCODING_FAILED",
+                "Could not decode Markdown with the selected encoding"
+            );
+        }
+    }
+
+    private void applyMarkdownSettingsFromCall(PluginCall call) {
+        defaultMarkdownEncoding = normalizeMarkdownEncoding(call.getString("defaultEncoding", defaultMarkdownEncoding));
+        autoDetectMarkdownEncoding = call.getBoolean("autoDetectEncoding", autoDetectMarkdownEncoding);
+    }
+
+    private MarkdownWriteOptions getMarkdownWriteOptions(PluginCall call) {
+        String encoding = normalizeMarkdownEncoding(call.getString("encoding", defaultMarkdownEncoding));
+        boolean writeBom = call.getBoolean("writeBom", false);
+        return new MarkdownWriteOptions(encoding, writeBom);
+    }
+
+    private String normalizeMarkdownEncoding(String encoding) {
+        String normalized = encoding == null ? "" : encoding.trim().toLowerCase(Locale.US);
+        switch (normalized) {
+            case "ascii":
+            case "utf8":
+            case "utf16be":
+            case "utf16le":
+            case "utf32be":
+            case "utf32le":
+            case "latin3":
+            case "iso885915":
+            case "cp1252":
+            case "arabic":
+            case "cp1256":
+            case "latin4":
+            case "cp1257":
+            case "iso88592":
+            case "windows1250":
+            case "cp866":
+            case "iso88595":
+            case "koi8r":
+            case "koi8u":
+            case "cp1251":
+            case "iso885913":
+            case "greek":
+            case "cp1253":
+            case "hebrew":
+            case "cp1255":
+            case "latin5":
+            case "cp1254":
+            case "gb2312":
+            case "gb18030":
+            case "gbk":
+            case "big5":
+            case "big5hkscs":
+            case "shiftjis":
+            case "eucjp":
+            case "euckr":
+            case "latin6":
+                return normalized;
+            default:
+                return "utf8";
+        }
+    }
+
+    private Charset getMarkdownCharset(String encoding) throws DocumentReadException {
+        try {
+            return Charset.forName(getMarkdownCharsetName(encoding));
+        } catch (IllegalArgumentException ex) {
+            throw new DocumentReadException(
+                "DOCUMENT_ENCODING_UNSUPPORTED",
+                "Selected Markdown encoding is not supported on this device"
+            );
+        }
+    }
+
+    private String getMarkdownCharsetName(String encoding) {
+        switch (normalizeMarkdownEncoding(encoding)) {
+            case "ascii":
+                return StandardCharsets.US_ASCII.name();
+            case "utf8":
+                return StandardCharsets.UTF_8.name();
+            case "utf16be":
+                return StandardCharsets.UTF_16BE.name();
+            case "utf16le":
+                return StandardCharsets.UTF_16LE.name();
+            case "utf32be":
+                return "UTF-32BE";
+            case "utf32le":
+                return "UTF-32LE";
+            case "latin3":
+                return "ISO-8859-3";
+            case "iso885915":
+                return "ISO-8859-15";
+            case "cp1252":
+                return "windows-1252";
+            case "arabic":
+                return "ISO-8859-6";
+            case "cp1256":
+                return "windows-1256";
+            case "latin4":
+                return "ISO-8859-4";
+            case "cp1257":
+                return "windows-1257";
+            case "iso88592":
+                return "ISO-8859-2";
+            case "windows1250":
+                return "windows-1250";
+            case "cp866":
+                return "IBM866";
+            case "iso88595":
+                return "ISO-8859-5";
+            case "koi8r":
+                return "KOI8-R";
+            case "koi8u":
+                return "KOI8-U";
+            case "cp1251":
+                return "windows-1251";
+            case "iso885913":
+                return "ISO-8859-13";
+            case "greek":
+                return "ISO-8859-7";
+            case "cp1253":
+                return "windows-1253";
+            case "hebrew":
+                return "ISO-8859-8";
+            case "cp1255":
+                return "windows-1255";
+            case "latin5":
+                return "ISO-8859-9";
+            case "cp1254":
+                return "windows-1254";
+            case "gb2312":
+                return "GB2312";
+            case "gb18030":
+                return "GB18030";
+            case "gbk":
+                return "GBK";
+            case "big5":
+                return "Big5";
+            case "big5hkscs":
+                return "Big5-HKSCS";
+            case "shiftjis":
+                return "Shift_JIS";
+            case "eucjp":
+                return "EUC-JP";
+            case "euckr":
+                return "EUC-KR";
+            case "latin6":
+                return "ISO-8859-10";
+            default:
+                return StandardCharsets.UTF_8.name();
+        }
+    }
+
+    private byte[] getEncodingBom(MarkdownWriteOptions writeOptions) {
+        if (!writeOptions.writeBom) {
+            return new byte[0];
+        }
+
+        switch (writeOptions.encoding) {
+            case "utf8":
+                return UTF8_BOM;
+            case "utf16be":
+                return UTF16BE_BOM;
+            case "utf16le":
+                return UTF16LE_BOM;
+            case "utf32be":
+                return UTF32BE_BOM;
+            case "utf32le":
+                return UTF32LE_BOM;
+            default:
+                return new byte[0];
+        }
+    }
+
+    private MarkdownBom detectMarkdownBom(byte[] bytes) {
+        if (startsWith(bytes, UTF8_BOM)) {
+            return new MarkdownBom("utf8", UTF8_BOM.length, true);
+        }
+        if (startsWith(bytes, UTF32BE_BOM)) {
+            return new MarkdownBom("utf32be", UTF32BE_BOM.length, true);
+        }
+        if (startsWith(bytes, UTF32LE_BOM)) {
+            return new MarkdownBom("utf32le", UTF32LE_BOM.length, true);
+        }
+        if (startsWith(bytes, UTF16BE_BOM)) {
+            return new MarkdownBom("utf16be", UTF16BE_BOM.length, true);
+        }
+        if (startsWith(bytes, UTF16LE_BOM)) {
+            return new MarkdownBom("utf16le", UTF16LE_BOM.length, true);
+        }
+        return new MarkdownBom(defaultMarkdownEncoding, 0, false);
+    }
+
+    private boolean startsWith(byte[] bytes, byte[] prefix) {
+        if (bytes.length < prefix.length) {
+            return false;
+        }
+        for (int index = 0; index < prefix.length; index++) {
+            if (bytes[index] != prefix[index]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void putMarkdownEncodingMetadata(JSObject result, DecodedMarkdown decoded) {
+        putMarkdownEncodingMetadata(result, decoded.encoding, decoded.hasBom);
+    }
+
+    private void putMarkdownEncodingMetadata(JSObject result, String encoding, boolean hasBom) {
+        result.put("encoding", normalizeMarkdownEncoding(encoding));
+        result.put("hasEncodingBom", hasBom);
     }
 
     private String getDisplayName(Uri uri) {
@@ -1446,6 +1753,43 @@ public class AndroidDocumentsPlugin extends Plugin {
         DocumentReadException(String code, String message) {
             super(message);
             this.code = code;
+        }
+    }
+
+    private static class MarkdownWriteOptions {
+
+        final String encoding;
+        final boolean writeBom;
+
+        MarkdownWriteOptions(String encoding, boolean writeBom) {
+            this.encoding = encoding;
+            this.writeBom = writeBom;
+        }
+    }
+
+    private static class DecodedMarkdown {
+
+        final String markdown;
+        final String encoding;
+        final boolean hasBom;
+
+        DecodedMarkdown(String markdown, String encoding, boolean hasBom) {
+            this.markdown = markdown;
+            this.encoding = encoding;
+            this.hasBom = hasBom;
+        }
+    }
+
+    private static class MarkdownBom {
+
+        final String encoding;
+        final int offset;
+        final boolean hasBom;
+
+        MarkdownBom(String encoding, int offset, boolean hasBom) {
+            this.encoding = encoding;
+            this.offset = offset;
+            this.hasBom = hasBom;
         }
     }
 

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
@@ -9,6 +9,7 @@ public class MainActivity extends BridgeActivity {
     protected void onCreate(Bundle savedInstanceState) {
         registerPlugin(AndroidDocumentsPlugin.class);
         registerPlugin(NativeLoggerPlugin.class);
+        registerPlugin(AndroidAppInfoPlugin.class);
         super.onCreate(savedInstanceState);
     }
 

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/NativeLoggerPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/NativeLoggerPlugin.java
@@ -1,26 +1,38 @@
 package io.github.renakoni.marktextandroid;
 
+import android.app.Activity;
+import android.content.ActivityNotFoundException;
+import android.content.ClipData;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.net.Uri;
 import android.util.Log;
+import androidx.core.content.FileProvider;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 @CapacitorPlugin(name = "NativeLogger")
 public class NativeLoggerPlugin extends Plugin {
 
     private static final String TAG = "MarkTextAndroid";
     private static final String LOG_DIR = "logs";
+    private static final String LOG_EXPORT_DIR = "log-exports";
 
     @PluginMethod
     public void write(PluginCall call) {
@@ -71,6 +83,64 @@ public class NativeLoggerPlugin extends Plugin {
         result.put("directory", dir.getAbsolutePath());
         result.put("currentFile", getLogFile(nowIso()).getAbsolutePath());
         call.resolve(result);
+    }
+
+    @PluginMethod
+    public void exportLogs(PluginCall call) {
+        Activity activity = getActivity();
+        if (activity == null) {
+            call.reject("No Android activity is available for sharing logs", "LOG_SHARE_TARGET_UNAVAILABLE");
+            return;
+        }
+
+        String webLogs = call.getString("webLogs", "");
+        String displayName = "marktext-android-logs-" + utcDateFormat("yyyyMMdd-HHmmss").format(new Date()) + ".zip";
+
+        try {
+            File exportDirectory = getLogExportDirectory();
+            if (!exportDirectory.exists() && !exportDirectory.mkdirs()) {
+                throw new IOException("Cannot create log export directory: " + exportDirectory.getAbsolutePath());
+            }
+
+            File exportFile = new File(exportDirectory, displayName);
+            if (!isFileInDirectory(exportFile, exportDirectory)) {
+                throw new SecurityException("Log export path escaped the expected directory");
+            }
+
+            int fileCount = writeLogZip(exportFile, webLogs);
+            Uri exportUri = FileProvider.getUriForFile(
+                getContext(),
+                getContext().getPackageName() + ".fileprovider",
+                exportFile
+            );
+            Intent shareIntent = new Intent(Intent.ACTION_SEND);
+            shareIntent.setType("application/zip");
+            shareIntent.putExtra(Intent.EXTRA_STREAM, exportUri);
+            shareIntent.putExtra(Intent.EXTRA_TITLE, displayName);
+            shareIntent.putExtra(Intent.EXTRA_SUBJECT, displayName);
+            shareIntent.setClipData(ClipData.newUri(getContext().getContentResolver(), displayName, exportUri));
+            shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+            Intent chooser = Intent.createChooser(shareIntent, "Export logs");
+            chooser.putExtra(
+                Intent.EXTRA_EXCLUDE_COMPONENTS,
+                new ComponentName[] { new ComponentName(getContext(), MainActivity.class) }
+            );
+            chooser.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            activity.startActivity(chooser);
+
+            JSObject result = new JSObject();
+            result.put("displayName", displayName);
+            result.put("bytes", exportFile.length());
+            result.put("fileCount", fileCount);
+            call.resolve(result);
+        } catch (ActivityNotFoundException ex) {
+            Log.w(TAG, "No Android share target is available for logs", ex);
+            call.reject("No Android share target is available for logs", "LOG_SHARE_TARGET_UNAVAILABLE", ex);
+        } catch (IOException | SecurityException ex) {
+            Log.e(TAG, "Failed to export native logs", ex);
+            call.reject("Failed to export native logs", "LOG_EXPORT_FAILED", ex);
+        }
     }
 
     private static String normalizeLevel(String level) {
@@ -163,6 +233,10 @@ public class NativeLoggerPlugin extends Plugin {
         return new File(getContext().getFilesDir(), LOG_DIR);
     }
 
+    private File getLogExportDirectory() {
+        return new File(getContext().getCacheDir(), LOG_EXPORT_DIR);
+    }
+
     private File getLogFile(String timestamp) {
         String day = dayFromTimestamp(timestamp);
         return new File(getLogDirectory(), "marktext-android-" + day + ".log");
@@ -186,5 +260,77 @@ public class NativeLoggerPlugin extends Plugin {
         SimpleDateFormat format = new SimpleDateFormat(pattern, Locale.US);
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
         return format;
+    }
+
+    private int writeLogZip(File outputFile, String webLogs) throws IOException {
+        int fileCount = 0;
+        try (ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(outputFile))) {
+            fileCount += writeInfoEntry(zip);
+            File[] logFiles = getLogDirectory().listFiles();
+            if (logFiles != null) {
+                Arrays.sort(logFiles, (left, right) -> left.getName().compareTo(right.getName()));
+                for (File logFile : logFiles) {
+                    if (logFile.isFile() && logFile.getName().endsWith(".log")) {
+                        writeFileEntry(zip, logFile, "native/" + sanitizeZipEntryName(logFile.getName()));
+                        fileCount += 1;
+                    }
+                }
+            }
+
+            if (webLogs != null && webLogs.trim().length() > 0) {
+                writeTextEntry(zip, "web/debug-logs.jsonl", webLogs);
+                fileCount += 1;
+            }
+        }
+        return fileCount;
+    }
+
+    private int writeInfoEntry(ZipOutputStream zip) throws IOException {
+        StringBuilder builder = new StringBuilder();
+        builder.append("createdAt=").append(nowIso()).append('\n');
+        builder.append("package=").append(getContext().getPackageName()).append('\n');
+        builder.append("androidApi=").append(android.os.Build.VERSION.SDK_INT).append('\n');
+        builder.append("device=").append(sanitize(android.os.Build.MANUFACTURER)).append(' ');
+        builder.append(sanitize(android.os.Build.MODEL)).append('\n');
+        builder.append("logDirectory=").append(getLogDirectory().getAbsolutePath()).append('\n');
+        writeTextEntry(zip, "manifest.txt", builder.toString());
+        return 1;
+    }
+
+    private void writeTextEntry(ZipOutputStream zip, String name, String content) throws IOException {
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        ZipEntry entry = new ZipEntry(name);
+        zip.putNextEntry(entry);
+        zip.write(bytes);
+        zip.closeEntry();
+    }
+
+    private void writeFileEntry(ZipOutputStream zip, File file, String name) throws IOException {
+        ZipEntry entry = new ZipEntry(name);
+        zip.putNextEntry(entry);
+        try (FileInputStream input = new FileInputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                zip.write(buffer, 0, read);
+            }
+        }
+        zip.closeEntry();
+    }
+
+    private String sanitizeZipEntryName(String value) {
+        String sanitized = value == null ? "" : value.replaceAll("[^A-Za-z0-9._-]+", "_");
+        return sanitized.length() == 0 ? "log.txt" : sanitized;
+    }
+
+    private boolean isFileInDirectory(File file, File directory) {
+        try {
+            String directoryPath = directory.getCanonicalPath();
+            String filePath = file.getCanonicalPath();
+            return filePath.startsWith(directoryPath + File.separator);
+        } catch (IOException ex) {
+            Log.w(TAG, "Could not validate log export path", ex);
+            return false;
+        }
     }
 }

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -2,5 +2,6 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="my_images" path="." />
     <cache-path name="shared_markdown" path="shared-markdown/" />
+    <cache-path name="log_exports" path="log-exports/" />
     <cache-path name="my_cache_images" path="." />
 </paths>

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@ import HomeScreen from './features/home/HomeScreen.vue'
 import EditorScreen from './features/editor/EditorScreen.vue'
 import {
   createAndroidMarkdownDocument,
+  configureAndroidMarkdownSettings,
   getAndroidDocumentErrorCode,
   getAndroidDocumentUserMessage,
   isAndroidDocumentAccessAvailable,
@@ -113,7 +114,12 @@ import {
   writeStoredAndroidRecentDocuments,
   writeStoredLocalDrafts,
 } from './lib/documentStorage'
-import { createLogger, getNativeLogInfo, isNativeLoggerAvailable } from './lib/logger'
+import {
+  createLogger,
+  exportNativeLogs,
+  getNativeLogInfo,
+  isNativeLoggerAvailable,
+} from './lib/logger'
 import {
   type MobileCommandId,
   type MobileEditorCommandTarget,
@@ -131,6 +137,12 @@ import {
   getEditorStyleVars,
 } from './features/settings/appearanceSettings'
 import { getEditingSettings } from './features/settings/editingSettings'
+import {
+  getAdvancedSettings,
+  getAndroidMarkdownSettings,
+  getMarkdownSaveSettings,
+  type AdvancedMaintenanceActionId,
+} from './features/settings/advancedSettings'
 import { createMuyaMobileEditorCommandTarget } from './lib/muyaMobileAdapter'
 import { translateKnownText, useI18n } from './lib/i18n'
 import {
@@ -185,12 +197,22 @@ const {
   openLinkSheet: openEditorLinkSheet,
   closeLinkSheet: resetEditorLinkSheet,
 } = useEditorToolbar()
-const { locale, t } = useI18n()
-const { getValue } = useSettingsState()
+const { locale, setLocale, t } = useI18n()
+const { getValue, clearSettings } = useSettingsState()
 const appearanceTextSettings = computed(() => getAppearanceTextSettings(getValue))
 const editingSettings = computed(() => getEditingSettings(getValue))
 const documentSettings = computed(() => getDocumentSettings(getValue))
 const imageSharingSettings = computed(() => getImageSharingSettings(getValue))
+const advancedSettings = computed(() => getAdvancedSettings(getValue))
+const androidMarkdownSettings = computed(() => getAndroidMarkdownSettings(advancedSettings.value))
+const detectedDocumentEncoding = computed(() =>
+  documentState.value.autosaveTarget === 'android-document'
+    ? documentState.value.encoding
+    : undefined,
+)
+const markdownSaveSettings = computed(() =>
+  getMarkdownSaveSettings(advancedSettings.value, detectedDocumentEncoding.value),
+)
 const editorStyleVars = computed(() => getEditorStyleVars(appearanceTextSettings.value))
 const displayStatus = computed(() => translateKnownText(status.value))
 const displayHomeNotice = computed(() =>
@@ -259,6 +281,20 @@ watch(documentSettings, (settings, previousSettings) => {
     }
   }
 })
+
+watch(
+  androidMarkdownSettings,
+  settings => {
+    if (!isAndroidDocumentAccessAvailable()) {
+      return
+    }
+
+    configureAndroidMarkdownSettings(settings).catch(error => {
+      androidDocumentLog.warn('Android Markdown settings update failed', error)
+    })
+  },
+  { immediate: true },
+)
 
 watch(locale, nextLocale => {
   void applyMuyaEditorLocale(editor, nextLocale, editorLog)
@@ -711,6 +747,7 @@ async function saveAndroidDocument() {
     documentState: documentState.value,
     markdown: value,
     canWrite: currentAndroidDocumentCanWrite.value,
+    markdownSaveSettings: markdownSaveSettings.value,
   })
 
   if (startResult.kind === 'not-android-document' || startResult.kind === 'clean') {
@@ -810,6 +847,7 @@ async function saveLocalDraftToAndroidDocument(options: { returnHomeAfterSave?: 
     transientAccessMessage: getTransientAndroidSaveMessage(),
     createAndroidMarkdownDocument,
     getAndroidDocumentUserMessage,
+    markdownSaveSettings: markdownSaveSettings.value,
     logger: androidDocumentLog,
   })
 
@@ -883,6 +921,7 @@ async function saveAndroidDocumentCopy(options: { returnHomeAfterSave?: boolean 
       transientAccessMessage: getTransientAndroidSaveMessage(),
       createAndroidMarkdownDocument,
       getAndroidDocumentUserMessage,
+      markdownSaveSettings: markdownSaveSettings.value,
       logger: androidDocumentLog,
     })
 
@@ -947,6 +986,7 @@ async function shareCurrentMarkdownDocument() {
       shareAndroidMarkdownDocument,
       getAndroidDocumentUserMessage,
       imageSharingSettings: imageSharingSettings.value,
+      markdownSaveSettings: markdownSaveSettings.value,
       logger: androidDocumentLog,
     })
 
@@ -1137,7 +1177,7 @@ async function openFileFromAndroid() {
   homeNotice.value = null
 
   const result = await openAndroidMarkdownDocumentWorkflow({
-    openAndroidMarkdownDocument,
+    openAndroidMarkdownDocument: () => openAndroidMarkdownDocument(androidMarkdownSettings.value),
     getAndroidDocumentErrorCode,
     getAndroidDocumentUserMessage,
     logger: androidDocumentLog,
@@ -1257,7 +1297,10 @@ async function openDocument(id: string) {
     homeNotice.value = null
     androidExitPromptOpen.value = false
     try {
-      const document = await readAndroidMarkdownDocument(recentDocument.sourceUri)
+      const document = await readAndroidMarkdownDocument(
+        recentDocument.sourceUri,
+        androidMarkdownSettings.value,
+      )
       await openAndroidDocumentResult(document)
     } catch (error) {
       homeNotice.value = getAndroidDocumentUserMessage(error)
@@ -1544,6 +1587,41 @@ function discardLocalDraftAndShowHome() {
   closeEditorToHome()
 }
 
+function clearLocalDraftMaintenanceState() {
+  clearDraftSaveTimer()
+  localDrafts.value = []
+  writeStoredLocalDrafts([])
+  if (documentState.value.autosaveTarget === 'local-draft') {
+    documentState.value = createUntitledDocument({ autosaveTarget: 'local-draft' })
+    promptLocalDraftSaveOnExit.value = false
+  }
+  draftLog.info('cleared local drafts from Advanced maintenance')
+}
+
+function resetSettingsMaintenanceState() {
+  clearSettings()
+  setLocale('en')
+  appLog.info('reset settings from Advanced maintenance')
+}
+
+async function runAdvancedMaintenanceAction(action: AdvancedMaintenanceActionId) {
+  if (action === 'exportLogs') {
+    const result = await exportNativeLogs()
+    if (!result) {
+      throw new Error(t('settings.maintenance.exportLogsUnavailable'))
+    }
+    loggingLog.info('exported native logs', result)
+    return
+  }
+
+  if (action === 'clearDrafts') {
+    clearLocalDraftMaintenanceState()
+    return
+  }
+
+  resetSettingsMaintenanceState()
+}
+
 onMounted(() => {
   appLog.info('app mounted')
   installAppLifecycleListeners()
@@ -1631,6 +1709,7 @@ onBeforeUnmount(() => {
     @open-file="openFileFromAndroid"
     @set-tab="setHomeTab"
     @set-settings-page="setSettingsPage"
+    @run-maintenance-action="runAdvancedMaintenanceAction"
   />
 
   <EditorScreen

--- a/src/features/android-documents/saveAndroidDocumentCopyWorkflow.test.ts
+++ b/src/features/android-documents/saveAndroidDocumentCopyWorkflow.test.ts
@@ -49,6 +49,7 @@ describe('saveAndroidDocumentCopyWorkflow', () => {
     expect(createAndroidMarkdownDocument).toHaveBeenCalledWith(
       '# Original Save Copy\n\nbody',
       'Original Save Copy copy 2.md',
+      { encoding: 'utf8', writeBom: false },
     )
     expect(result).toEqual({
       kind: 'canceled',
@@ -142,5 +143,31 @@ describe('saveAndroidDocumentCopyWorkflow', () => {
         markdown: '# Original\n\nbody\n\nchanged',
       },
     })
+  })
+
+  it('creates the copy with configured save preparation options', async () => {
+    const createAndroidMarkdownDocument = vi.fn().mockResolvedValue({ canceled: true })
+    const copySourceDocument = createDirtyAndroidDocumentState('one\ntwo\n\n')
+
+    await saveAndroidDocumentCopyWorkflow({
+      copySourceDocument,
+      originalSourceUri: 'content://provider/original.md',
+      reservedDisplayNames: [],
+      returnHomeAfterSave: false,
+      transientAccessMessage: 'transient',
+      createAndroidMarkdownDocument,
+      getAndroidDocumentUserMessage: () => 'failed',
+      markdownSaveSettings: {
+        encoding: 'utf16le',
+        lineEnding: 'crlf',
+        trimTrailingNewline: 0,
+      },
+    })
+
+    expect(createAndroidMarkdownDocument).toHaveBeenCalledWith(
+      'one\r\ntwo',
+      'Original copy.md',
+      { encoding: 'utf16le', writeBom: false },
+    )
   })
 })

--- a/src/features/android-documents/saveAndroidDocumentCopyWorkflow.ts
+++ b/src/features/android-documents/saveAndroidDocumentCopyWorkflow.ts
@@ -8,6 +8,11 @@ import {
   createSavedDocumentStateFromAndroidDocument,
   type SavedAndroidDocumentStateSource,
 } from '../document-session/documentSessionState'
+import {
+  DEFAULT_MARKDOWN_SAVE_SETTINGS,
+  type MarkdownEncoding,
+  type MarkdownSaveSettings,
+} from '../settings/advancedSettings'
 import type { OpenedAndroidDocument } from '../../lib/androidDocuments'
 
 interface CanceledAndroidDocumentCreate {
@@ -62,8 +67,10 @@ interface SaveAndroidDocumentCopyWorkflowOptions {
   createAndroidMarkdownDocument: (
     markdown: string,
     suggestedName: string,
+    options: { encoding: MarkdownEncoding; writeBom: boolean },
   ) => Promise<AndroidDocumentCreateResult>
   getAndroidDocumentUserMessage: (error: unknown) => string
+  markdownSaveSettings?: MarkdownSaveSettings
   now?: () => string
   logger?: WorkflowLogger
 }
@@ -90,10 +97,15 @@ export async function saveAndroidDocumentCopyWorkflow({
   transientAccessMessage,
   createAndroidMarkdownDocument,
   getAndroidDocumentUserMessage,
+  markdownSaveSettings = DEFAULT_MARKDOWN_SAVE_SETTINGS,
   now = () => new Date().toISOString(),
   logger,
 }: SaveAndroidDocumentCopyWorkflowOptions): Promise<SaveAndroidDocumentCopyResult> {
-  const markdownForSave = prepareMarkdownForSave(copySourceDocument.markdown, copySourceDocument)
+  const markdownForSave = prepareMarkdownForSave(
+    copySourceDocument.markdown,
+    copySourceDocument,
+    markdownSaveSettings,
+  )
   const suggestedName = getSuggestedMarkdownCopyFileName(
     copySourceDocument.markdown,
     copySourceDocument.displayName,
@@ -101,7 +113,10 @@ export async function saveAndroidDocumentCopyWorkflow({
   )
 
   try {
-    const document = await createAndroidMarkdownDocument(markdownForSave, suggestedName)
+    const document = await createAndroidMarkdownDocument(markdownForSave, suggestedName, {
+      encoding: markdownSaveSettings.encoding,
+      writeBom: copySourceDocument.hasEncodingBom,
+    })
     if (document.canceled) {
       logger?.info('Android document save copy canceled', {
         sourceUri: originalSourceUri,

--- a/src/features/android-documents/saveAndroidDocumentWorkflow.test.ts
+++ b/src/features/android-documents/saveAndroidDocumentWorkflow.test.ts
@@ -127,6 +127,7 @@ describe('saveAndroidDocumentWorkflow', () => {
     expect(writeAndroidMarkdownDocument).toHaveBeenCalledWith(
       'content://provider/android.md',
       '# Android\r\n\r\nbody\r\n\r\nchanged\r\n',
+      { encoding: 'utf8', writeBom: false },
     )
     expect(result).toMatchObject({
       kind: 'saved',
@@ -215,6 +216,30 @@ describe('saveAndroidDocumentWorkflow', () => {
       recoveryDraft: {
         sourceUri: 'content://provider/android.md',
         markdown: '# Android\n\nbody\n\nchanged',
+      },
+    })
+  })
+
+  it('applies configured line ending, trailing newline, and encoding settings', () => {
+    const documentState = createDirtyAndroidDocumentState('one\ntwo\n\n')
+
+    const start = createSaveAndroidDocumentWorkflowStart({
+      documentState,
+      markdown: documentState.markdown,
+      canWrite: true,
+      markdownSaveSettings: {
+        encoding: 'gbk',
+        lineEnding: 'crlf',
+        trimTrailingNewline: 1,
+      },
+    })
+
+    expect(start).toMatchObject({
+      kind: 'ready',
+      request: {
+        markdownForSave: 'one\r\ntwo\r\n',
+        encoding: 'gbk',
+        writeBom: false,
       },
     })
   })

--- a/src/features/android-documents/saveAndroidDocumentWorkflow.ts
+++ b/src/features/android-documents/saveAndroidDocumentWorkflow.ts
@@ -6,6 +6,11 @@ import {
   updateDocumentMarkdown,
   type MarkdownDocumentState,
 } from '../../lib/documentState'
+import {
+  DEFAULT_MARKDOWN_SAVE_SETTINGS,
+  type MarkdownEncoding,
+  type MarkdownSaveSettings,
+} from '../settings/advancedSettings'
 
 interface WorkflowLogger {
   debug(message: string, data?: unknown): void
@@ -22,6 +27,8 @@ export interface SaveAndroidDocumentWorkflowRequest {
   sourceUri: string
   savingDocument: MarkdownDocumentState
   markdownForSave: string
+  encoding: MarkdownEncoding
+  writeBom: boolean
   saveMarkdown: string
 }
 
@@ -84,12 +91,17 @@ interface CreateSaveAndroidDocumentWorkflowStartOptions {
   documentState: MarkdownDocumentState
   markdown: string
   canWrite: boolean
+  markdownSaveSettings?: MarkdownSaveSettings
 }
 
 interface SaveAndroidDocumentWorkflowOptions {
   request: SaveAndroidDocumentWorkflowRequest
   getCurrentDocumentState: () => MarkdownDocumentState
-  writeAndroidMarkdownDocument: (sourceUri: string, markdown: string) => Promise<unknown>
+  writeAndroidMarkdownDocument: (
+    sourceUri: string,
+    markdown: string,
+    options: { encoding: MarkdownEncoding; writeBom: boolean },
+  ) => Promise<unknown>
   getAndroidDocumentUserMessage: (error: unknown) => string
   recoveryMessage: string
   now?: () => string
@@ -100,6 +112,7 @@ function createSaveAndroidDocumentWorkflowRequest(
   documentState: MarkdownDocumentState,
   markdown: string,
   sourceUri: string,
+  markdownSaveSettings: MarkdownSaveSettings,
 ): SaveAndroidDocumentWorkflowRequest {
   const nextDocument = updateDocumentMarkdown(documentState, markdown, {
     markDirty: documentState.isDirty,
@@ -108,7 +121,9 @@ function createSaveAndroidDocumentWorkflowRequest(
   return {
     sourceUri,
     savingDocument: markDocumentSaving(nextDocument),
-    markdownForSave: prepareMarkdownForSave(nextDocument.markdown, nextDocument),
+    markdownForSave: prepareMarkdownForSave(nextDocument.markdown, nextDocument, markdownSaveSettings),
+    encoding: markdownSaveSettings.encoding,
+    writeBom: nextDocument.hasEncodingBom,
     saveMarkdown: nextDocument.markdown,
   }
 }
@@ -143,6 +158,7 @@ export function createSaveAndroidDocumentWorkflowStart({
   documentState,
   markdown,
   canWrite,
+  markdownSaveSettings = DEFAULT_MARKDOWN_SAVE_SETTINGS,
 }: CreateSaveAndroidDocumentWorkflowStartOptions): SaveAndroidDocumentWorkflowStartResult {
   if (documentState.autosaveTarget !== 'android-document') {
     return {
@@ -182,7 +198,12 @@ export function createSaveAndroidDocumentWorkflowStart({
     kind: 'ready',
     saved: false,
     status: 'Saving',
-    request: createSaveAndroidDocumentWorkflowRequest(documentState, markdown, sourceUri),
+    request: createSaveAndroidDocumentWorkflowRequest(
+      documentState,
+      markdown,
+      sourceUri,
+      markdownSaveSettings,
+    ),
   }
 }
 
@@ -196,7 +217,10 @@ export async function saveAndroidDocumentWorkflow({
   logger,
 }: SaveAndroidDocumentWorkflowOptions): Promise<SaveAndroidDocumentWorkflowResult> {
   try {
-    await writeAndroidMarkdownDocument(request.sourceUri, request.markdownForSave)
+    await writeAndroidMarkdownDocument(request.sourceUri, request.markdownForSave, {
+      encoding: request.encoding,
+      writeBom: request.writeBom,
+    })
     const savedAt = now()
     const currentDocument = getCurrentDocumentState()
 

--- a/src/features/android-documents/saveLocalDraftToAndroidDocumentWorkflow.test.ts
+++ b/src/features/android-documents/saveLocalDraftToAndroidDocumentWorkflow.test.ts
@@ -63,6 +63,7 @@ describe('saveLocalDraftToAndroidDocumentWorkflow', () => {
     expect(createAndroidMarkdownDocument).toHaveBeenCalledWith(
       '# Saved Draft\r\n\r\nbody\r\n',
       'Saved Draft.md',
+      { encoding: 'utf8', writeBom: false },
     )
     expect(result).toEqual({
       kind: 'canceled',
@@ -151,5 +152,29 @@ describe('saveLocalDraftToAndroidDocumentWorkflow', () => {
         lastSaveError: 'permission lost',
       },
     })
+  })
+
+  it('creates Android Markdown with configured save preparation options', async () => {
+    const createAndroidMarkdownDocument = vi.fn().mockResolvedValue({ canceled: true })
+
+    await saveLocalDraftToAndroidDocumentWorkflow({
+      draftDocument: createDraftDocument('one\ntwo\n\n'),
+      returnHomeAfterSave: false,
+      reopenPromptOnCancel: false,
+      transientAccessMessage: 'transient',
+      createAndroidMarkdownDocument,
+      getAndroidDocumentUserMessage: () => 'failed',
+      markdownSaveSettings: {
+        encoding: 'cp1252',
+        lineEnding: 'crlf',
+        trimTrailingNewline: 1,
+      },
+    })
+
+    expect(createAndroidMarkdownDocument).toHaveBeenCalledWith(
+      'one\r\ntwo\r\n',
+      'Draft.md',
+      { encoding: 'cp1252', writeBom: false },
+    )
   })
 })

--- a/src/features/android-documents/saveLocalDraftToAndroidDocumentWorkflow.ts
+++ b/src/features/android-documents/saveLocalDraftToAndroidDocumentWorkflow.ts
@@ -8,6 +8,11 @@ import {
   createSavedDocumentStateFromAndroidDocument,
   type SavedAndroidDocumentStateSource,
 } from '../document-session/documentSessionState'
+import {
+  DEFAULT_MARKDOWN_SAVE_SETTINGS,
+  type MarkdownEncoding,
+  type MarkdownSaveSettings,
+} from '../settings/advancedSettings'
 import type { OpenedAndroidDocument } from '../../lib/androidDocuments'
 
 interface CanceledAndroidDocumentCreate {
@@ -63,8 +68,10 @@ interface SaveLocalDraftToAndroidDocumentWorkflowOptions {
   createAndroidMarkdownDocument: (
     markdown: string,
     suggestedName: string,
+    options: { encoding: MarkdownEncoding; writeBom: boolean },
   ) => Promise<AndroidDocumentCreateResult>
   getAndroidDocumentUserMessage: (error: unknown) => string
+  markdownSaveSettings?: MarkdownSaveSettings
   now?: () => string
   logger?: WorkflowLogger
 }
@@ -76,6 +83,7 @@ export async function saveLocalDraftToAndroidDocumentWorkflow({
   transientAccessMessage,
   createAndroidMarkdownDocument,
   getAndroidDocumentUserMessage,
+  markdownSaveSettings = DEFAULT_MARKDOWN_SAVE_SETTINGS,
   now = () => new Date().toISOString(),
   logger,
 }: SaveLocalDraftToAndroidDocumentWorkflowOptions): Promise<SaveLocalDraftToAndroidDocumentResult> {
@@ -87,12 +95,15 @@ export async function saveLocalDraftToAndroidDocumentWorkflow({
   }
 
   try {
-    const markdownForSave = prepareMarkdownForSave(draftDocument.markdown, draftDocument)
+    const markdownForSave = prepareMarkdownForSave(draftDocument.markdown, draftDocument, markdownSaveSettings)
     const suggestedName = getSuggestedMarkdownFileName(
       draftDocument.markdown,
       draftDocument.displayName,
     )
-    const document = await createAndroidMarkdownDocument(markdownForSave, suggestedName)
+    const document = await createAndroidMarkdownDocument(markdownForSave, suggestedName, {
+      encoding: markdownSaveSettings.encoding,
+      writeBom: draftDocument.hasEncodingBom,
+    })
     if (document.canceled) {
       logger?.info('Android document create canceled')
       return {

--- a/src/features/android-documents/shareAndroidMarkdownDocumentWorkflow.test.ts
+++ b/src/features/android-documents/shareAndroidMarkdownDocumentWorkflow.test.ts
@@ -42,7 +42,7 @@ describe('shareAndroidMarkdownDocumentWorkflow', () => {
     expect(shareAndroidMarkdownDocument).toHaveBeenCalledWith(
       '# Share Out Note\n\nbody',
       'Share Out Note.md',
-      { attachImages: true },
+      { attachImages: true, encoding: 'utf8' },
     )
     expect(result).toEqual({
       kind: 'shared',
@@ -66,7 +66,29 @@ describe('shareAndroidMarkdownDocumentWorkflow', () => {
     expect(shareAndroidMarkdownDocument).toHaveBeenCalledWith(
       '# Share Out Note\n\nbody',
       'Share Out Note.md',
-      { attachImages: false },
+      { attachImages: false, encoding: 'utf8' },
+    )
+  })
+
+  it('shares Markdown with configured save preparation options', async () => {
+    const shareAndroidMarkdownDocument = vi.fn().mockResolvedValue(shareResult)
+
+    await shareAndroidMarkdownDocumentWorkflow({
+      currentDocument: createCurrentDocument('one\ntwo\n\n'),
+      shareAndroidMarkdownDocument,
+      getAndroidDocumentUserMessage: () => 'failed',
+      imageSharingSettings: defaultImageSharingSettings,
+      markdownSaveSettings: {
+        encoding: 'gb18030',
+        lineEnding: 'crlf',
+        trimTrailingNewline: 0,
+      },
+    })
+
+    expect(shareAndroidMarkdownDocument).toHaveBeenCalledWith(
+      'one\r\ntwo',
+      'Draft.md',
+      { attachImages: true, encoding: 'gb18030' },
     )
   })
 

--- a/src/features/android-documents/shareAndroidMarkdownDocumentWorkflow.ts
+++ b/src/features/android-documents/shareAndroidMarkdownDocumentWorkflow.ts
@@ -8,6 +8,11 @@ import {
   shouldAttachImagesWhenSharing,
   type ImageSharingSettings,
 } from './imageSharingSettings'
+import {
+  DEFAULT_MARKDOWN_SAVE_SETTINGS,
+  type MarkdownEncoding,
+  type MarkdownSaveSettings,
+} from '../settings/advancedSettings'
 
 interface WorkflowLogger {
   info(message: string, data?: unknown): void
@@ -31,10 +36,11 @@ interface ShareAndroidMarkdownDocumentWorkflowOptions {
   shareAndroidMarkdownDocument: (
     markdown: string,
     suggestedName: string,
-    options: { attachImages: boolean },
+    options: { attachImages: boolean; encoding: MarkdownEncoding },
   ) => Promise<AndroidShareResult>
   getAndroidDocumentUserMessage: (error: unknown) => string
   imageSharingSettings: Pick<ImageSharingSettings, 'shareImages'>
+  markdownSaveSettings?: MarkdownSaveSettings
   logger?: WorkflowLogger
 }
 
@@ -43,9 +49,10 @@ export async function shareAndroidMarkdownDocumentWorkflow({
   shareAndroidMarkdownDocument,
   getAndroidDocumentUserMessage,
   imageSharingSettings,
+  markdownSaveSettings = DEFAULT_MARKDOWN_SAVE_SETTINGS,
   logger,
 }: ShareAndroidMarkdownDocumentWorkflowOptions): Promise<ShareAndroidMarkdownDocumentResult> {
-  const markdownForShare = prepareMarkdownForSave(currentDocument.markdown, currentDocument)
+  const markdownForShare = prepareMarkdownForSave(currentDocument.markdown, currentDocument, markdownSaveSettings)
   const suggestedName = getSuggestedMarkdownFileName(
     currentDocument.markdown,
     currentDocument.displayName,
@@ -54,6 +61,7 @@ export async function shareAndroidMarkdownDocumentWorkflow({
   try {
     const result = await shareAndroidMarkdownDocument(markdownForShare, suggestedName, {
       attachImages: shouldAttachImagesWhenSharing(imageSharingSettings),
+      encoding: markdownSaveSettings.encoding,
     })
     logger?.info('Android share sheet opened', {
       displayName: result.displayName,

--- a/src/features/document-session/documentSessionState.ts
+++ b/src/features/document-session/documentSessionState.ts
@@ -23,6 +23,8 @@ export function createDocumentStateFromAndroidDocument(document: OpenedAndroidDo
     markdown: document.markdown,
     displayName: document.displayName,
     sourceUri: document.sourceUri,
+    encoding: document.encoding,
+    hasEncodingBom: document.hasEncodingBom,
     autosaveTarget: 'android-document',
   })
 

--- a/src/features/home/HomeScreen.vue
+++ b/src/features/home/HomeScreen.vue
@@ -6,6 +6,7 @@ import SettingsScreen from '../settings/SettingsScreen.vue'
 import type { HomeDocumentItem } from './homeDocuments'
 import { HOME_TABS, type HomeTab } from './homeNavigation'
 import { SETTINGS_PAGES, type SettingsPage } from '../settings/settingsNavigation'
+import type { AdvancedMaintenanceActionId } from '../settings/advancedSettings'
 
 interface Props {
   activeTab: HomeTab
@@ -23,6 +24,7 @@ const emit = defineEmits<{
   openFile: []
   newDocument: []
   setSettingsPage: [page: SettingsPage]
+  runMaintenanceAction: [action: AdvancedMaintenanceActionId]
 }>()
 
 const homeMain = ref<HTMLElement | null>(null)
@@ -58,6 +60,7 @@ watch(
         v-else
         :active-page="settingsPage"
         @set-page="page => emit('setSettingsPage', page)"
+        @run-maintenance-action="action => emit('runMaintenanceAction', action)"
       />
     </div>
     <AppBottomNavigation

--- a/src/features/settings/SettingsScreen.vue
+++ b/src/features/settings/SettingsScreen.vue
@@ -10,6 +10,7 @@ import {
   SETTINGS_PAGES,
   type SettingsPage,
 } from './settingsNavigation'
+import type { AdvancedMaintenanceActionId } from './advancedSettings'
 
 defineProps<{
   activePage: SettingsPage
@@ -17,6 +18,7 @@ defineProps<{
 
 const emit = defineEmits<{
   setPage: [page: SettingsPage]
+  runMaintenanceAction: [action: AdvancedMaintenanceActionId]
 }>()
 
 const { t } = useI18n()
@@ -67,7 +69,11 @@ const { t } = useI18n()
         </div>
       </template>
       <AboutSettings v-else-if="activePage === SETTINGS_PAGES.ABOUT" />
-      <SettingsDetailPage v-else :page="activePage" />
+      <SettingsDetailPage
+        v-else
+        :page="activePage"
+        :run-maintenance-action="action => emit('runMaintenanceAction', action)"
+      />
     </div>
   </section>
 </template>

--- a/src/features/settings/advancedDiagnostics.ts
+++ b/src/features/settings/advancedDiagnostics.ts
@@ -1,0 +1,31 @@
+import { Capacitor, registerPlugin } from '@capacitor/core'
+
+interface NativeAdvancedDiagnostics {
+  deviceInfo: string
+  webViewInfo: string
+}
+
+interface AndroidAppInfoPlugin {
+  getDiagnostics(): Promise<NativeAdvancedDiagnostics>
+}
+
+const AndroidAppInfo = registerPlugin<AndroidAppInfoPlugin>('AndroidAppInfo')
+
+function getBrowserDiagnostics(): NativeAdvancedDiagnostics {
+  return {
+    deviceInfo: Capacitor.getPlatform(),
+    webViewInfo: navigator.userAgent,
+  }
+}
+
+export async function getAdvancedDiagnostics(): Promise<NativeAdvancedDiagnostics> {
+  if (Capacitor.getPlatform() !== 'android' || !Capacitor.isNativePlatform()) {
+    return getBrowserDiagnostics()
+  }
+
+  try {
+    return await AndroidAppInfo.getDiagnostics()
+  } catch {
+    return getBrowserDiagnostics()
+  }
+}

--- a/src/features/settings/advancedSettings.test.ts
+++ b/src/features/settings/advancedSettings.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_ADVANCED_SETTINGS,
+  getAdvancedSettings,
+  getAndroidMarkdownSettings,
+  getMarkdownSaveSettings,
+  normalizeAdvancedSettingValue,
+  normalizeMarkdownEncoding,
+  type AdvancedSettingKey,
+} from './advancedSettings'
+import type { SettingsValue } from './settingsState'
+
+function createGetter(values: Record<string, SettingsValue>) {
+  return <T extends SettingsValue>(key: string, defaultValue: T): T =>
+    (values[key] ?? defaultValue) as T
+}
+
+describe('advancedSettings', () => {
+  it('returns normalized defaults for missing or invalid settings', () => {
+    expect(getAdvancedSettings(createGetter({}))).toEqual(DEFAULT_ADVANCED_SETTINGS)
+    expect(getAdvancedSettings(createGetter({
+      defaultEncoding: 'bad-encoding',
+      autoGuessEncoding: 'yes',
+      endOfLine: 'native',
+      trimTrailingNewline: 9,
+    }))).toEqual(DEFAULT_ADVANCED_SETTINGS)
+  })
+
+  it('normalizes each advanced setting value by key', () => {
+    const cases: Array<[AdvancedSettingKey, SettingsValue, unknown]> = [
+      ['defaultEncoding', 'gbk', 'gbk'],
+      ['autoGuessEncoding', false, false],
+      ['endOfLine', 'crlf', 'crlf'],
+      ['trimTrailingNewline', '0', 0],
+    ]
+
+    for (const [key, value, expected] of cases) {
+      expect(normalizeAdvancedSettingValue(key, value)).toBe(expected)
+    }
+  })
+
+  it('builds Android Markdown settings from Advanced file settings', () => {
+    expect(getAndroidMarkdownSettings({
+      defaultEncoding: 'gb18030',
+      autoGuessEncoding: false,
+    })).toEqual({
+      defaultEncoding: 'gb18030',
+      autoDetectEncoding: false,
+    })
+  })
+
+  it('uses detected document encoding only when auto-detect is enabled', () => {
+    expect(getMarkdownSaveSettings({
+      defaultEncoding: 'gbk',
+      autoGuessEncoding: true,
+      endOfLine: 'lf',
+      trimTrailingNewline: 1,
+    }, 'utf16le')).toEqual({
+      encoding: 'utf16le',
+      lineEnding: 'lf',
+      trimTrailingNewline: 1,
+    })
+
+    expect(getMarkdownSaveSettings({
+      defaultEncoding: 'gbk',
+      autoGuessEncoding: false,
+      endOfLine: 'crlf',
+      trimTrailingNewline: 0,
+    }, 'utf16le')).toEqual({
+      encoding: 'gbk',
+      lineEnding: 'crlf',
+      trimTrailingNewline: 0,
+    })
+  })
+
+  it('uses the default encoding when no document encoding was detected', () => {
+    expect(getMarkdownSaveSettings({
+      defaultEncoding: 'gb18030',
+      autoGuessEncoding: true,
+      endOfLine: 'default',
+      trimTrailingNewline: 2,
+    })).toMatchObject({
+      encoding: 'gb18030',
+    })
+  })
+
+  it('falls back to UTF-8 for unknown encoding metadata', () => {
+    expect(normalizeMarkdownEncoding('not-real')).toBe('utf8')
+  })
+})

--- a/src/features/settings/advancedSettings.ts
+++ b/src/features/settings/advancedSettings.ts
@@ -1,0 +1,211 @@
+import type { SettingsValue } from './settingsState'
+import type { LineEnding } from '../../lib/documentState'
+
+export type MarkdownEncoding =
+  | 'ascii'
+  | 'utf8'
+  | 'utf16be'
+  | 'utf16le'
+  | 'utf32be'
+  | 'utf32le'
+  | 'latin3'
+  | 'iso885915'
+  | 'cp1252'
+  | 'arabic'
+  | 'cp1256'
+  | 'latin4'
+  | 'cp1257'
+  | 'iso88592'
+  | 'windows1250'
+  | 'cp866'
+  | 'iso88595'
+  | 'koi8r'
+  | 'koi8u'
+  | 'cp1251'
+  | 'iso885913'
+  | 'greek'
+  | 'cp1253'
+  | 'hebrew'
+  | 'cp1255'
+  | 'latin5'
+  | 'cp1254'
+  | 'gb2312'
+  | 'gb18030'
+  | 'gbk'
+  | 'big5'
+  | 'big5hkscs'
+  | 'shiftjis'
+  | 'eucjp'
+  | 'euckr'
+  | 'latin6'
+
+export type AdvancedLineEnding = 'default' | LineEnding
+export type TrailingNewlineMode = 0 | 1 | 2
+export type AdvancedMaintenanceActionId = 'exportLogs' | 'clearDrafts' | 'resetSettings'
+
+export type AdvancedSettingKey =
+  | 'defaultEncoding'
+  | 'autoGuessEncoding'
+  | 'endOfLine'
+  | 'trimTrailingNewline'
+
+export interface AdvancedSettings {
+  defaultEncoding: MarkdownEncoding
+  autoGuessEncoding: boolean
+  endOfLine: AdvancedLineEnding
+  trimTrailingNewline: TrailingNewlineMode
+}
+
+export interface AndroidMarkdownSettings {
+  defaultEncoding: MarkdownEncoding
+  autoDetectEncoding: boolean
+}
+
+export interface MarkdownSaveSettings {
+  encoding: MarkdownEncoding
+  lineEnding: AdvancedLineEnding
+  trimTrailingNewline: TrailingNewlineMode
+}
+
+export const ADVANCED_SETTING_KEYS = [
+  'defaultEncoding',
+  'autoGuessEncoding',
+  'endOfLine',
+  'trimTrailingNewline',
+] as const satisfies readonly AdvancedSettingKey[]
+
+export const DEFAULT_ADVANCED_SETTINGS = {
+  defaultEncoding: 'utf8',
+  autoGuessEncoding: true,
+  endOfLine: 'default',
+  trimTrailingNewline: 2,
+} as const satisfies AdvancedSettings
+
+export const DEFAULT_MARKDOWN_SAVE_SETTINGS = {
+  encoding: DEFAULT_ADVANCED_SETTINGS.defaultEncoding,
+  lineEnding: DEFAULT_ADVANCED_SETTINGS.endOfLine,
+  trimTrailingNewline: DEFAULT_ADVANCED_SETTINGS.trimTrailingNewline,
+} as const satisfies MarkdownSaveSettings
+
+const MARKDOWN_ENCODINGS = new Set<MarkdownEncoding>([
+  'ascii',
+  'utf8',
+  'utf16be',
+  'utf16le',
+  'utf32be',
+  'utf32le',
+  'latin3',
+  'iso885915',
+  'cp1252',
+  'arabic',
+  'cp1256',
+  'latin4',
+  'cp1257',
+  'iso88592',
+  'windows1250',
+  'cp866',
+  'iso88595',
+  'koi8r',
+  'koi8u',
+  'cp1251',
+  'iso885913',
+  'greek',
+  'cp1253',
+  'hebrew',
+  'cp1255',
+  'latin5',
+  'cp1254',
+  'gb2312',
+  'gb18030',
+  'gbk',
+  'big5',
+  'big5hkscs',
+  'shiftjis',
+  'eucjp',
+  'euckr',
+  'latin6',
+])
+const ADVANCED_LINE_ENDINGS = new Set<AdvancedLineEnding>(['default', 'lf', 'crlf'])
+const TRAILING_NEWLINE_MODES = new Set<TrailingNewlineMode>([0, 1, 2])
+
+function normalizeBoolean(value: unknown, fallback: boolean) {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function normalizeChoice<T extends string>(value: unknown, options: Set<T>, fallback: T): T {
+  return options.has(value as T) ? (value as T) : fallback
+}
+
+function normalizeTrailingNewlineMode(value: unknown): TrailingNewlineMode {
+  const numericValue = typeof value === 'number' ? value : Number(value)
+  return TRAILING_NEWLINE_MODES.has(numericValue as TrailingNewlineMode)
+    ? (numericValue as TrailingNewlineMode)
+    : DEFAULT_ADVANCED_SETTINGS.trimTrailingNewline
+}
+
+export function normalizeMarkdownEncoding(value: unknown): MarkdownEncoding {
+  return normalizeChoice(
+    value,
+    MARKDOWN_ENCODINGS,
+    DEFAULT_ADVANCED_SETTINGS.defaultEncoding,
+  )
+}
+
+export function normalizeAdvancedSettingValue(key: AdvancedSettingKey, value: SettingsValue) {
+  switch (key) {
+    case 'defaultEncoding':
+      return normalizeMarkdownEncoding(value)
+    case 'autoGuessEncoding':
+      return normalizeBoolean(value, DEFAULT_ADVANCED_SETTINGS.autoGuessEncoding)
+    case 'endOfLine':
+      return normalizeChoice(value, ADVANCED_LINE_ENDINGS, DEFAULT_ADVANCED_SETTINGS.endOfLine)
+    case 'trimTrailingNewline':
+      return normalizeTrailingNewlineMode(value)
+  }
+}
+
+export function getAdvancedSettings(
+  getValue: <T extends SettingsValue>(key: string, defaultValue: T) => T,
+): AdvancedSettings {
+  return {
+    defaultEncoding: normalizeMarkdownEncoding(
+      getValue('defaultEncoding', DEFAULT_ADVANCED_SETTINGS.defaultEncoding),
+    ),
+    autoGuessEncoding: normalizeBoolean(
+      getValue('autoGuessEncoding', DEFAULT_ADVANCED_SETTINGS.autoGuessEncoding),
+      DEFAULT_ADVANCED_SETTINGS.autoGuessEncoding,
+    ),
+    endOfLine: normalizeChoice(
+      getValue('endOfLine', DEFAULT_ADVANCED_SETTINGS.endOfLine),
+      ADVANCED_LINE_ENDINGS,
+      DEFAULT_ADVANCED_SETTINGS.endOfLine,
+    ),
+    trimTrailingNewline: normalizeTrailingNewlineMode(
+      getValue('trimTrailingNewline', DEFAULT_ADVANCED_SETTINGS.trimTrailingNewline),
+    ),
+  }
+}
+
+export function getAndroidMarkdownSettings(
+  settings: Pick<AdvancedSettings, 'defaultEncoding' | 'autoGuessEncoding'>,
+): AndroidMarkdownSettings {
+  return {
+    defaultEncoding: settings.defaultEncoding,
+    autoDetectEncoding: settings.autoGuessEncoding,
+  }
+}
+
+export function getMarkdownSaveSettings(
+  settings: AdvancedSettings,
+  documentEncoding?: string,
+): MarkdownSaveSettings {
+  const detectedEncoding = documentEncoding
+    ? normalizeMarkdownEncoding(documentEncoding)
+    : settings.defaultEncoding
+
+  return {
+    encoding: settings.autoGuessEncoding ? detectedEncoding : settings.defaultEncoding,
+    lineEnding: settings.endOfLine,
+    trimTrailingNewline: settings.trimTrailingNewline,
+  }
+}

--- a/src/features/settings/components/SettingsDetailPage.vue
+++ b/src/features/settings/components/SettingsDetailPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import SettingsChoiceRow from './SettingsChoiceRow.vue'
 import SettingsRow from './SettingsRow.vue'
 import SettingsSection from './SettingsSection.vue'
@@ -19,17 +19,23 @@ import {
 import { APP_LANGUAGE_OPTIONS, useI18n, type I18nKey } from '../../../lib/i18n'
 import { SETTINGS_PAGES, type SettingsPage } from '../settingsNavigation'
 import { useSettingsState } from '../settingsState'
+import type { AdvancedMaintenanceActionId } from '../advancedSettings'
+import { getAdvancedDiagnostics } from '../advancedDiagnostics'
 
 const props = defineProps<{
   page: SettingsPage
+  runMaintenanceAction?: (action: AdvancedMaintenanceActionId) => Promise<void> | void
 }>()
 
 const { locale, setLocale, t } = useI18n()
 const { getValue, setValue } = useSettingsState()
 const sections = computed(() => SETTINGS_DETAIL_SECTIONS[props.page] ?? [])
-type MaintenanceActionId = 'exportLogs' | 'clearDrafts' | 'resetSettings'
+type MaintenanceActionId = AdvancedMaintenanceActionId
 
 const maintenanceAction = ref<MaintenanceActionId | null>(null)
+const maintenanceActionBusy = ref(false)
+const maintenanceActionError = ref<string | null>(null)
+const advancedDiagnostics = ref<Record<string, string>>({})
 const maintenanceActionCopies: Record<
   MaintenanceActionId,
   {
@@ -113,6 +119,12 @@ function getActionValue(row: SettingsActionRow) {
 }
 
 function getStatusValue(row: SettingsStatusRow) {
+  if (props.page === SETTINGS_PAGES.ADVANCED) {
+    const value = advancedDiagnostics.value[row.id]
+    if (value) {
+      return value
+    }
+  }
   return t(row.valueKey)
 }
 
@@ -140,21 +152,56 @@ function recordAction(row: SettingsActionRow) {
     : null
   if (maintenanceActionId) {
     maintenanceAction.value = maintenanceActionId
+    maintenanceActionError.value = null
     return
   }
   setValue(`action:${row.id}`, Date.now())
 }
 
 function closeMaintenanceSheet() {
+  if (maintenanceActionBusy.value) {
+    return
+  }
   maintenanceAction.value = null
+  maintenanceActionError.value = null
 }
 
-function confirmMaintenanceAction() {
-  if (maintenanceAction.value) {
-    setValue(`action:${maintenanceAction.value}`, Date.now())
+async function confirmMaintenanceAction() {
+  const action = maintenanceAction.value
+  if (!action || maintenanceActionBusy.value) {
+    return
   }
-  closeMaintenanceSheet()
+
+  maintenanceActionBusy.value = true
+  maintenanceActionError.value = null
+  try {
+    await props.runMaintenanceAction?.(action)
+    maintenanceAction.value = null
+  } catch (error) {
+    maintenanceActionError.value = error instanceof Error
+      ? error.message
+      : t('settings.maintenance.genericError')
+  } finally {
+    maintenanceActionBusy.value = false
+  }
 }
+
+watch(
+  () => props.page,
+  page => {
+    if (page !== SETTINGS_PAGES.ADVANCED) {
+      return
+    }
+
+    getAdvancedDiagnostics().then(result => {
+      advancedDiagnostics.value = {
+        deviceInfo: result.deviceInfo,
+        webviewInfo: result.webViewInfo,
+      }
+    })
+  },
+  { immediate: true },
+)
 </script>
 
 <template>
@@ -247,10 +294,15 @@ function confirmMaintenanceAction() {
     <div class="draft-save-panel">
       <h2 id="settings-maintenance-title">{{ t(activeMaintenanceActionCopy.titleKey) }}</h2>
       <p>{{ t(activeMaintenanceActionCopy.bodyKey) }}</p>
+      <p v-if="maintenanceActionError" role="alert">
+        {{ maintenanceActionError }}
+      </p>
       <div class="draft-save-actions">
         <button
           type="button"
           :class="{ 'danger-action': activeMaintenanceActionCopy.danger, 'primary-action': !activeMaintenanceActionCopy.danger }"
+          :disabled="maintenanceActionBusy"
+          :aria-busy="maintenanceActionBusy ? 'true' : undefined"
           :data-testid="activeMaintenanceActionCopy.confirmTestId"
           @click="confirmMaintenanceAction"
         >
@@ -258,6 +310,7 @@ function confirmMaintenanceAction() {
         </button>
         <button
           type="button"
+          :disabled="maintenanceActionBusy"
           data-testid="settings-maintenance-cancel"
           @click="closeMaintenanceSheet"
         >

--- a/src/features/settings/settingsContent.ts
+++ b/src/features/settings/settingsContent.ts
@@ -63,8 +63,8 @@ export interface SettingsDetailSection {
   rows: readonly SettingsDetailRow[]
 }
 
-// Settings descriptors are front-end-only metadata. Until each setting is wired
-// explicitly, controls must not change editor behavior, document text, or files.
+// Settings descriptors define the mobile settings UI. Individual settings are
+// wired only where a feature module explicitly consumes their stored values.
 export const SETTINGS_PAGE_TITLE_KEYS = {
   [SETTINGS_PAGES.INDEX]: 'settings.title',
   [SETTINGS_PAGES.APPEARANCE]: 'settings.appearance',

--- a/src/features/settings/settingsState.ts
+++ b/src/features/settings/settingsState.ts
@@ -48,6 +48,22 @@ function saveSettings() {
   }
 }
 
+function clearSettings() {
+  for (const key of Object.keys(settingsValues)) {
+    delete settingsValues[key]
+  }
+
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.removeItem(SETTINGS_STORAGE_KEY)
+  } catch {
+    // Resetting settings should leave the current session usable even if storage fails.
+  }
+}
+
 export function useSettingsState() {
   loadSettings()
 
@@ -65,5 +81,6 @@ export function useSettingsState() {
     values: readonly(settingsValues),
     getValue,
     setValue,
+    clearSettings,
   }
 }

--- a/src/lib/androidDocuments.ts
+++ b/src/lib/androidDocuments.ts
@@ -1,4 +1,9 @@
 import { Capacitor, registerPlugin, type PluginListenerHandle } from '@capacitor/core'
+import {
+  normalizeMarkdownEncoding,
+  type AndroidMarkdownSettings,
+  type MarkdownEncoding,
+} from '../features/settings/advancedSettings'
 
 export interface OpenedAndroidDocument {
   canceled?: false
@@ -8,6 +13,8 @@ export interface OpenedAndroidDocument {
   pathHint: string | null
   mimeType: string | null
   markdown: string
+  encoding?: MarkdownEncoding
+  hasEncodingBom?: boolean
   canWrite: boolean
   persisted: boolean
 }
@@ -20,6 +27,8 @@ export interface SharedAndroidDocument {
   pathHint: string | null
   mimeType: string | null
   markdown: string
+  encoding?: MarkdownEncoding
+  hasEncodingBom?: boolean
   canWrite: boolean
   persisted: boolean
   shareKind: 'text' | 'stream'
@@ -31,6 +40,8 @@ interface SavedAndroidDocument {
   providerName: string | null
   pathHint: string | null
   mimeType: string | null
+  encoding?: MarkdownEncoding
+  hasEncodingBom?: boolean
   canWrite: boolean
   persisted: boolean
 }
@@ -65,7 +76,16 @@ export interface AndroidShareResult {
 
 export interface AndroidShareOptions {
   attachImages: boolean
+  encoding: MarkdownEncoding
 }
+
+export interface AndroidWriteOptions {
+  encoding: MarkdownEncoding
+  writeBom?: boolean
+}
+
+export type AndroidCreateOptions = AndroidWriteOptions
+export type AndroidReadOptions = Partial<AndroidMarkdownSettings>
 
 interface CanceledAndroidDocumentOpen {
   canceled: true
@@ -95,15 +115,24 @@ interface AndroidDocumentsPlugin {
   createMarkdownDocument(options: {
     markdown: string
     suggestedName: string
+    encoding?: string
+    writeBom?: boolean
   }): Promise<OpenedAndroidDocument | CanceledAndroidDocumentOpen>
-  openMarkdownDocument(): Promise<OpenedAndroidDocument | CanceledAndroidDocumentOpen>
-  readMarkdownDocument(options: { sourceUri: string }): Promise<OpenedAndroidDocument>
+  openMarkdownDocument(options?: AndroidReadOptions): Promise<OpenedAndroidDocument | CanceledAndroidDocumentOpen>
+  readMarkdownDocument(options: { sourceUri: string } & AndroidReadOptions): Promise<OpenedAndroidDocument>
   shareMarkdownDocument(options: {
     markdown: string
     suggestedName: string
     attachImages?: boolean
+    encoding?: string
   }): Promise<AndroidShareResult>
-  writeMarkdownDocument(options: { sourceUri: string; markdown: string }): Promise<SavedAndroidDocument>
+  writeMarkdownDocument(options: {
+    sourceUri: string
+    markdown: string
+    encoding?: string
+    writeBom?: boolean
+  }): Promise<SavedAndroidDocument>
+  configureMarkdownSettings(options: AndroidMarkdownSettings): Promise<void>
   getImportedImageDirectory(): Promise<{ fileUri: string; webBaseUri?: string }>
   pickImageDocument(options?: { copyImage?: boolean }): Promise<{
     canceled?: false
@@ -132,9 +161,14 @@ export function isAndroidDocumentAccessAvailable() {
   return Capacitor.getPlatform() === 'android' && Capacitor.isNativePlatform()
 }
 
-export async function openAndroidMarkdownDocument() {
+export async function configureAndroidMarkdownSettings(settings: AndroidMarkdownSettings) {
   ensureAndroidDocumentsAvailable()
-  const result = await AndroidDocuments.openMarkdownDocument()
+  await AndroidDocuments.configureMarkdownSettings(settings)
+}
+
+export async function openAndroidMarkdownDocument(options: AndroidReadOptions = {}) {
+  ensureAndroidDocumentsAvailable()
+  const result = await AndroidDocuments.openMarkdownDocument(options)
   if (result.canceled) {
     return result
   }
@@ -142,11 +176,17 @@ export async function openAndroidMarkdownDocument() {
   return normalizeOpenedDocument(result)
 }
 
-export async function createAndroidMarkdownDocument(markdown: string, suggestedName: string) {
+export async function createAndroidMarkdownDocument(
+  markdown: string,
+  suggestedName: string,
+  options: AndroidCreateOptions,
+) {
   ensureAndroidDocumentsAvailable()
   const result = await AndroidDocuments.createMarkdownDocument({
     markdown,
     suggestedName,
+    encoding: options.encoding,
+    writeBom: options.writeBom,
   })
   if (result.canceled) {
     return result
@@ -155,17 +195,26 @@ export async function createAndroidMarkdownDocument(markdown: string, suggestedN
   return normalizeOpenedDocument(result)
 }
 
-export async function readAndroidMarkdownDocument(sourceUri: string) {
+export async function readAndroidMarkdownDocument(
+  sourceUri: string,
+  options: AndroidReadOptions = {},
+) {
   ensureAndroidDocumentsAvailable()
-  return normalizeOpenedDocument(await AndroidDocuments.readMarkdownDocument({ sourceUri }))
+  return normalizeOpenedDocument(await AndroidDocuments.readMarkdownDocument({ sourceUri, ...options }))
 }
 
-export async function writeAndroidMarkdownDocument(sourceUri: string, markdown: string) {
+export async function writeAndroidMarkdownDocument(
+  sourceUri: string,
+  markdown: string,
+  options: AndroidWriteOptions,
+) {
   ensureAndroidDocumentsAvailable()
   return normalizeSavedDocument(
     await AndroidDocuments.writeMarkdownDocument({
       sourceUri,
       markdown,
+      encoding: options.encoding,
+      writeBom: options.writeBom,
     }),
   )
 }
@@ -173,7 +222,7 @@ export async function writeAndroidMarkdownDocument(sourceUri: string, markdown: 
 export async function shareAndroidMarkdownDocument(
   markdown: string,
   suggestedName: string,
-  options: AndroidShareOptions = { attachImages: true },
+  options: AndroidShareOptions,
 ) {
   ensureAndroidDocumentsAvailable()
   return normalizeShareResult(
@@ -181,6 +230,7 @@ export async function shareAndroidMarkdownDocument(
       markdown,
       suggestedName,
       attachImages: options.attachImages,
+      encoding: options.encoding,
     }),
   )
 }
@@ -286,6 +336,14 @@ export function getAndroidDocumentUserMessage(error: unknown) {
     return 'Could not save this Markdown file.'
   }
 
+  if (code === 'DOCUMENT_ENCODING_UNSUPPORTED') {
+    return 'This text encoding is not available on this device.'
+  }
+
+  if (code === 'DOCUMENT_ENCODING_FAILED') {
+    return 'Could not read or save this file with the selected encoding.'
+  }
+
   if (code === 'DOCUMENT_CREATOR_UNAVAILABLE') {
     return 'Could not create a Markdown file on this device.'
   }
@@ -312,6 +370,8 @@ function normalizeOpenedDocument(value: OpenedAndroidDocument): OpenedAndroidDoc
     pathHint: value.pathHint ?? null,
     mimeType: value.mimeType ?? null,
     markdown: value.markdown,
+    encoding: normalizeMarkdownEncodingValue(value.encoding),
+    hasEncodingBom: Boolean(value.hasEncodingBom),
     canWrite: Boolean(value.canWrite),
     persisted: Boolean(value.persisted),
   }
@@ -336,6 +396,8 @@ function normalizeSharedDocument(value: SharedAndroidDocument): SharedAndroidDoc
     pathHint: value.pathHint ?? null,
     mimeType: value.mimeType ?? null,
     markdown: value.markdown,
+    encoding: normalizeMarkdownEncodingValue(value.encoding),
+    hasEncodingBom: Boolean(value.hasEncodingBom),
     canWrite: Boolean(value.canWrite),
     persisted: Boolean(value.persisted),
     shareKind,
@@ -353,9 +415,15 @@ function normalizeSavedDocument(value: SavedAndroidDocument): SavedAndroidDocume
     providerName: value.providerName ?? null,
     pathHint: value.pathHint ?? null,
     mimeType: value.mimeType ?? null,
+    encoding: normalizeMarkdownEncodingValue(value.encoding),
+    hasEncodingBom: Boolean(value.hasEncodingBom),
     canWrite: Boolean(value.canWrite),
     persisted: Boolean(value.persisted),
   }
+}
+
+function normalizeMarkdownEncodingValue(value: unknown): MarkdownEncoding {
+  return normalizeMarkdownEncoding(value)
 }
 
 function normalizeShareResult(value: AndroidShareResult): AndroidShareResult {

--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -72,6 +72,25 @@ describe('documentState', () => {
     expect(saved).toBe('one\r\ntwo\r\n')
   })
 
+  it('overrides preserved line endings when a global save setting is selected', () => {
+    const documentState = createUntitledDocument({ markdown: 'one\r\ntwo\r\n' })
+    const saved = prepareMarkdownForSave('one\ntwo\n', documentState, {
+      lineEnding: 'lf',
+      trimTrailingNewline: 1,
+    })
+
+    expect(saved).toBe('one\ntwo\n')
+  })
+
+  it('trims trailing newlines when the global save setting requests it', () => {
+    const documentState = createUntitledDocument({ markdown: 'one\n\n' })
+    const saved = prepareMarkdownForSave('one\n\n', documentState, {
+      trimTrailingNewline: 0,
+    })
+
+    expect(saved).toBe('one')
+  })
+
   it('preserves a final newline added after opening a document without one', () => {
     const documentState = createUntitledDocument({ markdown: 'one' })
     const dirty = updateDocumentMarkdown(documentState, 'one\n')

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -1,6 +1,7 @@
 export type LineEnding = 'lf' | 'crlf'
 export type AutosaveTarget = 'local-draft' | 'android-document'
 export type AutosaveState = 'clean' | 'dirty' | 'saving' | 'save-failed'
+export type MarkdownDocumentEncoding = string
 
 export interface DocumentStats {
   words: number
@@ -27,6 +28,8 @@ export interface MarkdownDocumentState {
   isMixedLineEndings: boolean
   adjustLineEndingOnSave: boolean
   trimTrailingNewline: number
+  encoding: MarkdownDocumentEncoding
+  hasEncodingBom: boolean
   autosaveTarget: AutosaveTarget
   autosaveState: AutosaveState
   lastSavedAt: string | null
@@ -42,6 +45,8 @@ interface CreateDocumentOptions {
   sourceUri?: string | null
   autosaveTarget?: AutosaveTarget
   preferredLineEnding?: LineEnding
+  encoding?: MarkdownDocumentEncoding
+  hasEncodingBom?: boolean
   createdAt?: string
   now?: string
 }
@@ -54,6 +59,11 @@ interface UpdateDocumentOptions {
 interface SaveDocumentOptions {
   autosaveTarget?: AutosaveTarget
   now?: string
+}
+
+export interface MarkdownSaveOptions {
+  lineEnding?: 'default' | LineEnding
+  trimTrailingNewline?: number
 }
 
 const DEFAULT_UNTITLED_NAME = 'Untitled-1'
@@ -149,10 +159,17 @@ export function normalizeMarkdownForEditor(
 export function prepareMarkdownForSave(
   markdown: string,
   options: Pick<MarkdownDocumentState, 'adjustLineEndingOnSave' | 'lineEnding' | 'trimTrailingNewline'>,
+  saveOptions: MarkdownSaveOptions = {},
 ) {
-  let nextMarkdown = adjustTrailingNewlines(markdown, options.trimTrailingNewline)
+  const trailingNewlineMode = saveOptions.trimTrailingNewline ?? options.trimTrailingNewline
+  const lineEndingMode = saveOptions.lineEnding ?? 'default'
+  const lineEnding = lineEndingMode === 'default' ? options.lineEnding : lineEndingMode
+  const adjustLineEndingOnSave = lineEndingMode === 'default'
+    ? options.adjustLineEndingOnSave
+    : lineEndingMode === 'crlf'
+  let nextMarkdown = adjustTrailingNewlines(markdown, trailingNewlineMode)
 
-  if (options.adjustLineEndingOnSave && options.lineEnding === 'crlf') {
+  if (adjustLineEndingOnSave && lineEnding === 'crlf') {
     nextMarkdown = nextMarkdown.replace(LINE_ENDING_REGEXP, '\r\n')
   }
 
@@ -238,6 +255,8 @@ export function createUntitledDocument(options: CreateDocumentOptions = {}): Mar
     isMixedLineEndings: normalized.isMixedLineEndings,
     adjustLineEndingOnSave: normalized.adjustLineEndingOnSave,
     trimTrailingNewline: normalized.trimTrailingNewline,
+    encoding: options.encoding ?? 'utf8',
+    hasEncodingBom: options.hasEncodingBom ?? false,
     autosaveTarget: options.autosaveTarget ?? 'local-draft',
     autosaveState: 'clean',
     lastSavedAt: now,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -172,6 +172,8 @@ const MESSAGES = {
     'android.message.readFailed': 'Could not read this Markdown file.',
     'android.message.readOnly': 'This file is read-only.',
     'android.message.saveFailed': 'Could not save this Markdown file.',
+    'android.message.encodingUnsupported': 'This text encoding is not available on this device.',
+    'android.message.encodingFailed': 'Could not read or save this file with the selected encoding.',
     'android.message.createFailed': 'Could not create a Markdown file on this device.',
     'android.message.openFailed': 'Could not open this Markdown file.',
     'android.image.fromAppBuild': 'Insert images from the Android app build.',
@@ -334,6 +336,7 @@ const MESSAGES = {
     'settings.maintenance.exportLogsBody': 'Package app logs as a ZIP archive for Android sharing.',
     'settings.maintenance.exportLogsAction': 'Export',
     'settings.maintenance.exportLogsConfirm': 'Export ZIP',
+    'settings.maintenance.exportLogsUnavailable': 'Export logs from the Android app build.',
     'settings.maintenance.clearDraftsTitle': 'Clear local drafts?',
     'settings.maintenance.clearDraftsBody':
       'This removes local drafts stored inside MarkText. Markdown files on the device are not deleted.',
@@ -344,6 +347,7 @@ const MESSAGES = {
       'This restores settings to defaults. Documents and local drafts are not deleted.',
     'settings.maintenance.resetSettingsAction': 'Reset',
     'settings.maintenance.resetSettingsConfirm': 'Reset',
+    'settings.maintenance.genericError': 'Action failed.',
 
     'settings.value.on': 'On',
     'settings.value.off': 'Off',
@@ -707,6 +711,8 @@ const MESSAGES = {
     'android.message.readFailed': '无法读取此 Markdown 文件。',
     'android.message.readOnly': '此文件为只读。',
     'android.message.saveFailed': '无法保存此 Markdown 文件。',
+    'android.message.encodingUnsupported': '此设备不支持所选文本编码。',
+    'android.message.encodingFailed': '无法使用所选编码读取或保存此文件。',
     'android.message.createFailed': '无法在此设备上创建 Markdown 文件。',
     'android.message.openFailed': '无法打开此 Markdown 文件。',
     'android.image.fromAppBuild': '请在 Android 应用中插入图片。',
@@ -869,6 +875,7 @@ const MESSAGES = {
     'settings.maintenance.exportLogsBody': '将应用日志打包为 ZIP 压缩包，用于通过系统分享。',
     'settings.maintenance.exportLogsAction': '导出',
     'settings.maintenance.exportLogsConfirm': '导出压缩包',
+    'settings.maintenance.exportLogsUnavailable': '请在 Android 应用内导出日志。',
     'settings.maintenance.clearDraftsTitle': '清除本地草稿？',
     'settings.maintenance.clearDraftsBody':
       '这会删除保存在 MarkText 内的本地草稿，不会删除设备上的 Markdown 文件。',
@@ -879,6 +886,7 @@ const MESSAGES = {
       '这会恢复所有设置为默认值，不会删除文档和本地草稿。',
     'settings.maintenance.resetSettingsAction': '重置',
     'settings.maintenance.resetSettingsConfirm': '重置',
+    'settings.maintenance.genericError': '操作失败。',
 
     'settings.value.on': '开',
     'settings.value.off': '关',
@@ -1133,6 +1141,8 @@ const KNOWN_TEXT_MESSAGE_KEYS = {
   'Could not read this Markdown file.': 'android.message.readFailed',
   'This file is read-only.': 'android.message.readOnly',
   'Could not save this Markdown file.': 'android.message.saveFailed',
+  'This text encoding is not available on this device.': 'android.message.encodingUnsupported',
+  'Could not read or save this file with the selected encoding.': 'android.message.encodingFailed',
   'Could not create a Markdown file on this device.': 'android.message.createFailed',
   'Could not open this Markdown file.': 'android.message.openFailed',
   'Insert images from the Android app build.': 'android.image.fromAppBuild',

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -19,9 +19,16 @@ interface NativeLogInfo {
   currentFile?: string
 }
 
+interface NativeLogExportResult {
+  displayName?: string
+  bytes?: number
+  fileCount?: number
+}
+
 interface NativeLoggerPlugin {
   write(entry: NativeLogEntry): Promise<void>
   getInfo(): Promise<NativeLogInfo>
+  exportLogs(options: { webLogs: string }): Promise<NativeLogExportResult>
 }
 
 interface CapacitorWindow {
@@ -257,4 +264,15 @@ export async function getNativeLogInfo() {
     nativeLoggingUnavailable = true
     return null
   }
+}
+
+export async function exportNativeLogs() {
+  if (!isNativeLoggerAvailable()) {
+    return null
+  }
+
+  const webLogs = readStoredEntries()
+    .map(entry => JSON.stringify(entry))
+    .join('\n')
+  return await NativeLogger.exportLogs({ webLogs })
 }

--- a/tests/e2e/mobile-home-navigation.spec.ts
+++ b/tests/e2e/mobile-home-navigation.spec.ts
@@ -228,7 +228,8 @@ test('switches between document home and the settings about screen', async ({ pa
     'Diagnostics',
     'Maintenance',
   ])
-  await expect(page.getByTestId('settings-advanced-diagnostics')).toContainText('Ready')
+  await expect(page.getByTestId('settings-advanced-diagnostics')).toContainText('web')
+  await expect(page.getByTestId('settings-advanced-webview')).toContainText('Mozilla')
   await expect(page.getByTestId('settings-advanced-encoding')).toContainText('UTF-8')
   await expect(page.getByTestId('settings-advanced-auto-detect-encoding')).toHaveAttribute(
     'aria-checked',


### PR DESCRIPTION
## Summary
- Wire Advanced > Files settings into Android document open/read/write/create/share workflows.
- Add real line-ending and trailing-newline save handling across autosave, Save as copy, local draft export, and Markdown sharing.
- Add basic Android encoding plumbing: selected/default encoding, BOM detection/preservation, Android charset mapping, and clear errors for unsupported/failed encoding. Full non-BOM charset detection is intentionally left as a code TODO for a later pass.
- Wire Advanced > Diagnostics to native Android device/WebView info with browser/e2e fallback.
- Wire Advanced > Maintenance actions: export logs as a ZIP through Android sharing, clear local drafts, and reset settings.

## Android permissions and security
- No broad storage permission added; document files still use SAF grants.
- Log exports and shared Markdown are written under app cache and shared through FileProvider.
- FileProvider remains non-exported and uses temporary read URI grants with ClipData.
- No nested intent forwarding added; incoming document/share intents keep existing validation patterns.

## Verification
- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm android:sync
- pnpm test:e2e tests/e2e/mobile-home-navigation.spec.ts
- ./gradlew.bat assembleDebug