### PR TITLE
Port upstream Muya image resize reflow fix

### DIFF
--- a/third_party/muya/src/ui/imageResizeBar/__tests__/imageResizeBarReflow.spec.ts
+++ b/third_party/muya/src/ui/imageResizeBar/__tests__/imageResizeBarReflow.spec.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import type { Muya } from '../../../index';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const floatingMocks = vi.hoisted(() => {
+    const state: {
+        callback?: () => void;
+        cleanup: ReturnType<typeof vi.fn>;
+    } = {
+        cleanup: vi.fn(),
+    };
+
+    return {
+        state,
+        autoUpdate: vi.fn((_reference: Element, _floating: Element, update: () => void) => {
+            state.callback = update;
+            return state.cleanup;
+        }),
+    };
+});
+
+vi.mock('@floating-ui/dom', () => ({
+    autoUpdate: floatingMocks.autoUpdate,
+}));
+
+function createMuyaStub(): Muya {
+    const domNode = document.createElement('div');
+    document.body.appendChild(domNode);
+
+    return {
+        domNode,
+        eventCenter: {
+            on: vi.fn(),
+            emit: vi.fn(),
+            attachDOMEvent: vi.fn(() => 'event-id'),
+            detachDOMEvent: vi.fn(),
+        },
+    } as unknown as Muya;
+}
+
+function mutableReference() {
+    const reference = document.createElement('span');
+    let rect = new DOMRect(20, 30, 100, 40);
+    reference.getBoundingClientRect = () => rect;
+
+    return {
+        reference,
+        moveTo(next: DOMRect) {
+            rect = next;
+        },
+    };
+}
+
+describe('ImageResizeBar reflow tracking (#2939)', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        floatingMocks.autoUpdate.mockClear();
+        floatingMocks.state.cleanup.mockClear();
+        floatingMocks.state.callback = undefined;
+    });
+
+    it('repositions handles through autoUpdate and cleans the observer on hide', async () => {
+        const { ImageResizeBar } = await import('../index');
+        const resizeBar = new ImageResizeBar(createMuyaStub());
+        const moving = mutableReference();
+        const internals = resizeBar as unknown as {
+            _container: HTMLDivElement;
+            _reference: HTMLElement;
+            _render: () => void;
+        };
+
+        internals._reference = moving.reference;
+        internals._render();
+
+        expect(floatingMocks.autoUpdate).toHaveBeenCalledWith(
+            moving.reference,
+            internals._container,
+            expect.any(Function),
+        );
+
+        moving.moveTo(new DOMRect(40, 60, 80, 30));
+        floatingMocks.state.callback?.();
+
+        expect(internals._container.querySelector<HTMLElement>('.left')?.style.left).toBe('35px');
+        expect(internals._container.querySelector<HTMLElement>('.right')?.style.left).toBe('115px');
+
+        resizeBar.hide();
+        expect(floatingMocks.state.cleanup).toHaveBeenCalledTimes(1);
+    });
+});

--- a/third_party/muya/src/ui/imageResizeBar/index.ts
+++ b/third_party/muya/src/ui/imageResizeBar/index.ts
@@ -2,6 +2,7 @@ import type Format from '../../block/base/format';
 import type { Muya } from '../../index';
 import type { ImageToken } from '../../inlineRenderer/types';
 
+import { autoUpdate } from '@floating-ui/dom';
 import { isHTMLElement, isMouseEvent } from '../../utils';
 import { findScrollContainer } from '../../utils/dom';
 import './index.css';
@@ -26,6 +27,8 @@ export class ImageResizeBar {
     private _eventId: string[] = [];
     private _lastScrollTop: number | null = null;
     private _resizing: boolean = false;
+    // Stops the autoUpdate reposition loop set up in `_render`.
+    private _cleanup: (() => void) | null = null;
     // A container for storing drag strips
     private _container: HTMLDivElement;
 
@@ -89,6 +92,9 @@ export class ImageResizeBar {
 
         this._createElements();
         this._update();
+        // Reposition the handles whenever the image moves (window/ancestor
+        // resize, sidebar toggle, scroll), so they stay attached to it (#2939).
+        this._cleanup = autoUpdate(this._reference!, this._container, () => this._update());
         eventCenter.emit('muya-float', this, true);
     }
 
@@ -202,6 +208,8 @@ export class ImageResizeBar {
 
     hide() {
         const { eventCenter } = this.muya;
+        this._cleanup?.();
+        this._cleanup = null;
         const circles = this._container.querySelectorAll('.bar');
         Array.from(circles).forEach(c => c.remove());
         this._status = false;
@@ -211,6 +219,8 @@ export class ImageResizeBar {
     // Remove the `.mu-transformer` container appended to document.body in the
     // constructor; invoked by `Muya.destroy()` so it is not leaked (#3315).
     destroy() {
+        this._cleanup?.();
+        this._cleanup = null;
         this._container.remove();
     }
 }


### PR DESCRIPTION
## Summary

Ports upstream marktext/marktext PR #4802 into the Android Muya copy.

Upstream source: https://github.com/marktext/marktext/pull/4802

The upstream PR fixes image resize handles becoming detached from the selected image after layout reflow. Android uses the same Muya image resize bar in the WebView editor, and mobile layout can reflow from viewport changes, keyboard/insets, orientation, or toolbar/layout changes, so the behavior is relevant here too.

## Changes

- Uses `@floating-ui/dom` `autoUpdate()` to keep the image resize bar positioned against the selected image after ancestor resize/scroll/layout changes.
- Tears down the auto-update observer in both `hide()` and `destroy()` so no observer loop leaks after the bar is hidden or Muya is destroyed.
- Adds focused unit coverage that verifies autoUpdate drives handle repositioning and that cleanup runs on hide.

## Verification

- `pnpm test -- src/ui/imageResizeBar/__tests__/imageResizeBarReflow.spec.ts` from `third_party/muya` passed: 1 test.
- `pnpm exec eslint src/ui/imageResizeBar/index.ts src/ui/imageResizeBar/__tests__/imageResizeBarReflow.spec.ts --no-ignore --max-warnings 0` from `third_party/muya` passed.
- `pnpm typecheck` from repo root passed.

## Audit Decision

This upstream PR is Android-relevant because it changes Muya editor image interaction UI inside the WebView. It was not already present in `third_party/muya`: `ImageResizeBar` only positioned on render/drag and had no `autoUpdate` subscription or cleanup path.