### PR TITLE
Port upstream Muya cpp language aliases

### DIFF
--- a/third_party/muya/src/block/content/codeBlockContent/index.ts
+++ b/third_party/muya/src/block/content/codeBlockContent/index.ts
@@ -417,7 +417,7 @@ class CodeBlockContent extends Content {
             // transform alias to original language
             const fullLengthLang = transformAliasToOrigin([lang])[0];
             if (fullLengthLang && /\S/.test(text) && loadedLanguages.has(fullLengthLang)) {
-                const tokens = prism.tokenize(text, prism.languages[lang]);
+                const tokens = prism.tokenize(text, prism.languages[fullLengthLang]);
                 let offset = start.offset;
                 let code = '';
                 let needRender = false;

--- a/third_party/muya/src/utils/prism/__tests__/languageAlias.spec.ts
+++ b/third_party/muya/src/utils/prism/__tests__/languageAlias.spec.ts
@@ -1,0 +1,46 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../loadLanguage', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../loadLanguage')>();
+    return {
+        ...actual,
+        // This spec validates alias registration; component loading is covered
+        // by Prism/Vite integration and would make the unit depend on globbed
+        // language modules unrelated to the alias table.
+        default: () => async () => [],
+    };
+});
+
+async function loadPrismModule() {
+    (globalThis as unknown as { window: typeof globalThis }).window = globalThis;
+    return import('../index');
+}
+
+describe('c++ language alias (#2910)', () => {
+    it('resolves `c++` to the cpp grammar', async () => {
+        const { transformAliasToOrigin } = await loadPrismModule();
+        expect(transformAliasToOrigin(['c++'])[0]).toBe('cpp');
+    });
+
+    it('resolves `h++` to the cpp grammar', async () => {
+        const { transformAliasToOrigin } = await loadPrismModule();
+        expect(transformAliasToOrigin(['h++'])[0]).toBe('cpp');
+    });
+
+    it('leaves the canonical `cpp` id untouched', async () => {
+        const { transformAliasToOrigin } = await loadPrismModule();
+        expect(transformAliasToOrigin(['cpp'])[0]).toBe('cpp');
+    });
+
+    it('exposes a runtime grammar for the resolved id but not the raw alias', async () => {
+        const { default: prism, transformAliasToOrigin } = await loadPrismModule();
+        const resolved = transformAliasToOrigin(['c++'])[0];
+        expect(resolved).toBe('cpp');
+
+        prism.languages.cpp = prism.languages.javascript;
+        expect(prism.languages[resolved]).toBeTruthy();
+        expect(prism.languages['c++']).toBeUndefined();
+        expect(() => prism.tokenize('int main(){}', prism.languages[resolved])).not.toThrow();
+    });
+});

--- a/third_party/muya/src/utils/prism/index.ts
+++ b/third_party/muya/src/utils/prism/index.ts
@@ -7,6 +7,15 @@ const prism = Prism;
 window.Prism = Prism;
 import('prismjs/plugins/keep-markup/prism-keep-markup');
 
+if (languages.cpp) {
+    const existing = languages.cpp.alias;
+    languages.cpp.alias = Array.isArray(existing)
+        ? [...existing, 'c++', 'h++']
+        : existing
+            ? [existing, 'c++', 'h++']
+            : ['c++', 'h++'];
+}
+
 const langs: {
     name: string;
     [key: string]: string;


### PR DESCRIPTION
## Summary

Ports upstream marktext/marktext PR #4794 into the Android Muya copy.

Upstream source: https://github.com/marktext/marktext/pull/4794

That upstream PR fixes fenced code blocks tagged with `c++` or `h++`: Prism ships C++ under the canonical `cpp` grammar, so those aliases did not resolve and the code block stayed unhighlighted. The Android editor uses the vendored Muya renderer/runtime, so the same syntax-highlighting path applies here.

## Changes

- Registers `c++` and `h++` as aliases of Prism's `cpp` language before Muya builds its language-search table.
- Uses the resolved canonical language id when tokenizing in `CodeBlockContent`, so alias languages do not try to read `prism.languages['c++']`.
- Adds a focused Prism alias regression test for `c++`, `h++`, and canonical `cpp`.

## Verification

- `pnpm test -- src/utils/prism/__tests__/languageAlias.spec.ts` from `third_party/muya` passed: 4 tests.
- `pnpm exec eslint src/utils/prism/index.ts src/utils/prism/__tests__/languageAlias.spec.ts src/block/content/codeBlockContent/index.ts --no-ignore --max-warnings 0` from `third_party/muya` passed.
- `pnpm typecheck` from repo root passed.
- Full root `pnpm lint` was attempted but is currently blocked by unrelated checked-in reference code under `refs/spellcheck/**` (960 existing lint problems such as CommonJS globals and vendored/minified files). The touched Muya files lint clean with the targeted command above.

## Audit Decision

This upstream PR is Android-relevant because it affects Muya code-block rendering inside the WebView editor, not desktop shell code. It was not already present in `third_party/muya`: `transformAliasToOrigin(['c++'])` could not resolve to `cpp`, and `codeBlockContent` tokenized with the raw alias key.