### PR TITLE
Port upstream autolink encoding fix

### DIFF
--- a/third_party/muya/src/inlineRenderer/__tests__/autoLinkEncoding.spec.ts
+++ b/third_party/muya/src/inlineRenderer/__tests__/autoLinkEncoding.spec.ts
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+
+import type { Muya as MuyaType } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../muya';
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (language: string) => language,
+    loadLanguage: () => Promise.resolve([]),
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): MuyaType {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('#3548: autolink hrefs are not double percent-encoded', () => {
+    it('keeps an already-encoded `%20` intact instead of turning it into `%2520`', () => {
+        const muya = bootMuya('<https://www.google.com/search?q=marktext%20foo%20bar>\n');
+        const anchor = muya.domNode.querySelector<HTMLAnchorElement>('a.mu-auto-link')!;
+        const href = anchor.getAttribute('href')!;
+
+        expect(href).toContain('%20');
+        expect(href).not.toContain('%2520');
+    });
+
+    it('does not re-encode reserved characters in a query string', () => {
+        const muya = bootMuya('<https://example.com/a?b=c&d=e>\n');
+        const anchor = muya.domNode.querySelector<HTMLAnchorElement>('a.mu-auto-link')!;
+
+        expect(anchor.getAttribute('href')).toBe('https://example.com/a?b=c&d=e');
+    });
+});

--- a/third_party/muya/src/inlineRenderer/renderer/autoLink.ts
+++ b/third_party/muya/src/inlineRenderer/renderer/autoLink.ts
@@ -28,7 +28,7 @@ export default function autoLink(
         token,
     );
 
-    const hyperlink = isLink ? encodeURI(href) : `mailto:${email}`;
+    const hyperlink = isLink ? href : `mailto:${email}`;
 
     return [
         h(`span.${className}`, startMarker),


### PR DESCRIPTION
## Summary
- Port upstream MarkText PR #4841 into the Android Muya copy.
- Stop CommonMark autolink hrefs from double-encoding already percent-encoded URLs.
- Add a regression test for rendered autolink href attributes.

## Upstream Source
- Upstream PR: https://github.com/marktext/marktext/pull/4841
- Upstream commit: https://github.com/marktext/marktext/commit/404c8c8648950e61820e40f6ab0ebe47cc8c652e
- Upstream issue: https://github.com/marktext/marktext/issues/3548

## Android Relevance
The Android live editor consumes `third_party/muya`. A CommonMark autolink such as `<https://www.google.com/search?q=marktext%20foo%20bar>` is rendered as a clickable link in the WebView. The previous renderer called `encodeURI(href)`, which changed `%20` to `%2520`; following the link could therefore open a different URL. Standard Markdown links already keep hrefs verbatim, so this aligns autolinks with them.

## Change Details
- Use the autolink token href directly for URL autolinks.
- Preserve the existing `mailto:` construction for email autolinks.
- Verify that `%20` and reserved query characters survive in the rendered anchor.
- Isolate this unrelated rendering test from Prism's asynchronous language loader under Vitest.

## Verification
- `pnpm --dir third_party/muya exec vitest run src/inlineRenderer/__tests__/autoLinkEncoding.spec.ts src/inlineRenderer/__tests__/autoLinkTrailingPunct.spec.ts src/inlineRenderer/__tests__/linkFollowedByAutolink.spec.ts` (15 tests passed)
- `pnpm vitest run src/features/editor/muyaVendorSyncContract.test.ts`
- `pnpm lint`
- `pnpm build`