### PR TITLE
Fix bottom toolbar formatting over Android selections

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -139,6 +139,7 @@ import {
   isNativeLoggerAvailable,
 } from './lib/logger'
 import {
+  isSelectionDependentMobileCommand,
   type MobileCommandId,
   type MobileEditorCommandTarget,
 } from './lib/mobileCommands'
@@ -543,9 +544,12 @@ function insertMarkdownAtPendingSelection(markdown: string) {
   return insertTextAtRestoredSelection(markdown, pendingInlineInsertRange)
 }
 
-function openLinkSheet() {
+function openLinkSheet(restoreRange: Range | null = null) {
   const hasEditor = Boolean(editor)
-  const capturedRange = editorReady.value && hasEditor ? captureEditorSelection() : null
+  const capturedRange =
+    editorReady.value && hasEditor
+      ? restoreRange?.cloneRange() ?? captureEditorSelection()
+      : null
   const nextLinkSheet = createLinkInsertSheetWorkflow({
     editorReady: editorReady.value,
     hasEditor,
@@ -586,7 +590,7 @@ function insertLinkFromSheet() {
   syncAfterToolbarCommand(result.beforeMarkdown)
 }
 
-async function insertImageFromAndroidPicker() {
+async function insertImageFromAndroidPicker(restoreRange: Range | null = null) {
   const startResult = createAndroidImageInsertStart({
     editorReady: editorReady.value,
     hasEditor: Boolean(editor),
@@ -609,7 +613,7 @@ async function insertImageFromAndroidPicker() {
   }
 
   const beforeMarkdown = editor.getMarkdown()
-  pendingInlineInsertRange = captureEditorSelection()
+  pendingInlineInsertRange = restoreRange?.cloneRange() ?? captureEditorSelection()
   const selectedText = normalizeToolbarSelectionText(pendingInlineInsertRange?.toString() ?? '')
   closeEditorMenu()
   closeEditorToolbar()
@@ -950,8 +954,16 @@ async function runSelectionToolbarCommand(
   }
 }
 
-function runEditorToolbarCommand(commandId: MobileCommandId) {
+function runEditorToolbarCommand(commandId: MobileCommandId, restoreRange: Range | null = null) {
   const activeEditor = editorReady.value ? editor : null
+  const commandRange =
+    activeEditor && isSelectionDependentMobileCommand(commandId)
+      ? restoreRange?.cloneRange() ?? captureEditorSelection()
+      : null
+  if (activeEditor && commandRange) {
+    restoreEditorSelectionRange(activeEditor, commandRange)
+  }
+
   const result = runEditorToolbarCommandWorkflow({
     commandId,
     editorReady: editorReady.value,
@@ -962,12 +974,12 @@ function runEditorToolbarCommand(commandId: MobileCommandId) {
   })
 
   if (result.kind === 'open-link-sheet') {
-    openLinkSheet()
+    openLinkSheet(commandRange)
     return
   }
 
   if (result.kind === 'insert-image') {
-    void insertImageFromAndroidPicker()
+    void insertImageFromAndroidPicker(commandRange)
     return
   }
 

--- a/src/features/editor/EditorScreen.vue
+++ b/src/features/editor/EditorScreen.vue
@@ -59,7 +59,7 @@ const emit = defineEmits<{
   share: []
   'save-to-device': []
   'save-copy': []
-  'run-toolbar-command': [commandId: MobileCommandId]
+  'run-toolbar-command': [commandId: MobileCommandId, restoreRange: Range | null]
   'run-selection-command': [commandId: SelectionToolbarCommandId, restoreRange: Range | null]
   'dismiss-selection': [caretRange: Range | null]
   'toggle-toolbar': []
@@ -179,12 +179,13 @@ onBeforeUnmount(() => {
       :expanded="toolbarExpanded"
       :active-panel="toolbarPanel"
       :editor-ready="editorReady"
+      :host="editorShell"
       :compact="toolbarCompact"
       :quick-commands="quickToolbarCommands"
       :word-count="wordCount"
       :character-count="characterCount"
       :line-count="lineCount"
-      @run-command="commandId => emit('run-toolbar-command', commandId)"
+      @run-command="(commandId, restoreRange) => emit('run-toolbar-command', commandId, restoreRange)"
       @toggle-expanded="emit('toggle-toolbar')"
       @set-panel="panel => emit('set-toolbar-panel', panel)"
     />

--- a/src/features/editor/components/MobileEditorToolbar.vue
+++ b/src/features/editor/components/MobileEditorToolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { MobileCommandId } from '../../../lib/mobileCommands'
 import {
   MOBILE_TOOLBAR_EDIT_COMMANDS,
@@ -10,11 +10,13 @@ import {
   type MobileToolbarCommandButton,
 } from '../../../lib/mobileToolbarConfig'
 import { useI18n, type I18nKey } from '../../../lib/i18n'
+import { captureNonCollapsedSelectionRange } from '../selectionToolbar'
 
 const props = defineProps<{
   expanded: boolean
   activePanel: MobileEditorToolbarPanel
   editorReady: boolean
+  host: HTMLElement | null
   wordCount: number
   characterCount: number
   lineCount: number
@@ -23,7 +25,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  runCommand: [commandId: MobileCommandId]
+  runCommand: [commandId: MobileCommandId, restoreRange: Range | null]
   toggleExpanded: []
   setPanel: [panel: MobileEditorToolbarPanel]
 }>()
@@ -32,6 +34,7 @@ const panels = MOBILE_TOOLBAR_PANELS
 const editCommands = MOBILE_TOOLBAR_EDIT_COMMANDS
 const groupMenuOpen = ref(false)
 const { t } = useI18n()
+let lastEditorSelectionRange: Range | null = null
 
 const activePanelDef = computed(() => getMobileToolbarPanel(props.activePanel))
 const activePanelCommands = computed(() => getMobileToolbarPanelCommands(props.activePanel))
@@ -53,12 +56,40 @@ watch(
   },
 )
 
+onMounted(() => {
+  document.addEventListener('selectionchange', rememberCurrentEditorSelection)
+  document.addEventListener('pointerdown', clearEditorSelectionRangeFromEditorPointer, true)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('selectionchange', rememberCurrentEditorSelection)
+  document.removeEventListener('pointerdown', clearEditorSelectionRangeFromEditorPointer, true)
+})
+
+watch(
+  () => props.host,
+  () => rememberCurrentEditorSelection(),
+)
+
+function rememberCurrentEditorSelection() {
+  const range = captureNonCollapsedSelectionRange(props.host)
+  if (range) {
+    lastEditorSelectionRange = range
+  }
+}
+
+function clearEditorSelectionRangeFromEditorPointer(event: PointerEvent) {
+  if (event.target instanceof Node && props.host?.contains(event.target)) {
+    lastEditorSelectionRange = null
+  }
+}
+
 function runCommand(commandId: MobileCommandId) {
   if (!props.editorReady) {
     return
   }
 
-  emit('runCommand', commandId)
+  emit('runCommand', commandId, lastEditorSelectionRange?.cloneRange() ?? null)
 }
 
 function toggleGroupMenu() {

--- a/src/features/editor/components/MobileSelectionToolbar.vue
+++ b/src/features/editor/components/MobileSelectionToolbar.vue
@@ -2,6 +2,7 @@
 import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import {
   caretRangeAtPoint,
+  captureNonCollapsedSelectionRange,
   computeSelectionToolbarPlacement,
   getDomSelectionSnapshot,
   getSelectionToolbarCommands,
@@ -79,9 +80,9 @@ function updateFromSelection() {
   top.value = placed.top
   placement.value = placed.placement
 
-  const selection = document.getSelection()
-  if (selection && selection.rangeCount > 0 && !selection.isCollapsed) {
-    lastEditorSelectionRange = selection.getRangeAt(0).cloneRange()
+  const range = captureNonCollapsedSelectionRange(props.host)
+  if (range) {
+    lastEditorSelectionRange = range
   }
 
   if (!visible.value) {

--- a/src/features/editor/selectionToolbar.ts
+++ b/src/features/editor/selectionToolbar.ts
@@ -160,6 +160,28 @@ export function getDomSelectionSnapshot(host: HTMLElement | null): SelectionSnap
           width: rect.width,
           height: rect.height,
         }
-      : null,
+    : null,
   }
+}
+
+export function captureNonCollapsedSelectionRange(host: HTMLElement | null): Range | null {
+  if (!host || typeof document === 'undefined') {
+    return null
+  }
+
+  const selection = document.getSelection()
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return null
+  }
+
+  const range = selection.getRangeAt(0)
+  if (!host.contains(range.startContainer) || !host.contains(range.endContainer)) {
+    return null
+  }
+
+  if (selection.toString().trim().length === 0) {
+    return null
+  }
+
+  return range.cloneRange()
 }

--- a/src/lib/mobileCommands.test.ts
+++ b/src/lib/mobileCommands.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  isSelectionDependentMobileCommand,
   MOBILE_COMMANDS,
   runMobileEditorCommand,
   type MobileEditorCommandTarget,
@@ -100,5 +101,14 @@ describe('mobileCommands', () => {
     const result = runMobileEditorCommand(editor, MOBILE_COMMANDS.PARAGRAPH_CODE_FENCE)
 
     expect(result.handled).toBe(false)
+  })
+
+  it('marks only selection-scoped editor commands as selection-dependent', () => {
+    expect(isSelectionDependentMobileCommand(MOBILE_COMMANDS.FORMAT_STRONG)).toBe(true)
+    expect(isSelectionDependentMobileCommand(MOBILE_COMMANDS.FORMAT_HYPERLINK)).toBe(true)
+    expect(isSelectionDependentMobileCommand(MOBILE_COMMANDS.PARAGRAPH_HEADING_1)).toBe(true)
+    expect(isSelectionDependentMobileCommand(MOBILE_COMMANDS.EDIT_UNDO)).toBe(false)
+    expect(isSelectionDependentMobileCommand(MOBILE_COMMANDS.EDIT_REDO)).toBe(false)
+    expect(isSelectionDependentMobileCommand(MOBILE_COMMANDS.FILE_OPEN)).toBe(false)
   })
 })

--- a/src/lib/mobileCommands.ts
+++ b/src/lib/mobileCommands.ts
@@ -135,3 +135,7 @@ export function runMobileEditorCommand(
 
   return { handled: false, commandId, reason: 'editor-unavailable' }
 }
+
+export function isSelectionDependentMobileCommand(commandId: MobileCommandId) {
+  return Boolean(FORMAT_ACTIONS[commandId] || PARAGRAPH_ACTIONS[commandId])
+}

--- a/tests/e2e/mobile-editor-toolbar.spec.ts
+++ b/tests/e2e/mobile-editor-toolbar.spec.ts
@@ -44,6 +44,50 @@ async function getDraftStorage(page: Page) {
   return page.evaluate(() => localStorage.getItem('marktext-for-android:drafts') ?? '')
 }
 
+async function selectTextInFirstParagraph(page: Page, text: string) {
+  await page.evaluate(selectedText => {
+    const paragraph = document.querySelector('[data-testid="editor-host"] .mu-editor p')
+    if (!paragraph?.textContent?.includes(selectedText)) {
+      throw new Error(`paragraph text not found: ${selectedText}`)
+    }
+
+    const walker = document.createTreeWalker(paragraph, NodeFilter.SHOW_TEXT)
+    const remainingStart = paragraph.textContent.indexOf(selectedText)
+    const remainingEnd = remainingStart + selectedText.length
+    let startNode: Text | null = null
+    let endNode: Text | null = null
+    let startOffset = 0
+    let endOffset = 0
+    let cursor = 0
+
+    while (walker.nextNode()) {
+      const node = walker.currentNode as Text
+      const nextCursor = cursor + node.length
+      if (!startNode && remainingStart >= cursor && remainingStart <= nextCursor) {
+        startNode = node
+        startOffset = remainingStart - cursor
+      }
+      if (!endNode && remainingEnd >= cursor && remainingEnd <= nextCursor) {
+        endNode = node
+        endOffset = remainingEnd - cursor
+      }
+      cursor = nextCursor
+    }
+
+    if (!startNode || !endNode) {
+      throw new Error(`selection text nodes not found: ${selectedText}`)
+    }
+
+    const range = document.createRange()
+    range.setStart(startNode, startOffset)
+    range.setEnd(endNode, endOffset)
+    const selection = document.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    document.dispatchEvent(new Event('selectionchange'))
+  }, text)
+}
+
 async function openToolbarSettings(page: Page) {
   await page.goto('/')
   await page.evaluate(() => localStorage.clear())
@@ -155,6 +199,27 @@ test('applies quick toolbar inline formatting to selected editor text', async ({
   await page.getByTestId('toolbar-command-format.strong').click()
 
   await expect.poll(() => getDraftStorage(page)).toContain('**bold from mobile toolbar**')
+})
+
+test('keeps selected text active while chaining quick inline formatting', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('abc')
+  await selectTextInFirstParagraph(page, 'abc')
+  await expect.poll(() => page.evaluate(() => document.getSelection()?.toString() ?? '')).toBe('abc')
+  await page.evaluate(() => document.getSelection()?.removeAllRanges())
+
+  await page.getByTestId('toolbar-command-format.strong').tap()
+
+  await expect.poll(() => getDraftStorage(page)).toContain('**abc**')
+  await expect.poll(() => page.evaluate(() => document.getSelection()?.toString() ?? '')).toBe('abc')
+  await page.evaluate(() => document.getSelection()?.removeAllRanges())
+
+  await page.getByTestId('toolbar-command-format.emphasis').tap()
+
+  await expect.poll(() => getDraftStorage(page)).toContain('***abc***')
+  await expect.poll(() => page.evaluate(() => document.getSelection()?.toString() ?? '')).toBe('abc')
 })
 
 test('applies expanded desktop format commands to selected editor text', async ({ page }) => {


### PR DESCRIPTION
## Summary

This PR fixes the Android bottom editor toolbar path when formatting an existing text selection.

Before this change, selecting text such as `abc` and tapping the bottom toolbar `B` could do nothing from the user's perspective, or degrade into an empty marker insertion like `****abc`, because the Android/WebView tap sequence can clear the live DOM selection before Muya receives `format('strong')`.

The expected behavior is now preserved:

- Select `abc`
- Tap bottom toolbar `B` -> `**abc**`
- The visible/editor selection remains `abc`
- Tap bottom toolbar `I` immediately -> `***abc***`

## Root Cause / Evidence Chain

- Muya's formatting path is selection-driven: `Muya.format(type)` reads `editor.selection.getSelection()` before applying inline or block formatting.
- `TextSelection.getSelection()` reads from `document.getSelection()` and maps the DOM range back into Muya blocks/offsets.
- On Android WebView, tapping the bottom toolbar can collapse or clear `document.getSelection()` before the toolbar click handler runs.
- The floating selection toolbar already had a robust restore-range path: it keeps the last non-collapsed editor `Range` and sends it with the command.
- The bottom mobile editor toolbar only emitted `commandId`, so direct format commands had no way to restore the user's previous selected range before calling Muya.

## Changes

- Added `captureNonCollapsedSelectionRange()` in `selectionToolbar.ts` so both mobile selection controls use the same editor-contained, non-empty selection capture rule.
- Updated `MobileEditorToolbar` to keep the latest non-collapsed editor selection range while the user is editing.
- Extended the bottom toolbar command event to pass `restoreRange` alongside `commandId`.
- Updated `App.vue` to restore the captured range before running selection-dependent toolbar commands.
- Added `isSelectionDependentMobileCommand()` to avoid applying selection restoration to undo/redo/file commands.
- Kept link/image flows compatible by passing the restored range into their existing pending-selection insertion path.
- Added a regression e2e test that simulates Android clearing `document.getSelection()` before tapping toolbar commands, then verifies chained `B` + `I` formatting keeps operating on the selected `abc` text.

## Validation

Passed:

- `pnpm exec vitest run src/lib/mobileCommands.test.ts`
- `pnpm exec playwright test tests/e2e/mobile-editor-toolbar.spec.ts -g "keeps selected text active while chaining quick inline formatting"`
- `pnpm typecheck`
- `pnpm exec playwright test tests/e2e/mobile-editor-toolbar.spec.ts` — 12 passed
- `pnpm exec eslint src/App.vue src/features/editor/components/MobileEditorToolbar.vue src/features/editor/components/MobileSelectionToolbar.vue src/features/editor/EditorScreen.vue src/features/editor/selectionToolbar.ts src/lib/mobileCommands.ts src/lib/mobileCommands.test.ts tests/e2e/mobile-editor-toolbar.spec.ts --max-warnings 0`
- `pnpm build`
- `pnpm exec cap sync android`
- `./gradlew.bat assembleDebug`
- `adb install -r android/app/build/outputs/apk/debug/app-debug.apk`
- `adb shell monkey -p io.github.renakoni.marktextandroid -c android.intent.category.LAUNCHER 1`

Known validation note:

- Full `pnpm lint` currently fails because existing reference code under `refs/spellcheck/...` is included by ESLint. The touched-file lint command above passes cleanly.