### PR TITLE
Ignore graphify output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ todolist.md
 AGENTS.md
 PRODUCT.md
 refs/
+graphify-out/
 
 # Environment
 .env


### PR DESCRIPTION
## Summary
- Add graphify-out/ to .gitignore so local graphify analysis output does not appear as an untracked product file.

## Validation
- git diff --check