### PR TITLE
Port upstream soft break export fix

### DIFF
--- a/third_party/muya/src/assets/styles/exportStyle.css
+++ b/third_party/muya/src/assets/styles/exportStyle.css
@@ -89,6 +89,21 @@
     white-space: pre-wrap;
 }
 
+/* Render soft line breaks (Shift+Enter -> a bare `\n` inside a block) the way
+   the editor does (`.mu-content` is pre-wrap) instead of emitting a
+   non-standard `<br>`, so exported HTML stays CommonMark-conformant while still
+   showing the break (#3676).
+
+   `li:not(:has(> p))` targets only tight list items, whose soft break is a
+   bare `\n` directly inside the `<li>`. Loose items wrap their content in
+   `<p>` (handled by the `p` rule); giving them `li` pre-wrap would expose
+   marked's pretty-printing newline between `</p>` and `</li>` as a stray blank
+   line, so they are deliberately excluded. */
+.markdown-body p,
+.markdown-body li:not(:has(> p)) {
+    white-space: pre-wrap;
+}
+
 .markdown-body table {
     display: table;
 }

--- a/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
+++ b/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getHighlightHtml } from '../../utils/marked';
+
+const OPTS = { math: false, superSubScript: false, footnote: false, frontMatter: false };
+
+describe('#3676: soft line breaks survive export as conformant newlines', () => {
+    it('keeps a paragraph soft break as a newline, never a <br>', () => {
+        const html = getHighlightHtml('line one\nline two', OPTS);
+
+        expect(html).toContain('<p>line one\nline two</p>');
+        expect(html).not.toMatch(/<br\s*\/?>/);
+    });
+
+    it('keeps a soft break inside a tight list item, never a <br>', () => {
+        const html = getHighlightHtml('- line A\n  line B', OPTS);
+
+        expect(html).toMatch(/<li>line A\nline B<\/li>/);
+        expect(html).not.toMatch(/<br\s*\/?>/);
+    });
+
+    it('leaves a real hard break as <br>', () => {
+        const html = getHighlightHtml('line one  \nline two', OPTS);
+
+        expect(html).toMatch(/<br\s*\/?>/);
+    });
+});


### PR DESCRIPTION
## Summary
- Port upstream MarkText PR #4844 into the Android Muya copy.
- Preserve soft line breaks in exported HTML by rendering paragraph and tight-list content with `white-space: pre-wrap`.
- Add regression coverage that soft breaks remain conformant newlines instead of becoming `<br>`.

## Upstream Source
- Upstream PR: https://github.com/marktext/marktext/pull/4844
- Upstream issue: https://github.com/marktext/marktext/issues/3676

## Android Relevance
The Android repo carries Muya's HTML export implementation and stylesheet. A soft line break is represented as a bare newline inside a paragraph or tight list item. The live editor shows it because editor content uses pre-wrap behavior, but exported HTML could collapse it into a space. This keeps the embedded Muya export path consistent with editor rendering without changing the CommonMark HTML produced by `getHighlightHtml()`.

## Change Details
- Add export CSS for `.markdown-body p` and tight list items (`li:not(:has(> p))`) to use `white-space: pre-wrap`.
- Avoid applying that rule to loose list item containers so pretty-printed paragraph/list newlines do not become visible blank lines.
- Add `softBreakExportHtml.spec.ts` asserting soft breaks remain newlines and hard breaks still render as `<br>`.

## Verification
- `pnpm --dir third_party/muya exec vitest run src/state/__tests__/softBreakExportHtml.spec.ts` passed.
- `pnpm build` passed.
