### PR TITLE
Polish selection toolbar icon actions

### DIFF
--- a/src/features/editor/components/MobileSelectionToolbar.vue
+++ b/src/features/editor/components/MobileSelectionToolbar.vue
@@ -34,7 +34,7 @@ const pressedCommandId = ref<SelectionToolbarCommandId | null>(null)
 
 // Used for the first placement pass before the toolbar has rendered; the
 // update loop re-measures the real element right after it becomes visible.
-const FALLBACK_TOOLBAR_SIZE = { width: 248, height: 52 }
+const FALLBACK_TOOLBAR_SIZE = { width: 194, height: 54 }
 let frameId: number | null = null
 // Last non-collapsed editor selection, kept so commands can restore it if the
 // tap that pressed a toolbar button still managed to collapse the selection.
@@ -261,6 +261,8 @@ watch(
       class="selection-toolbar-button"
       :class="{ 'is-pressed': pressedCommandId === command.commandId }"
       type="button"
+      :aria-label="t(command.labelKey)"
+      :title="t(command.labelKey)"
       :data-command-id="command.commandId"
       :data-testid="`selection-command-${command.commandId}`"
       @touchstart="pressedCommandId = command.commandId"
@@ -268,7 +270,47 @@ watch(
       @touchend.prevent="runCommandFromTouch(command.commandId, $event)"
       @click="runCommand(command.commandId)"
     >
-      {{ t(command.labelKey) }}
+      <svg
+        v-if="command.iconName === 'copy'"
+        class="selection-toolbar-icon"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <rect x="9" y="8" width="10" height="12" rx="2" />
+        <path d="M5 16V6a2 2 0 0 1 2-2h8" />
+      </svg>
+      <svg
+        v-else-if="command.iconName === 'cut'"
+        class="selection-toolbar-icon"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <circle cx="6" cy="7" r="2.3" />
+        <circle cx="6" cy="17" r="2.3" />
+        <path d="M8.1 8.1 19 19" />
+        <path d="M8.1 15.9 19 5" />
+      </svg>
+      <svg
+        v-else-if="command.iconName === 'paste'"
+        class="selection-toolbar-icon"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path d="M9 5h6" />
+        <path d="M9 4.8A2.8 2.8 0 0 1 11.8 2h.4A2.8 2.8 0 0 1 15 4.8V6H9Z" />
+        <path d="M8 5H6.8A2.8 2.8 0 0 0 4 7.8v10.4A2.8 2.8 0 0 0 6.8 21h10.4a2.8 2.8 0 0 0 2.8-2.8V7.8A2.8 2.8 0 0 0 17.2 5H16" />
+      </svg>
+      <svg
+        v-else
+        class="selection-toolbar-icon selection-toolbar-icon-select-all"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <rect x="4" y="4" width="16" height="16" rx="2.5" />
+        <path d="M8 9h8" />
+        <path d="M8 12h8" />
+        <path d="M8 15h5" />
+      </svg>
     </button>
   </div>
 </template>
@@ -278,8 +320,8 @@ watch(
   position: fixed;
   z-index: 24;
   display: flex;
-  align-items: stretch;
-  gap: 2px;
+  align-items: center;
+  gap: 3px;
   padding: 4px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -291,19 +333,34 @@ watch(
 }
 
 .selection-toolbar-button {
+  display: grid;
+  place-items: center;
+  width: 44px;
   min-height: 44px;
-  padding: 0 14px;
+  padding: 0;
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text);
-  font-size: 14px;
-  font-weight: 600;
-  white-space: nowrap;
+  touch-action: manipulation;
 }
 
 .selection-toolbar-button:active,
 .selection-toolbar-button.is-pressed {
   background: var(--accent-tint-11);
+}
+
+.selection-toolbar-icon {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.selection-toolbar-icon-select-all rect {
+  stroke-dasharray: 2.4 2.4;
 }
 </style>

--- a/src/features/editor/selectionToolbar.test.ts
+++ b/src/features/editor/selectionToolbar.test.ts
@@ -30,6 +30,12 @@ describe('selection toolbar commands', () => {
       'paste',
       'selectAll',
     ])
+    expect(SELECTION_TOOLBAR_COMMANDS.map(command => command.iconName)).toEqual([
+      'copy',
+      'cut',
+      'paste',
+      'selectAll',
+    ])
   })
 
   it('drops paste when clipboard read is unavailable', () => {

--- a/src/features/editor/selectionToolbar.ts
+++ b/src/features/editor/selectionToolbar.ts
@@ -1,17 +1,19 @@
 import type { I18nKey } from '../../lib/i18n'
 
 export type SelectionToolbarCommandId = 'copy' | 'cut' | 'paste' | 'selectAll'
+export type SelectionToolbarIconName = 'copy' | 'cut' | 'paste' | 'selectAll'
 
 export interface SelectionToolbarCommand {
   commandId: SelectionToolbarCommandId
   labelKey: I18nKey
+  iconName: SelectionToolbarIconName
 }
 
 export const SELECTION_TOOLBAR_COMMANDS: readonly SelectionToolbarCommand[] = [
-  { commandId: 'copy', labelKey: 'editor.selection.copy' },
-  { commandId: 'cut', labelKey: 'editor.selection.cut' },
-  { commandId: 'paste', labelKey: 'editor.selection.paste' },
-  { commandId: 'selectAll', labelKey: 'editor.selection.selectAll' },
+  { commandId: 'copy', labelKey: 'editor.selection.copy', iconName: 'copy' },
+  { commandId: 'cut', labelKey: 'editor.selection.cut', iconName: 'cut' },
+  { commandId: 'paste', labelKey: 'editor.selection.paste', iconName: 'paste' },
+  { commandId: 'selectAll', labelKey: 'editor.selection.selectAll', iconName: 'selectAll' },
 ]
 
 export function getSelectionToolbarCommands(canPaste: boolean) {


### PR DESCRIPTION
## Summary

Polishes the MarkText-owned mobile selection toolbar by replacing the visible text labels for core actions with compact icon buttons.

This keeps the existing command behavior unchanged while reducing the toolbar footprint before we add future Markdown-specific selection actions such as bold, italic, inline code, and link.

## Changes

- Renders Copy, Cut, Paste, and Select all as inline SVG icon buttons.
- Keeps each button at a 44px touch target for mobile ergonomics.
- Preserves existing command ids and `data-testid` values so current e2e flows continue to target the same commands.
- Preserves i18n-backed `aria-label` and `title` text for accessibility and discoverability.
- Adds command-level `iconName` metadata and a small unit contract for icon ordering.
- Narrows the initial fallback placement width from the old text-button size to the new compact icon-toolbar size.

## Product Rationale

The selection toolbar is now a product surface, not just a platform workaround. Text labels were useful while proving copy/cut/paste/select-all behavior, but they consume too much horizontal space, especially before adding Markdown actions.

Icon actions better match a mobile selection surface:

- less visual noise near selected text;
- less horizontal overflow near viewport edges;
- stable width across English and Chinese UI strings;
- more room for future formatting commands without making the toolbar feel crowded.

## Validation

Ran targeted checks:

```powershell
pnpm exec vitest run src/features/editor/selectionToolbar.test.ts
pnpm typecheck
pnpm exec eslint src/features/editor/components/MobileSelectionToolbar.vue src/features/editor/selectionToolbar.ts src/features/editor/selectionToolbar.test.ts --max-warnings 0
pnpm build
pnpm exec cap sync android
cd android
.\gradlew.bat assembleDebug
adb install -r android\app\build\outputs\apk\debug\app-debug.apk
```

Also installed the debug APK for visual inspection.

Note: full `pnpm lint` currently fails on reference code under `refs/spellcheck/...`, unrelated to this PR. Touched-file lint passes.

## Scope

This is a visual polish PR only. It does not add formatting commands and does not change clipboard, selection, Android bridge, or Muya command behavior.