### PR TITLE
Fix Unicode inline emphasis visibility

### DIFF
--- a/src/features/editor/muyaInlineUnicodeStyleContract.test.ts
+++ b/src/features/editor/muyaInlineUnicodeStyleContract.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function inlineSyntaxCss() {
+  return readFileSync(resolve('third_party/muya/src/assets/styles/inlineSyntax.css'), 'utf8')
+}
+
+describe('Muya inline unicode emphasis style contract', () => {
+  it('allows synthesized strong and emphasis faces for scripts without native variants', () => {
+    const css = inlineSyntaxCss()
+
+    expect(css).toContain('strong.mu-inline-rule')
+    expect(css).toContain('font-weight: 700')
+    expect(css).toContain('em.mu-inline-rule')
+    expect(css).toContain('font-style: italic')
+    expect(css).toContain('font-style: oblique 12deg')
+    expect(css).toContain('font-synthesis: weight style')
+  })
+})

--- a/third_party/muya/src/assets/styles/inlineSyntax.css
+++ b/third_party/muya/src/assets/styles/inlineSyntax.css
@@ -47,13 +47,24 @@ span.mu-inline-rule.mu-link {
 }
 
 /* strong and emphasis — default to `inherit` (the surrounding editor color)
-   so the bundled light theme is unchanged; themes can recolor them. */
+   so the bundled light theme is unchanged; themes can recolor them.
+   The app shell disables font synthesis globally for UI chrome. Re-enable the
+   specific synthesized faces Markdown needs here so CJK/Arabic/system fonts
+   without native bold/italic variants still show visible emphasis. */
+strong.mu-inline-rule,
+em.mu-inline-rule {
+    font-synthesis: weight style;
+}
+
 strong.mu-inline-rule {
     color: var(--strong-color, inherit);
+    font-weight: 700;
 }
 
 em.mu-inline-rule {
     color: var(--em-color, inherit);
+    font-style: italic;
+    font-style: oblique 12deg;
 }
 
 /* inline code */


### PR DESCRIPTION
## Summary

Fixes Unicode inline emphasis visibility in the mobile editor.

The Markdown parser was already recognizing Chinese, Arabic, and Portuguese emphasis correctly. The visible failure came from styling: the app shell disables `font-synthesis` globally for UI chrome, and Android system fonts often do not provide distinct native bold/italic faces for CJK/Arabic text. As a result, rendered `<strong>` / `<em>` content could look visually unchanged even though the DOM was correct.

This PR scopes the fix to Muya inline Markdown content only:

- re-enables synthesized weight/style faces for `strong.mu-inline-rule` and `em.mu-inline-rule`
- gives `strong` an explicit `font-weight: 700`
- gives `em` an `italic` fallback plus the preferred `oblique 12deg` style for clearer mobile emphasis
- uses `font-synthesis: weight style` on both strong and em so nested bold+italic forms such as `***中文***`, `**_中文_**`, and `_**中文**_` keep both synthesis axes
- adds a focused CSS contract test so the Unicode emphasis styling does not regress silently

## Why

The reported symptom was that Chinese text like `**脾气急**` and `*脾气急*` looked the same as plain text, while English emphasis was visibly distinct.

Runtime WebView inspection confirmed this was not a Markdown parsing issue:

- `**脾气急**` rendered as `STRONG.mu-inline-rule`
- `*脾气急*` rendered as `EM.mu-inline-rule`
- Arabic and Portuguese samples also rendered into the expected inline elements

The missing piece was visual font synthesis. The global app theme intentionally sets `font-synthesis: none`, which is appropriate for UI chrome but too broad for Markdown content semantics on Android fonts.

## Implementation Notes

The fix stays inside Muya's inline syntax stylesheet rather than changing global app typography. That keeps the behavior high-cohesion and low-blast-radius: app UI typography remains unchanged, while Markdown strong/emphasis regain their expected visual distinction.

The final runtime nested-emphasis probe in the Android WebView showed both nested orders now preserve both axes:

```json
[
  {
    "tag": "EM",
    "parent": "STRONG",
    "fontWeight": "700",
    "fontStyle": "oblique 12deg",
    "fontSynthesis": "weight style"
  },
  {
    "tag": "STRONG",
    "parent": "EM",
    "fontWeight": "700",
    "fontStyle": "oblique 12deg",
    "fontSynthesis": "weight style"
  }
]
```

## Validation

Ran targeted and build validation:

```powershell
pnpm exec vitest run src/features/editor/muyaInlineUnicodeStyleContract.test.ts src/features/editor/muyaVendorSyncContract.test.ts
pnpm build
pnpm exec cap sync android
cd android
.\gradlew.bat assembleDebug
adb install -r android\app\build\outputs\apk\debug\app-debug.apk
```

Also verified in the installed Android debug APK through WebView DevTools / CDP:

- Chinese `strong` and `em` computed styles are visibly distinct
- Arabic and Portuguese samples also compute to the expected emphasis styles
- nested bold+italic content keeps `font-synthesis: weight style`

## Scope

This PR fixes live editor inline Markdown rendering. Export/HTML/PDF styling is intentionally not expanded in this PR unless a separate export-specific issue is found.