### PR TITLE
Port upstream Muya rendered-text TOC slugs

### DIFF
--- a/third_party/muya/src/__tests__/getTOC.spec.ts
+++ b/third_party/muya/src/__tests__/getTOC.spec.ts
@@ -1,7 +1,16 @@
 // @vitest-environment happy-dom
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya } from '../muya';
+
+vi.mock('../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => Promise.resolve([]),
+    search: () => [],
+}));
 
 // Regression coverage for PR-15: re-introduces marktext's TOC API as a
 // public muya method (`muya.getTOC()`). Mirrors marktext's `tocCtrl.js`
@@ -10,9 +19,10 @@ import { Muya } from '../muya';
 //
 //  - Only top-level heading blocks are surfaced (matches marktext
 //    iterating `this.blocks`).
-//  - Heading text is the raw inner content — inline markdown markers are
-//    NOT stripped. marktext used `block.children[0].text` for the same
-//    reason.
+//  - Heading text is the rendered plain text: inline markdown markers,
+//    link/image URLs and tags are stripped to what a reader sees (#4811),
+//    and `githubSlug` is derived from that same plain text so it matches
+//    the anchor id the HTML export injects from `heading.textContent`.
 //  - Slug is a stable per-block identifier (so `getTOC()` returns the
 //    same slug across multiple invocations on the same document); duplicate
 //    headings keep distinct slugs but share `githubSlug`. The marktext
@@ -89,16 +99,28 @@ describe('muya.getTOC()', () => {
         expect(toc[1]).toMatchObject({ lvl: 2, content: 'Title Two' });
     });
 
-    it('keeps raw markdown inline markers in `content` (no inline parsing)', () => {
-        // marktext reads `block.children[0].text` — the raw source of the
-        // heading line — so `**bold**` and `[link](url)` are preserved as
-        // typed. Consumers that want rendered text should run their own
-        // inline tokenizer over `content`.
+    it('strips inline markdown to plain text in `content` (#4811)', () => {
         const md = `## **bold** and [link](https://example.com)`;
         const muya = bootMuya(md);
         const toc = muya.getTOC();
         expect(toc).toHaveLength(1);
-        expect(toc[0].content).toBe('**bold** and [link](https://example.com)');
+        expect(toc[0].content).toBe('bold and link');
+    });
+
+    it('renders an image heading as its alt text, not the raw `![]()`', () => {
+        const md = `## ![Logo](https://example.com/logo.png) Title`;
+        const muya = bootMuya(md);
+        const toc = muya.getTOC();
+        expect(toc).toHaveLength(1);
+        expect(toc[0].content).toBe('Logo Title');
+    });
+
+    it('derives githubSlug from the stripped text so anchors match the export', () => {
+        const md = `## a [link](https://example.com) here`;
+        const muya = bootMuya(md);
+        const toc = muya.getTOC();
+        expect(toc[0].content).toBe('a link here');
+        expect(toc[0].githubSlug).toBe('a-link-here');
     });
 
     it('strips the leading hash run robustly (9cb2cbe8 \\s regex fix)', () => {

--- a/third_party/muya/src/inlineRenderer/lexer.ts
+++ b/third_party/muya/src/inlineRenderer/lexer.ts
@@ -5,6 +5,7 @@ import type {
     Labels,
     Token,
 } from './types';
+import escapeCharactersMap from '../config/escapeCharacter';
 import { isLengthEven, union } from '../utils';
 import { beginRules, inlineRules, linkValidateRules, validateRules } from './rules';
 import {
@@ -921,6 +922,73 @@ export function generator(tokens: Token[], rebuildWrappers = false) {
 
     for (const token of tokens)
         result += rebuildWrappers ? rebuildWrapperToken(token) : token.raw;
+
+    return result;
+}
+
+// The reader-facing text of inline tokens with every marker, delimiter, URL and
+// tag dropped: `**bold**` -> `bold`, `[text](url)` -> `text`, `![alt](src)` ->
+// `alt`. This mirrors the visible `textContent` a rendered heading yields, so a
+// slug derived from this matches the anchor id the HTML export injects.
+export function tokensToPlainText(tokens: Token[]): string {
+    let result = '';
+
+    for (const token of tokens) {
+        switch (token.type) {
+            case 'text':
+            case 'inline_code':
+            case 'inline_math':
+            case 'emoji':
+            case 'super_sub_script':
+            case 'footnote_identifier':
+                result += token.content;
+                break;
+
+            case 'strong':
+            case 'em':
+            case 'del':
+            case 'link':
+            case 'reference_link':
+                result += tokensToPlainText(token.children);
+                break;
+
+            case 'image':
+            case 'reference_image':
+                result += token.alt;
+                break;
+
+            case 'html_tag':
+                if (token.children)
+                    result += tokensToPlainText(token.children);
+                else if (token.content)
+                    result += token.content;
+                break;
+
+            case 'backlash':
+                result += token.raw.replace(/^\\/, '');
+                break;
+
+            case 'html_escape':
+                result += escapeCharactersMap[token.escapeCharacter] ?? token.raw;
+                break;
+
+            case 'auto_link':
+                result += token.raw.replace(/^<|>$/g, '');
+                break;
+
+            case 'auto_link_extension':
+                result += token.raw;
+                break;
+
+            case 'soft_line_break':
+            case 'hard_line_break':
+                result += ' ';
+                break;
+
+            default:
+                break;
+        }
+    }
 
     return result;
 }

--- a/third_party/muya/src/state/getTOC.ts
+++ b/third_party/muya/src/state/getTOC.ts
@@ -1,6 +1,7 @@
 import type Content from '../block/base/content';
 import type Parent from '../block/base/parent';
 import type { Muya } from '../muya';
+import { tokenizer, tokensToPlainText } from '../inlineRenderer/lexer';
 import { getUniqueId } from '../utils';
 import { generateGithubSlug } from '../utils/slug';
 
@@ -42,9 +43,17 @@ export function getTOC(muya: Muya): ITocItem[] {
         const head = block.children.head as Content | null;
         const text = head?.text ?? '';
 
-        const content = blockName === 'setext-heading'
+        const source = blockName === 'setext-heading'
             ? text.trim()
             : text.replace(/^\s*#{1,6}\s+/, '').trim();
+
+        const { superSubScript, footnote } = muya.options;
+        const content = tokensToPlainText(
+            tokenizer(source, {
+                hasBeginRules: false,
+                options: { superSubScript, footnote },
+            }),
+        ).trim();
 
         items.push({
             content,


### PR DESCRIPTION
## Summary

Ports upstream marktext/marktext PR #4811 into the Android Muya copy.

Upstream source: https://github.com/marktext/marktext/pull/4811

The upstream PR fixes TOC heading labels and slugs when headings contain inline Markdown. Previously `getTOC()` exposed the raw heading source (`**bold**`, `[label](url)`, `![alt](src)`), and `githubSlug` was derived from that raw text. Android vendors the same Muya engine and already exposes `muya.getTOC()`, so this affects any Android-side outline, anchor, or generated TOC behavior that consumes engine TOC data.

## Changes

- Adds `tokensToPlainText()` to collapse inline tokens to reader-visible text.
- Updates `getTOC()` to tokenize heading content without begin rules and use visible text for both `content` and `githubSlug`.
- Updates `getTOC` regression coverage for formatted headings, image-alt headings, and slug convergence.
- Adds a Prism shim in the TOC spec so this focused test does not trip the local vendored Prism component glob while booting Muya.

## Verification

- `pnpm test -- src/__tests__/getTOC.spec.ts` from `third_party/muya` passed: 12 tests.
- `pnpm typecheck` from repo root passed.
- `pnpm exec eslint src/inlineRenderer/lexer.ts src/state/getTOC.ts src/__tests__/getTOC.spec.ts --no-ignore --max-warnings 1` from `third_party/muya` completed with only one pre-existing warning in `lexer.ts` (`Unused eslint-disable directive` at the older tokenizer code around line 677). No new lint errors were introduced.

## Audit Decision

This upstream PR is Android-relevant because it changes Muya engine output for TOC/anchor data rather than desktop-only shell code. It was not present in `third_party/muya`: `getTOC()` still returned raw heading source and `lexer.ts` had no `tokensToPlainText()` helper.