### PR TITLE
Port upstream Muya cpp alias idempotence

### DIFF
--- a/third_party/muya/src/utils/prism/__tests__/languageAlias.spec.ts
+++ b/third_party/muya/src/utils/prism/__tests__/languageAlias.spec.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { languages } from 'prismjs/components.js';
 
 vi.mock('../loadLanguage', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../loadLanguage')>();
@@ -17,7 +18,16 @@ async function loadPrismModule() {
     return import('../index');
 }
 
+function cppAliases(): string[] {
+    const alias = languages.cpp.alias;
+    return Array.isArray(alias) ? alias : alias ? [alias] : [];
+}
+
 describe('c++ language alias (#2910)', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
     it('resolves `c++` to the cpp grammar', async () => {
         const { transformAliasToOrigin } = await loadPrismModule();
         expect(transformAliasToOrigin(['c++'])[0]).toBe('cpp');
@@ -42,5 +52,14 @@ describe('c++ language alias (#2910)', () => {
         expect(prism.languages[resolved]).toBeTruthy();
         expect(prism.languages['c++']).toBeUndefined();
         expect(() => prism.tokenize('int main(){}', prism.languages[resolved])).not.toThrow();
+    });
+
+    it('registers aliases only once across repeated module evaluation (#4816)', async () => {
+        await loadPrismModule();
+        vi.resetModules();
+        await loadPrismModule();
+
+        expect(cppAliases().filter(alias => alias === 'c++')).toHaveLength(1);
+        expect(cppAliases().filter(alias => alias === 'h++')).toHaveLength(1);
     });
 });

--- a/third_party/muya/src/utils/prism/index.ts
+++ b/third_party/muya/src/utils/prism/index.ts
@@ -9,11 +9,14 @@ import('prismjs/plugins/keep-markup/prism-keep-markup');
 
 if (languages.cpp) {
     const existing = languages.cpp.alias;
-    languages.cpp.alias = Array.isArray(existing)
-        ? [...existing, 'c++', 'h++']
-        : existing
-            ? [existing, 'c++', 'h++']
-            : ['c++', 'h++'];
+    // components.languages survives test/HMR module reloads, so aliases must
+    // not be appended again each time this module is evaluated.
+    const alias = Array.isArray(existing) ? [...existing] : existing ? [existing] : [];
+    for (const name of ['c++', 'h++']) {
+        if (!alias.includes(name))
+            alias.push(name);
+    }
+    languages.cpp.alias = alias;
 }
 
 const langs: {


### PR DESCRIPTION
## Summary

Ports upstream marktext/marktext PR #4816 into the Android Muya copy.

Upstream source: https://github.com/marktext/marktext/pull/4816
Upstream commit: `e7207faa474902ac9509b0d2c9215d13a8b1b307`

## Changes

- makes `c++` / `h++` alias registration idempotent by adding each alias only when it is absent
- prevents duplicate aliases when the shared Prism component metadata survives test or HMR module reloads
- extends the existing alias regression suite to reload the Prism module and assert that each alias appears exactly once

## Refreshed review

This PR was rebased onto the current `main` after the original parent alias PR had already merged. The obsolete parent commit and duplicate code-block tokenization change are no longer part of this PR. The remaining implementation matches upstream #4816, with a focused regression test and a short comment documenting the shared-singleton constraint.

## Verification

- `pnpm --dir third_party/muya exec vitest run src/utils/prism/__tests__/languageAlias.spec.ts` (5 tests)
- `pnpm --dir third_party/muya exec eslint src/utils/prism/index.ts src/utils/prism/__tests__/languageAlias.spec.ts --no-ignore --max-warnings 0`
- `pnpm vitest run src/features/editor/muyaVendorSyncContract.test.ts`
- `pnpm typecheck`
- `git diff --check origin/main...HEAD`

## Audit decision

Keep. Prism's `components.languages` metadata is shared across module evaluation, so blindly appending the same aliases can accumulate duplicates and make the dependency loader reject an alias as registered more than once. The fix is narrow, Android-WebView relevant, and covered by a regression test.