### PR TITLE
Test: add settings wiring governance

### DIFF
--- a/src/features/editor/editorToolbarSettings.ts
+++ b/src/features/editor/editorToolbarSettings.ts
@@ -11,6 +11,13 @@ import type { SettingsValue } from '../settings/settingsState'
 
 export type ToolbarDisplayMode = 'docked' | 'hidden'
 export type ToolbarQuickBarMode = 'default' | 'custom'
+export type EditorToolbarSettingKey =
+  | 'toolbarDisplayMode'
+  | 'toolbarDefaultPanel'
+  | 'toolbarRememberPanel'
+  | 'toolbarCompact'
+  | 'toolbarQuickBarMode'
+  | 'toolbarCustomQuickCommands'
 export type ToolbarSettingsReader = <T extends SettingsValue>(key: string, defaultValue: T) => T
 
 export interface EditorToolbarSettings {
@@ -26,10 +33,19 @@ export interface EditorToolbarSettings {
 export const TOOLBAR_FIXED_QUICK_COMMAND_ID = MOBILE_COMMANDS.EDIT_UNDO
 export const TOOLBAR_CUSTOM_COMMANDS_STORAGE_KEY = 'toolbarCustomQuickCommands'
 
-const TOOLBAR_DISPLAY_MODE_STORAGE_KEY = 'toolbarDisplayMode'
-const TOOLBAR_DEFAULT_PANEL_STORAGE_KEY = 'toolbarDefaultPanel'
-const TOOLBAR_REMEMBER_PANEL_STORAGE_KEY = 'toolbarRememberPanel'
-const TOOLBAR_QUICK_BAR_MODE_STORAGE_KEY = 'toolbarQuickBarMode'
+export const TOOLBAR_DISPLAY_MODE_STORAGE_KEY = 'toolbarDisplayMode'
+export const TOOLBAR_DEFAULT_PANEL_STORAGE_KEY = 'toolbarDefaultPanel'
+export const TOOLBAR_REMEMBER_PANEL_STORAGE_KEY = 'toolbarRememberPanel'
+export const TOOLBAR_QUICK_BAR_MODE_STORAGE_KEY = 'toolbarQuickBarMode'
+
+export const EDITOR_TOOLBAR_SETTING_KEYS = [
+  TOOLBAR_DISPLAY_MODE_STORAGE_KEY,
+  TOOLBAR_DEFAULT_PANEL_STORAGE_KEY,
+  TOOLBAR_REMEMBER_PANEL_STORAGE_KEY,
+  'toolbarCompact',
+  TOOLBAR_QUICK_BAR_MODE_STORAGE_KEY,
+  TOOLBAR_CUSTOM_COMMANDS_STORAGE_KEY,
+] as const satisfies readonly EditorToolbarSettingKey[]
 
 const TOOLBAR_DISPLAY_MODES = new Set<ToolbarDisplayMode>(['docked', 'hidden'])
 const TOOLBAR_QUICK_BAR_MODES = new Set<ToolbarQuickBarMode>(['default', 'custom'])

--- a/src/features/settings/advancedSettings.ts
+++ b/src/features/settings/advancedSettings.ts
@@ -74,6 +74,12 @@ export const ADVANCED_SETTING_KEYS = [
   'trimTrailingNewline',
 ] as const satisfies readonly AdvancedSettingKey[]
 
+export const ADVANCED_MAINTENANCE_ACTION_IDS = [
+  'exportLogs',
+  'clearDrafts',
+  'resetSettings',
+] as const satisfies readonly AdvancedMaintenanceActionId[]
+
 export const DEFAULT_ADVANCED_SETTINGS = {
   defaultEncoding: 'utf8',
   autoGuessEncoding: true,

--- a/src/features/settings/advancedSettings.ts
+++ b/src/features/settings/advancedSettings.ts
@@ -80,6 +80,10 @@ export const ADVANCED_MAINTENANCE_ACTION_IDS = [
   'resetSettings',
 ] as const satisfies readonly AdvancedMaintenanceActionId[]
 
+export function isAdvancedMaintenanceActionId(value: string): value is AdvancedMaintenanceActionId {
+  return ADVANCED_MAINTENANCE_ACTION_IDS.includes(value as AdvancedMaintenanceActionId)
+}
+
 export const DEFAULT_ADVANCED_SETTINGS = {
   defaultEncoding: 'utf8',
   autoGuessEncoding: true,

--- a/src/features/settings/appearanceSettings.ts
+++ b/src/features/settings/appearanceSettings.ts
@@ -7,8 +7,25 @@ export type AppearanceTextSettingKey =
   | 'editorFontFamily'
   | 'textDirection'
 
+export type AppearanceThemeSettingKey =
+  | 'followSystemTheme'
+  | 'appTheme'
+  | 'lightModeTheme'
+  | 'darkModeTheme'
+  | 'theme'
+
+export type AppearanceSettingKey = AppearanceTextSettingKey | AppearanceThemeSettingKey
+
 export type EditorFontFamily = 'open-sans' | 'system' | 'serif' | 'monospace'
 export type TextDirection = 'ltr' | 'rtl'
+
+export interface AppearanceThemeSettings {
+  followSystemTheme: boolean
+  appTheme: 'system' | 'light' | 'dark'
+  lightModeTheme: string
+  darkModeTheme: string
+  theme: string
+}
 
 export interface AppearanceTextSettings {
   fontSize: number
@@ -25,6 +42,27 @@ export const APPEARANCE_TEXT_SETTING_KEYS = [
   'editorFontFamily',
   'textDirection',
 ] as const satisfies readonly AppearanceTextSettingKey[]
+
+export const APPEARANCE_THEME_SETTING_KEYS = [
+  'followSystemTheme',
+  'appTheme',
+  'lightModeTheme',
+  'darkModeTheme',
+  'theme',
+] as const satisfies readonly AppearanceThemeSettingKey[]
+
+export const APPEARANCE_SETTING_KEYS = [
+  ...APPEARANCE_THEME_SETTING_KEYS,
+  ...APPEARANCE_TEXT_SETTING_KEYS,
+] as const satisfies readonly AppearanceSettingKey[]
+
+export const DEFAULT_APPEARANCE_THEME_SETTINGS = {
+  followSystemTheme: true,
+  appTheme: 'system',
+  lightModeTheme: 'light',
+  darkModeTheme: 'dark',
+  theme: 'light',
+} as const satisfies AppearanceThemeSettings
 
 export const DEFAULT_APPEARANCE_TEXT_SETTINGS = {
   fontSize: 16,

--- a/src/features/settings/components/SettingsDetailPage.vue
+++ b/src/features/settings/components/SettingsDetailPage.vue
@@ -20,7 +20,10 @@ import {
 import { APP_LANGUAGE_OPTIONS, useI18n, type I18nKey } from '../../../lib/i18n'
 import { SETTINGS_PAGES, type SettingsPage } from '../settingsNavigation'
 import { useSettingsState } from '../settingsState'
-import type { AdvancedMaintenanceActionId } from '../advancedSettings'
+import {
+  isAdvancedMaintenanceActionId,
+  type AdvancedMaintenanceActionId,
+} from '../advancedSettings'
 import { getAdvancedDiagnostics } from '../advancedDiagnostics'
 
 const props = defineProps<{
@@ -138,10 +141,7 @@ function setStoredValue(rowId: string, value: boolean | number | string) {
 }
 
 function getMaintenanceActionId(rowId: string): MaintenanceActionId | null {
-  if (rowId === 'exportLogs' || rowId === 'clearDrafts' || rowId === 'resetSettings') {
-    return rowId
-  }
-  return null
+  return isAdvancedMaintenanceActionId(rowId) ? rowId : null
 }
 
 function getMaintenanceActionCopy(rowId: string) {

--- a/src/features/settings/settingsContent.test.ts
+++ b/src/features/settings/settingsContent.test.ts
@@ -6,6 +6,7 @@ import {
 } from './advancedSettings'
 import {
   APPEARANCE_SETTING_KEYS,
+  DEFAULT_APPEARANCE_THEME_SETTINGS,
   DEFAULT_APPEARANCE_TEXT_SETTINGS,
 } from './appearanceSettings'
 import {
@@ -50,6 +51,11 @@ const EXPECTED_UNFINISHED_ROW_IDS = new Set([
   'customWords',
   'addWord',
   'removeWord',
+])
+
+const EXPECTED_DERIVED_ROW_IDS = new Set([
+  'deviceInfo',
+  'webviewInfo',
 ])
 
 const OWNED_STORED_SETTING_KEYS = new Set<string>([
@@ -119,6 +125,16 @@ const RUNTIME_SETTING_DEFAULTS = new Map<string, SettingsValue>([
   ['autoGuessEncoding', DEFAULT_ADVANCED_SETTINGS.autoGuessEncoding],
   ['endOfLine', DEFAULT_ADVANCED_SETTINGS.endOfLine],
   ['trimTrailingNewline', String(DEFAULT_ADVANCED_SETTINGS.trimTrailingNewline)],
+])
+
+const STORED_ONLY_SETTING_DEFAULTS = new Map<string, SettingsValue>([
+  ['followSystemTheme', DEFAULT_APPEARANCE_THEME_SETTINGS.followSystemTheme],
+  ['appTheme', DEFAULT_APPEARANCE_THEME_SETTINGS.appTheme],
+  ['lightModeTheme', DEFAULT_APPEARANCE_THEME_SETTINGS.lightModeTheme],
+  ['darkModeTheme', DEFAULT_APPEARANCE_THEME_SETTINGS.darkModeTheme],
+  ['theme', DEFAULT_APPEARANCE_THEME_SETTINGS.theme],
+  ['sourceCodeModeEnabled', DEFAULT_EDITING_SETTINGS.sourceCodeModeEnabled],
+  ['preferHeadingStyle', DEFAULT_EDITING_SETTINGS.preferHeadingStyle],
 ])
 
 function getRows(): SettingsRowWithLocation[] {
@@ -197,6 +213,27 @@ describe('settings content governance', () => {
       .toEqual([...EXPECTED_STORED_ONLY_ROW_IDS].sort())
     expect(rows.filter(row => row.implementation === 'unfinished').map(row => row.id).sort())
       .toEqual([...EXPECTED_UNFINISHED_ROW_IDS].sort())
+  })
+
+  it('keeps stored-only descriptor defaults aligned with feature defaults', () => {
+    const storedOnlyRows = getStoredRows(getRows()).filter(
+      (row): row is SettingsDefaultValueRow =>
+        row.implementation === 'storedOnly' && hasDefaultValue(row),
+    )
+
+    expect(storedOnlyRows.map(row => row.id).filter(id => !STORED_ONLY_SETTING_DEFAULTS.has(id)))
+      .toEqual([])
+
+    for (const row of storedOnlyRows) {
+      expect(row.defaultValue, row.id).toBe(STORED_ONLY_SETTING_DEFAULTS.get(row.id))
+    }
+  })
+
+  it('keeps derived rows explicit and display-only', () => {
+    const derivedRows = getRows().filter(row => row.implementation === 'derived')
+
+    expect(derivedRows.map(row => row.id).sort()).toEqual([...EXPECTED_DERIVED_ROW_IDS].sort())
+    expect(derivedRows.map(row => row.kind)).toEqual(['status', 'status'])
   })
 
   it('keeps choice defaults valid and option ids unique', () => {

--- a/src/features/settings/settingsContent.test.ts
+++ b/src/features/settings/settingsContent.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ADVANCED_MAINTENANCE_ACTION_IDS,
+  ADVANCED_SETTING_KEYS,
+  DEFAULT_ADVANCED_SETTINGS,
+} from './advancedSettings'
+import {
+  APPEARANCE_SETTING_KEYS,
+  DEFAULT_APPEARANCE_TEXT_SETTINGS,
+} from './appearanceSettings'
+import {
+  SETTINGS_DETAIL_SECTIONS,
+  type SettingsDetailRow,
+} from './settingsContent'
+import { EDITING_SETTING_KEYS, DEFAULT_EDITING_SETTINGS } from './editingSettings'
+import { DOCUMENT_SETTING_KEYS, DEFAULT_DOCUMENT_SETTINGS } from '../document-session/documentSettings'
+import {
+  IMAGE_SHARING_SETTING_KEYS,
+  DEFAULT_IMAGE_SHARING_SETTINGS,
+} from '../android-documents/imageSharingSettings'
+import {
+  DEFAULT_EDITOR_TOOLBAR_SETTINGS,
+  EDITOR_TOOLBAR_SETTING_KEYS,
+} from '../editor/editorToolbarSettings'
+import type { SettingsValue } from './settingsState'
+
+type SettingsRowWithLocation = SettingsDetailRow & {
+  page: string
+  sectionTitleKey: string
+}
+
+type SettingsValueRow = Extract<
+  SettingsDetailRow,
+  { kind: 'toggle' | 'choice' | 'slider' | 'text' | 'customToolbar' }
+>
+type SettingsDefaultValueRow = Exclude<SettingsValueRow, { kind: 'customToolbar' }>
+
+const EXPECTED_STORED_ONLY_ROW_IDS = new Set([
+  'followSystemTheme',
+  'appTheme',
+  'lightModeTheme',
+  'darkModeTheme',
+  'theme',
+  'sourceCodeModeEnabled',
+  'preferHeadingStyle',
+])
+
+const EXPECTED_UNFINISHED_ROW_IDS = new Set([
+  'shareLinkedImages',
+  'customWords',
+  'addWord',
+  'removeWord',
+])
+
+const OWNED_STORED_SETTING_KEYS = new Set<string>([
+  ...APPEARANCE_SETTING_KEYS,
+  ...EDITING_SETTING_KEYS,
+  ...EDITOR_TOOLBAR_SETTING_KEYS,
+  ...DOCUMENT_SETTING_KEYS,
+  ...IMAGE_SHARING_SETTING_KEYS,
+  ...ADVANCED_SETTING_KEYS,
+])
+
+const RUNTIME_SETTING_DEFAULTS = new Map<string, SettingsValue>([
+  ['fontSize', DEFAULT_APPEARANCE_TEXT_SETTINGS.fontSize],
+  ['lineHeight', DEFAULT_APPEARANCE_TEXT_SETTINGS.lineHeight],
+  ['editorLineWidth', DEFAULT_APPEARANCE_TEXT_SETTINGS.editorLineWidth],
+  ['editorFontFamily', DEFAULT_APPEARANCE_TEXT_SETTINGS.editorFontFamily],
+  ['textDirection', DEFAULT_APPEARANCE_TEXT_SETTINGS.textDirection],
+
+  ['autoPairBracket', DEFAULT_EDITING_SETTINGS.autoPairBracket],
+  ['autoPairMarkdownSyntax', DEFAULT_EDITING_SETTINGS.autoPairMarkdownSyntax],
+  ['autoPairQuote', DEFAULT_EDITING_SETTINGS.autoPairQuote],
+  ['quickInsert', DEFAULT_EDITING_SETTINGS.quickInsert],
+  ['linkPopup', DEFAULT_EDITING_SETTINGS.linkPopup],
+  ['autoCheck', DEFAULT_EDITING_SETTINGS.autoCheck],
+  ['preferLooseListItem', DEFAULT_EDITING_SETTINGS.preferLooseListItem],
+  ['bulletListMarker', DEFAULT_EDITING_SETTINGS.bulletListMarker],
+  ['orderListDelimiter', DEFAULT_EDITING_SETTINGS.orderListDelimiter],
+  ['listIndentation', String(DEFAULT_EDITING_SETTINGS.listIndentation)],
+  ['frontmatterType', DEFAULT_EDITING_SETTINGS.frontmatterType],
+  ['footnote', DEFAULT_EDITING_SETTINGS.footnote],
+  ['superSubScript', DEFAULT_EDITING_SETTINGS.superSubScript],
+  ['isHtmlEnabled', DEFAULT_EDITING_SETTINGS.isHtmlEnabled],
+  ['isGitlabCompatibilityEnabled', DEFAULT_EDITING_SETTINGS.isGitlabCompatibilityEnabled],
+  ['sequenceTheme', DEFAULT_EDITING_SETTINGS.sequenceTheme],
+  ['plantumlServer', DEFAULT_EDITING_SETTINGS.plantumlServer],
+  ['codeBlockLineNumbers', DEFAULT_EDITING_SETTINGS.codeBlockLineNumbers],
+  ['wrapCodeBlocks', DEFAULT_EDITING_SETTINGS.wrapCodeBlocks],
+  [
+    'trimUnnecessaryCodeBlockEmptyLines',
+    DEFAULT_EDITING_SETTINGS.trimUnnecessaryCodeBlockEmptyLines,
+  ],
+  ['codeFontSize', DEFAULT_EDITING_SETTINGS.codeFontSize],
+  ['codeFontFamily', DEFAULT_EDITING_SETTINGS.codeFontFamily],
+  ['tabSize', String(DEFAULT_EDITING_SETTINGS.tabSize)],
+  ['spellcheckerEnabled', DEFAULT_EDITING_SETTINGS.spellcheckerEnabled],
+  ['spellcheckerLanguage', DEFAULT_EDITING_SETTINGS.spellcheckerLanguage],
+  ['spellcheckerUnderline', DEFAULT_EDITING_SETTINGS.spellcheckerUnderline],
+
+  ['toolbarDisplayMode', DEFAULT_EDITOR_TOOLBAR_SETTINGS.displayMode],
+  ['toolbarDefaultPanel', DEFAULT_EDITOR_TOOLBAR_SETTINGS.defaultPanel],
+  ['toolbarRememberPanel', DEFAULT_EDITOR_TOOLBAR_SETTINGS.rememberPanel],
+  ['toolbarCompact', DEFAULT_EDITOR_TOOLBAR_SETTINGS.compact],
+  ['toolbarQuickBarMode', DEFAULT_EDITOR_TOOLBAR_SETTINGS.quickBarMode],
+
+  ['localDrafts', DEFAULT_DOCUMENT_SETTINGS.localDrafts],
+  ['recoveryDrafts', DEFAULT_DOCUMENT_SETTINGS.recoveryDrafts],
+  ['autoSave', DEFAULT_DOCUMENT_SETTINGS.autoSave],
+  ['autoSaveDelay', DEFAULT_DOCUMENT_SETTINGS.autoSaveDelaySeconds],
+  ['startUpAction', DEFAULT_DOCUMENT_SETTINGS.startUpAction],
+  ['fileSortBy', DEFAULT_DOCUMENT_SETTINGS.fileSortBy],
+  ['fileSortOrder', DEFAULT_DOCUMENT_SETTINGS.fileSortOrder],
+
+  ['imageCopyImages', DEFAULT_IMAGE_SHARING_SETTINGS.imageCopyImages],
+  ['shareImages', DEFAULT_IMAGE_SHARING_SETTINGS.shareImages],
+
+  ['defaultEncoding', DEFAULT_ADVANCED_SETTINGS.defaultEncoding],
+  ['autoGuessEncoding', DEFAULT_ADVANCED_SETTINGS.autoGuessEncoding],
+  ['endOfLine', DEFAULT_ADVANCED_SETTINGS.endOfLine],
+  ['trimTrailingNewline', String(DEFAULT_ADVANCED_SETTINGS.trimTrailingNewline)],
+])
+
+function getRows(): SettingsRowWithLocation[] {
+  return Object.entries(SETTINGS_DETAIL_SECTIONS).flatMap(([page, sections]) =>
+    (sections ?? []).flatMap(section =>
+      section.rows.map(row => ({
+        ...row,
+        page,
+        sectionTitleKey: section.titleKey,
+      })),
+    ),
+  )
+}
+
+function getStoredRows(rows: SettingsDetailRow[]): SettingsValueRow[] {
+  return rows.filter((row): row is SettingsValueRow =>
+    row.kind === 'toggle' ||
+    row.kind === 'choice' ||
+    row.kind === 'slider' ||
+    row.kind === 'text' ||
+    row.kind === 'customToolbar',
+  )
+}
+
+function hasDefaultValue(row: SettingsValueRow): row is SettingsDefaultValueRow {
+  return row.kind !== 'customToolbar'
+}
+
+function duplicates(values: readonly string[]) {
+  const seen = new Set<string>()
+  const repeated = new Set<string>()
+
+  for (const value of values) {
+    if (seen.has(value)) {
+      repeated.add(value)
+    }
+    seen.add(value)
+  }
+
+  return [...repeated].sort()
+}
+
+describe('settings content governance', () => {
+  it('keeps row ids and test ids globally unique across rendered settings pages', () => {
+    const rows = getRows()
+
+    expect(duplicates(rows.map(row => row.id))).toEqual([])
+    expect(duplicates(rows.map(row => row.testId))).toEqual([])
+  })
+
+  it('keeps every setting-backed row owned by a feature settings module', () => {
+    const storedRows = getStoredRows(getRows())
+
+    expect(storedRows.map(row => row.id).filter(id => !OWNED_STORED_SETTING_KEYS.has(id)))
+      .toEqual([])
+  })
+
+  it('keeps runtime descriptor defaults aligned with feature defaults', () => {
+    const runtimeRows = getStoredRows(getRows()).filter(
+      (row): row is SettingsDefaultValueRow =>
+        row.implementation === 'runtime' && hasDefaultValue(row),
+    )
+
+    expect(runtimeRows.map(row => row.id).filter(id => !RUNTIME_SETTING_DEFAULTS.has(id)))
+      .toEqual([])
+
+    for (const row of runtimeRows) {
+      expect(row.defaultValue, row.id).toBe(RUNTIME_SETTING_DEFAULTS.get(row.id))
+    }
+  })
+
+  it('keeps stored-only and unfinished rows explicit', () => {
+    const rows = getRows()
+
+    expect(rows.filter(row => row.implementation === 'storedOnly').map(row => row.id).sort())
+      .toEqual([...EXPECTED_STORED_ONLY_ROW_IDS].sort())
+    expect(rows.filter(row => row.implementation === 'unfinished').map(row => row.id).sort())
+      .toEqual([...EXPECTED_UNFINISHED_ROW_IDS].sort())
+  })
+
+  it('keeps choice defaults valid and option ids unique', () => {
+    const choiceRows = getRows().filter(row => row.kind === 'choice')
+
+    for (const row of choiceRows) {
+      const optionIds = row.options.map(option => option.id)
+
+      expect(optionIds, row.id).toContain(row.defaultValue)
+      expect(duplicates(optionIds), row.id).toEqual([])
+    }
+  })
+
+  it('keeps slider defaults inside their declared range and step', () => {
+    const sliderRows = getRows().filter(row => row.kind === 'slider')
+
+    for (const row of sliderRows) {
+      const offset = (row.defaultValue - row.min) / row.step
+
+      expect(row.defaultValue, row.id).toBeGreaterThanOrEqual(row.min)
+      expect(row.defaultValue, row.id).toBeLessThanOrEqual(row.max)
+      expect(Math.abs(offset - Math.round(offset)), row.id).toBeLessThan(1e-8)
+    }
+  })
+
+  it('keeps runtime action rows mapped to concrete handlers', () => {
+    const runtimeActionIds = getRows()
+      .filter(row => row.kind === 'action' && row.implementation === 'runtime')
+      .map(row => row.id)
+      .sort()
+
+    expect(runtimeActionIds).toEqual([...ADVANCED_MAINTENANCE_ACTION_IDS].sort())
+  })
+})

--- a/src/features/settings/settingsContent.ts
+++ b/src/features/settings/settingsContent.ts
@@ -13,7 +13,7 @@ interface SettingsBaseRow {
   testId: string
 }
 
-export type SettingsRowImplementation = 'runtime' | 'storedOnly' | 'unfinished'
+export type SettingsRowImplementation = 'runtime' | 'storedOnly' | 'derived' | 'unfinished'
 
 export interface SettingsToggleRow extends SettingsBaseRow {
   kind: 'toggle'
@@ -974,7 +974,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'status',
           id: 'deviceInfo',
-          implementation: 'runtime',
+          implementation: 'derived',
           labelKey: 'settings.advanced.diagnostics',
           valueKey: 'settings.value.ready',
           testId: 'settings-advanced-diagnostics',
@@ -982,7 +982,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'status',
           id: 'webviewInfo',
-          implementation: 'runtime',
+          implementation: 'derived',
           labelKey: 'settings.advanced.webview',
           valueKey: 'settings.value.ready',
           testId: 'settings-advanced-webview',

--- a/src/features/settings/settingsContent.ts
+++ b/src/features/settings/settingsContent.ts
@@ -8,9 +8,12 @@ interface SettingsOption {
 
 interface SettingsBaseRow {
   id: string
+  implementation: SettingsRowImplementation
   labelKey: I18nKey
   testId: string
 }
+
+export type SettingsRowImplementation = 'runtime' | 'storedOnly' | 'unfinished'
 
 export interface SettingsToggleRow extends SettingsBaseRow {
   kind: 'toggle'
@@ -296,6 +299,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'followSystemTheme',
+          implementation: 'storedOnly',
           labelKey: 'settings.appearance.followSystemTheme',
           defaultValue: true,
           testId: 'settings-appearance-system-theme',
@@ -303,6 +307,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'appTheme',
+          implementation: 'storedOnly',
           labelKey: 'settings.appearance.appTheme',
           defaultValue: 'system',
           options: appThemeOptions,
@@ -311,6 +316,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'lightModeTheme',
+          implementation: 'storedOnly',
           labelKey: 'settings.appearance.lightTheme',
           defaultValue: 'light',
           display: 'select',
@@ -320,6 +326,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'darkModeTheme',
+          implementation: 'storedOnly',
           labelKey: 'settings.appearance.darkTheme',
           defaultValue: 'dark',
           display: 'select',
@@ -329,6 +336,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'theme',
+          implementation: 'storedOnly',
           labelKey: 'settings.appearance.editorTheme',
           defaultValue: 'light',
           display: 'select',
@@ -343,6 +351,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'slider',
           id: 'fontSize',
+          implementation: 'runtime',
           labelKey: 'settings.appearance.fontSize',
           defaultValue: 16,
           min: 12,
@@ -354,6 +363,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'slider',
           id: 'lineHeight',
+          implementation: 'runtime',
           labelKey: 'settings.appearance.lineHeight',
           defaultValue: 1.6,
           min: 1.2,
@@ -364,6 +374,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'text',
           id: 'editorLineWidth',
+          implementation: 'runtime',
           labelKey: 'settings.appearance.lineWidth',
           defaultValue: '',
           placeholderKey: 'settings.placeholder.lineWidth',
@@ -372,6 +383,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'editorFontFamily',
+          implementation: 'runtime',
           labelKey: 'settings.appearance.font',
           defaultValue: 'open-sans',
           display: 'select',
@@ -381,6 +393,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'textDirection',
+          implementation: 'runtime',
           labelKey: 'settings.appearance.direction',
           defaultValue: 'ltr',
           options: textDirectionOptions,
@@ -396,6 +409,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'autoPairBracket',
+          implementation: 'runtime',
           labelKey: 'settings.editing.autoPairBrackets',
           defaultValue: true,
           testId: 'settings-editing-brackets',
@@ -403,6 +417,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'autoPairMarkdownSyntax',
+          implementation: 'runtime',
           labelKey: 'settings.editing.autoPairMarkdown',
           defaultValue: true,
           testId: 'settings-editing-markdown-syntax',
@@ -410,6 +425,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'autoPairQuote',
+          implementation: 'runtime',
           labelKey: 'settings.editing.autoPairQuotes',
           defaultValue: true,
           testId: 'settings-editing-quotes',
@@ -422,6 +438,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'quickInsert',
+          implementation: 'runtime',
           labelKey: 'settings.editing.quickInsert',
           defaultValue: true,
           testId: 'settings-editing-quick-insert',
@@ -429,6 +446,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'linkPopup',
+          implementation: 'runtime',
           labelKey: 'settings.editing.linkPopup',
           defaultValue: true,
           testId: 'settings-editing-link-popup',
@@ -436,6 +454,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'autoCheck',
+          implementation: 'runtime',
           labelKey: 'settings.editing.taskSync',
           defaultValue: false,
           testId: 'settings-editing-task-sync',
@@ -448,6 +467,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'sourceCodeModeEnabled',
+          implementation: 'storedOnly',
           labelKey: 'settings.editing.sourceMode',
           defaultValue: false,
           testId: 'settings-editing-source-mode',
@@ -460,6 +480,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'toolbarDisplayMode',
+          implementation: 'runtime',
           labelKey: 'settings.editing.toolbarDisplayMode',
           defaultValue: 'docked',
           options: toolbarDisplayOptions,
@@ -468,6 +489,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'toolbarDefaultPanel',
+          implementation: 'runtime',
           labelKey: 'settings.editing.defaultToolbarPanel',
           defaultValue: 'format',
           options: toolbarPanelOptions,
@@ -476,6 +498,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'toolbarRememberPanel',
+          implementation: 'runtime',
           labelKey: 'settings.editing.rememberToolbarPanel',
           defaultValue: true,
           testId: 'settings-editing-toolbar-remember',
@@ -483,6 +506,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'toolbarCompact',
+          implementation: 'runtime',
           labelKey: 'settings.editing.compactToolbar',
           defaultValue: false,
           testId: 'settings-editing-toolbar-compact',
@@ -495,6 +519,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'toolbarQuickBarMode',
+          implementation: 'runtime',
           labelKey: 'settings.editing.quickBarContent',
           defaultValue: 'default',
           options: quickBarContentOptions,
@@ -503,6 +528,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'customToolbar',
           id: 'toolbarCustomQuickCommands',
+          implementation: 'runtime',
           labelKey: 'settings.toolbar.custom.title',
           testId: 'settings-editing-quickbar-custom',
         },
@@ -516,6 +542,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'codeBlockLineNumbers',
+          implementation: 'runtime',
           labelKey: 'settings.code.lineNumbers',
           defaultValue: false,
           testId: 'settings-code-line-numbers',
@@ -523,6 +550,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'wrapCodeBlocks',
+          implementation: 'runtime',
           labelKey: 'settings.code.wrapLines',
           defaultValue: true,
           testId: 'settings-code-wrap-lines',
@@ -530,6 +558,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'trimUnnecessaryCodeBlockEmptyLines',
+          implementation: 'runtime',
           labelKey: 'settings.code.trimEmptyLines',
           defaultValue: true,
           testId: 'settings-code-trim-empty-lines',
@@ -542,6 +571,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'slider',
           id: 'codeFontSize',
+          implementation: 'runtime',
           labelKey: 'settings.code.fontSize',
           defaultValue: 14,
           min: 12,
@@ -553,6 +583,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'codeFontFamily',
+          implementation: 'runtime',
           labelKey: 'settings.code.font',
           defaultValue: 'dejavu-sans-mono',
           display: 'select',
@@ -562,6 +593,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'tabSize',
+          implementation: 'runtime',
           labelKey: 'settings.code.tabWidth',
           defaultValue: '4',
           options: tabWidthOptions,
@@ -577,6 +609,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'preferLooseListItem',
+          implementation: 'runtime',
           labelKey: 'settings.markdown.looseLists',
           defaultValue: true,
           testId: 'settings-markdown-loose-lists',
@@ -584,6 +617,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'bulletListMarker',
+          implementation: 'runtime',
           labelKey: 'settings.markdown.bulletMarker',
           defaultValue: '-',
           options: bulletMarkerOptions,
@@ -592,6 +626,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'orderListDelimiter',
+          implementation: 'runtime',
           labelKey: 'settings.markdown.orderedDelimiter',
           defaultValue: '.',
           options: orderedDelimiterOptions,
@@ -600,6 +635,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'listIndentation',
+          implementation: 'runtime',
           labelKey: 'settings.markdown.listIndentation',
           defaultValue: '1',
           display: 'select',
@@ -614,6 +650,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'preferHeadingStyle',
+          implementation: 'storedOnly',
           labelKey: 'settings.markdown.headingStyle',
           defaultValue: 'atx',
           options: headingStyleOptions,
@@ -627,6 +664,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'frontmatterType',
+          implementation: 'runtime',
           labelKey: 'settings.markdown.frontMatter',
           defaultValue: '-',
           display: 'select',
@@ -636,6 +674,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'footnote',
+          implementation: 'runtime',
           labelKey: 'settings.markdown.footnotes',
           defaultValue: false,
           testId: 'settings-markdown-footnotes',
@@ -643,6 +682,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'superSubScript',
+          implementation: 'runtime',
           labelKey: 'settings.markdown.superSub',
           defaultValue: false,
           testId: 'settings-markdown-super-sub',
@@ -655,6 +695,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'isHtmlEnabled',
+          implementation: 'runtime',
           labelKey: 'settings.markdown.htmlRendering',
           defaultValue: true,
           testId: 'settings-markdown-html-rendering',
@@ -662,6 +703,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'isGitlabCompatibilityEnabled',
+          implementation: 'runtime',
           labelKey: 'settings.markdown.gitlab',
           defaultValue: false,
           testId: 'settings-markdown-gitlab',
@@ -674,6 +716,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'sequenceTheme',
+          implementation: 'runtime',
           labelKey: 'settings.markdown.sequenceTheme',
           defaultValue: 'hand',
           options: sequenceThemeOptions,
@@ -682,6 +725,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'text',
           id: 'plantumlServer',
+          implementation: 'runtime',
           labelKey: 'settings.markdown.plantumlServer',
           defaultValue: 'https://www.plantuml.com/plantuml',
           placeholderKey: 'settings.placeholder.url',
@@ -697,6 +741,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'localDrafts',
+          implementation: 'runtime',
           labelKey: 'settings.documents.localDrafts',
           defaultValue: true,
           testId: 'settings-documents-local-drafts',
@@ -704,6 +749,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'recoveryDrafts',
+          implementation: 'runtime',
           labelKey: 'settings.documents.recovery',
           defaultValue: true,
           testId: 'settings-documents-recovery',
@@ -716,6 +762,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'autoSave',
+          implementation: 'runtime',
           labelKey: 'settings.documents.autosave',
           defaultValue: true,
           testId: 'settings-documents-autosave',
@@ -723,6 +770,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'slider',
           id: 'autoSaveDelay',
+          implementation: 'runtime',
           labelKey: 'settings.documents.saveDelay',
           defaultValue: 1,
           min: 1,
@@ -739,6 +787,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'startUpAction',
+          implementation: 'runtime',
           labelKey: 'settings.documents.startupAction',
           defaultValue: 'home',
           options: startupOptions,
@@ -752,6 +801,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'fileSortBy',
+          implementation: 'runtime',
           labelKey: 'settings.documents.sortBy',
           defaultValue: 'modified',
           display: 'select',
@@ -761,6 +811,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'fileSortOrder',
+          implementation: 'runtime',
           labelKey: 'settings.documents.sortOrder',
           defaultValue: 'desc',
           options: sortOrderOptions,
@@ -776,6 +827,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'imageCopyImages',
+          implementation: 'runtime',
           labelKey: 'settings.images.copyImages',
           defaultValue: true,
           testId: 'settings-images-copy',
@@ -788,6 +840,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'shareImages',
+          implementation: 'runtime',
           labelKey: 'settings.images.shareImages',
           defaultValue: 'attach',
           options: imageShareOptions,
@@ -796,6 +849,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'shareLinkedImages',
+          implementation: 'unfinished',
           labelKey: 'settings.images.includeLinked',
           defaultValue: false,
           testId: 'settings-images-include-linked',
@@ -810,6 +864,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'spellcheckerEnabled',
+          implementation: 'runtime',
           labelKey: 'settings.spelling.enabled',
           defaultValue: false,
           testId: 'settings-spelling-enabled',
@@ -817,6 +872,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'spellcheckerLanguage',
+          implementation: 'runtime',
           labelKey: 'settings.spelling.language',
           defaultValue: 'en-US',
           display: 'select',
@@ -831,6 +887,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'spellcheckerUnderline',
+          implementation: 'runtime',
           labelKey: 'settings.spelling.underlines',
           defaultValue: true,
           testId: 'settings-spelling-underlines',
@@ -844,6 +901,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'action',
           id: 'customWords',
+          implementation: 'unfinished',
           labelKey: 'settings.spelling.dictionary',
           valueKey: 'settings.value.open',
           testId: 'settings-spelling-dictionary',
@@ -851,6 +909,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'action',
           id: 'addWord',
+          implementation: 'unfinished',
           labelKey: 'settings.spelling.addWord',
           valueKey: 'settings.value.manual',
           testId: 'settings-spelling-add-word',
@@ -858,6 +917,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'action',
           id: 'removeWord',
+          implementation: 'unfinished',
           labelKey: 'settings.spelling.removeWord',
           valueKey: 'settings.value.manual',
           testId: 'settings-spelling-remove-word',
@@ -872,6 +932,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'defaultEncoding',
+          implementation: 'runtime',
           labelKey: 'settings.advanced.encoding',
           defaultValue: 'utf8',
           display: 'select',
@@ -881,6 +942,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'toggle',
           id: 'autoGuessEncoding',
+          implementation: 'runtime',
           labelKey: 'settings.advanced.autoDetectEncoding',
           defaultValue: true,
           testId: 'settings-advanced-auto-detect-encoding',
@@ -888,6 +950,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'endOfLine',
+          implementation: 'runtime',
           labelKey: 'settings.advanced.lineEndings',
           defaultValue: 'default',
           options: lineEndingOptions,
@@ -896,6 +959,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'choice',
           id: 'trimTrailingNewline',
+          implementation: 'runtime',
           labelKey: 'settings.advanced.trailingNewline',
           defaultValue: '2',
           display: 'select',
@@ -910,6 +974,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'status',
           id: 'deviceInfo',
+          implementation: 'runtime',
           labelKey: 'settings.advanced.diagnostics',
           valueKey: 'settings.value.ready',
           testId: 'settings-advanced-diagnostics',
@@ -917,6 +982,7 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'status',
           id: 'webviewInfo',
+          implementation: 'runtime',
           labelKey: 'settings.advanced.webview',
           valueKey: 'settings.value.ready',
           testId: 'settings-advanced-webview',
@@ -929,18 +995,21 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
         {
           kind: 'action',
           id: 'exportLogs',
+          implementation: 'runtime',
           labelKey: 'settings.advanced.exportLogs',
           testId: 'settings-advanced-export-logs',
         },
         {
           kind: 'action',
           id: 'clearDrafts',
+          implementation: 'runtime',
           labelKey: 'settings.advanced.clearDrafts',
           testId: 'settings-advanced-clear-drafts',
         },
         {
           kind: 'action',
           id: 'resetSettings',
+          implementation: 'runtime',
           labelKey: 'settings.advanced.reset',
           testId: 'settings-advanced-reset',
         },


### PR DESCRIPTION
## Summary

This PR adds a lightweight governance layer for Settings without introducing a runtime settings framework.

The goal is to make Settings honest and auditable:

- Every rendered settings row now declares an implementation status:
  - `runtime`: the row has concrete behavior wired today.
  - `storedOnly`: the row can store a preference, but it intentionally has no runtime effect yet.
  - `unfinished`: the row represents a deliberately visible unfinished capability.
- Feature modules export the small ownership lists needed by tests:
  - Appearance setting keys now include theme preference keys, while theme runtime remains deferred.
  - Toolbar setting keys are exported from the toolbar feature module.
  - Advanced maintenance action ids are exported from the advanced settings module.
- A new governance test audits the Settings descriptor instead of creating a central runtime service.

The new test checks:

- Row ids and test ids stay globally unique across rendered settings pages.
- Every setting-backed row is owned by a feature settings module.
- Runtime row defaults match the feature runtime defaults.
- Stored-only rows remain explicit: theme rows, source mode, and heading style.
- Unfinished rows remain explicit: linked image sharing and dictionary actions.
- Choice defaults are present in their option lists.
- Choice option ids are unique.
- Slider defaults stay within range and align with step.
- Runtime action rows map to concrete maintenance handlers.

This intentionally does not add:

- A global SettingsManager.
- A versioned migration layer.
- A hidden settings service behind `App.vue`.
- Shared normalizer centralization in `lib/`.
- Theme runtime, linked image sharing, spelling dictionary backend, or encoding detection behavior.

## Engineering Intent

This is an explicit governance/audit layer. It applies high cohesion and low coupling by keeping runtime ownership inside each feature module while letting tests verify the descriptor-to-runtime contract.

It also applies open/closed only where it helps: adding a future setting should extend the descriptor and the owning feature key/default list, while the governance tests catch missing wiring or accidental unfinished rows. The production runtime stays simple.

## Validation

- `pnpm exec vitest run src/features/settings/settingsContent.test.ts`
- `pnpm test` - 33 files, 165 tests passed
- `pnpm lint`
- `pnpm build` - passed after fixing a test type narrowing issue; Vite still reports the existing large chunk warning
- `git diff --check`