### PR TITLE
Port upstream Muya latex percent highlight fix

### DIFF
--- a/third_party/muya/src/utils/prism/__tests__/latexEscapedPercent.spec.ts
+++ b/third_party/muya/src/utils/prism/__tests__/latexEscapedPercent.spec.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../loadLanguage', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../loadLanguage')>();
+    return {
+        ...actual,
+        // Keep this test focused on the grammar patch. The actual Vite globbed
+        // Prism component loading is covered by integration paths.
+        default: () => async () => [],
+    };
+});
+
+async function loadPatchedPrism() {
+    (globalThis as unknown as { window: typeof globalThis }).window = globalThis;
+    const mod = await import('../index');
+    mod.default.languages.latex = { comment: /%.*/ };
+    mod.patchLatexEscapedPercent(mod.default);
+    return mod.default;
+}
+
+function hasCommentToken(tokens: unknown[]): boolean {
+    return tokens.some((token) => {
+        if (typeof token !== 'object' || token === null)
+            return false;
+
+        const maybeToken = token as { type?: string; content?: unknown };
+        if (maybeToken.type === 'comment')
+            return true;
+
+        return Array.isArray(maybeToken.content)
+            ? hasCommentToken(maybeToken.content)
+            : false;
+    });
+}
+
+describe('latex escaped percent highlighting (#3037)', () => {
+    it('does not treat `\\%` as the start of a comment', async () => {
+        const prism = await loadPatchedPrism();
+        expect(hasCommentToken(prism.tokenize('1\\%+2\\%=3\\%', prism.languages.latex))).toBe(false);
+    });
+
+    it('still treats a bare `%` as a comment', async () => {
+        const prism = await loadPatchedPrism();
+        expect(hasCommentToken(prism.tokenize('100% done', prism.languages.latex))).toBe(true);
+    });
+
+    it('still treats a line-leading `%` as a comment', async () => {
+        const prism = await loadPatchedPrism();
+        expect(hasCommentToken(prism.tokenize('%a real comment', prism.languages.latex))).toBe(true);
+    });
+});

--- a/third_party/muya/src/utils/prism/index.ts
+++ b/third_party/muya/src/utils/prism/index.ts
@@ -50,8 +50,18 @@ function search(text: string) {
     return fuse.search(text).map(i => i.item).slice(0, 5);
 }
 
+// In LaTeX `\%` is an escaped literal percent, not a line comment, but
+// prismjs's default latex `comment` token (`/%.*/`) swallows everything after
+// it. Require the `%` to not follow a backslash so `\%` highlights normally
+// (#3037). tex/context alias the same grammar object, so this covers all three.
+export function patchLatexEscapedPercent(prismInstance: typeof Prism) {
+    const latex = prismInstance.languages.latex as { comment?: unknown } | undefined;
+    if (latex?.comment)
+        latex.comment = { pattern: /(^|[^\\])%.*/, lookbehind: true };
+}
+
 // pre load latex and yaml and html for `math block` \ `front matter` and `html block`
-loadLanguage('latex');
+loadLanguage('latex').then(() => patchLatexEscapedPercent(prism));
 loadLanguage('yaml');
 
 export { walkTokens } from './walkToken';


### PR DESCRIPTION
## Summary

Ports upstream marktext/marktext PR #4795 into the Android Muya copy.

Upstream source: https://github.com/marktext/marktext/pull/4795

The upstream PR fixes LaTeX highlighting where an escaped percent (`\%`) was incorrectly tokenized as a comment by Prism's default latex grammar. Android uses the same vendored Muya/Prism highlighting path inside the WebView editor, so this affects mobile editing/display for math/code content.

## Changes

- Adds `patchLatexEscapedPercent()` to override Prism's latex `comment` token after the latex grammar is loaded.
- Keeps bare `%` and line-leading `%` comments working, while preventing escaped `\%` from greying out the rest of the line.
- Adds a focused regression test for escaped percent, bare percent, and line-leading percent behavior.

## Verification

- `pnpm test -- src/utils/prism/__tests__/latexEscapedPercent.spec.ts` from `third_party/muya` passed: 3 tests.
- `pnpm exec eslint src/utils/prism/index.ts src/utils/prism/__tests__/latexEscapedPercent.spec.ts --no-ignore --max-warnings 0` from `third_party/muya` passed.
- `pnpm typecheck` from repo root passed.
- Root full `pnpm lint` is currently blocked by unrelated checked-in reference code under `refs/spellcheck/**` (CommonJS globals and vendored/minified files). For this PR, the touched Muya files were linted directly with `--no-ignore` and passed.

## Audit Decision

This upstream PR is Android-relevant because it changes Muya's Prism rendering behavior for LaTeX/math content shown in the Android WebView editor. It was not present in `third_party/muya`: there was no latex percent patch or regression coverage for `\%`.