### PR TITLE
Port upstream Muya sequence dark theme colors

### DIFF
--- a/third_party/muya/src/assets/styles/blockSyntax.css
+++ b/third_party/muya/src/assets/styles/blockSyntax.css
@@ -815,6 +815,20 @@ figure.mu-diagram-block .mu-diagram-preview svg path[stroke='#000000'] {
     stroke: var(--editor-color);
 }
 
+/* js-sequence-diagrams creates its <text> with no fill attribute and its
+   note/actor boxes with the 3-char `#fff`, so the attribute-keyed rules above
+   miss them and the labels/boxes stay black-on-white on dark themes (#3047).
+   Recolor the sequence SVG by element, scoped to `svg.sequence` so mermaid /
+   vega / flowchart (which set fills via attributes) are untouched. */
+figure.mu-diagram-block .mu-diagram-preview svg.sequence text {
+    fill: var(--editor-color);
+}
+
+figure.mu-diagram-block .mu-diagram-preview svg.sequence rect[fill='#fff'],
+figure.mu-diagram-block .mu-diagram-preview svg.sequence path[fill='#fff'] {
+    fill: var(--editor-bg-color);
+}
+
 figure.mu-active.mu-math-block > div.mu-math-preview,
 figure.mu-active.mu-diagram-block > div.mu-diagram-preview {
     position: absolute;


### PR DESCRIPTION
## Summary

Ports upstream marktext/marktext PR #4800 into the Android Muya copy.

Upstream source: https://github.com/marktext/marktext/pull/4800

The upstream PR fixes dark-theme readability for sequence diagrams. js-sequence-diagrams emits text without an explicit fill and some boxes with `#fff`, so the existing attribute-keyed diagram recolor rules do not catch them. Android renders the same Muya diagram preview inside the WebView editor, so this affects mobile display when dark/theme variables are active.

## Changes

- Adds `svg.sequence`-scoped CSS rules for sequence diagram text and `#fff` boxes.
- Maps sequence text to `--editor-color` and note/actor boxes to `--editor-bg-color`.
- Keeps the scope narrow so mermaid, vega, and flowchart SVGs continue using the existing attribute-based recolor rules.

## Verification

- `pnpm build` from repo root passed, including `pnpm typecheck` and Vite CSS bundling.
- `pnpm typecheck` from repo root passed independently before the build.
- Tried `pnpm exec stylelint src/assets/styles/blockSyntax.css` from `third_party/muya`, but this vendored package currently has no stylelint config in this repo, so stylelint exits with `ConfigurationError: No configuration provided`. The production build verifies the CSS parses and bundles.

## Audit Decision

This upstream PR is Android-relevant because it changes Muya editor display CSS for diagrams rendered inside the WebView. It was not already present in `third_party/muya`: the existing dark-theme recolor block only handled `#ffffff`, `#000000`, and `black` attributes and had no `svg.sequence` rules for missing fill attributes or `#fff` fills.