### PR TITLE
Port upstream Prism dependency order fix

### DIFF
--- a/third_party/muya/src/utils/prism/__tests__/loadLanguageDependencyOrder.spec.ts
+++ b/third_party/muya/src/utils/prism/__tests__/loadLanguageDependencyOrder.spec.ts
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import prism, { loadLanguage } from '../index';
+import { loadedLanguages } from '../loadLanguage';
+
+function resetCppState() {
+    for (const lang of ['c', 'cpp']) {
+        delete (prism.languages as Record<string, unknown>)[lang];
+        loadedLanguages.delete(lang);
+    }
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('loadLanguage dependency order', () => {
+    it('loads a dependency before the dependent grammar that extends it', async () => {
+        resetCppState();
+
+        const addOrder: string[] = [];
+        const realAdd = loadedLanguages.add.bind(loadedLanguages);
+        vi.spyOn(loadedLanguages, 'add').mockImplementation((lang: string) => {
+            addOrder.push(lang);
+            return realAdd(lang);
+        });
+
+        await expect(loadLanguage('cpp')).resolves.toBeDefined();
+
+        expect(addOrder).toContain('c');
+        expect(addOrder).toContain('cpp');
+        expect(addOrder.indexOf('c')).toBeLessThan(addOrder.indexOf('cpp'));
+        expect(prism.languages.cpp).toBeTruthy();
+        expect(() => prism.tokenize('int main(){}', prism.languages.cpp)).not.toThrow();
+    });
+});

--- a/third_party/muya/src/utils/prism/loadLanguage.ts
+++ b/third_party/muya/src/utils/prism/loadLanguage.ts
@@ -1,6 +1,5 @@
 import components from 'prismjs/components.js';
 import getLoader from 'prismjs/dependencies';
-import { getDefer } from '../index';
 
 interface ILangLoadStatus {
     lang: string;
@@ -19,10 +18,28 @@ export const loadedLanguages = new Set([
 ]);
 
 const { languages } = components;
-const languageModules = import.meta.glob([
-    '../../../../../prismjs/components/prism-*.js',
-    '!../../../../../prismjs/components/prism-*.min.js',
-]) as Record<string, () => Promise<unknown>>;
+// Two glob shapes on purpose: the importer path differs between Muya's own
+// vitest/build context (three levels up to third_party/muya/node_modules) and
+// the Android app build, where this file compiles from the installed
+// @muyajs/core copy and prismjs resolves five levels up beside it in the
+// pnpm store. Each shape matches nothing in the other context, so keep them
+// as separate globs (one array poisons resolution for both) and merge.
+const languageModules = {
+    ...import.meta.glob([
+        '../../../../../prismjs/components/prism-*.js',
+        '!../../../../../prismjs/components/prism-*.min.js',
+    ]),
+    ...import.meta.glob([
+        '../../../node_modules/prismjs/components/prism-*.js',
+        '!../../../node_modules/prismjs/components/prism-*.min.js',
+    ]),
+} as Record<string, () => Promise<unknown>>;
+
+function getLanguageModule(lang: string) {
+    const modulePath = `../../../node_modules/prismjs/components/prism-${lang}.js`;
+    return languageModules[modulePath]
+        ?? Object.entries(languageModules).find(([path]) => path.endsWith(`/prism-${lang}.js`))?.[1];
+}
 
 // Look for the origin language by alias
 export function transformAliasToOrigin(langs: string[]) {
@@ -81,43 +98,38 @@ function initLoadLanguage(Prism: IPrismLike) {
         if (!Array.isArray(langs))
             langs = [langs];
 
-        const promises: Promise<ILangLoadStatus>[] = [];
+        const statuses: ILangLoadStatus[] = [];
         // The user might have loaded languages via some other way or used `prism.js` which already includes some
         // We don't need to validate the ids because `getLoader` will ignore invalid ones
         const loaded = [...loadedLanguages, ...Object.keys(Prism.languages)];
-        getLoader(components, langs, loaded).load(async (lang: string) => {
-            const defer = getDefer<ILangLoadStatus>();
-            promises.push(defer.promise);
+        const loadComponent = async (lang: string): Promise<void> => {
             if (!(lang in components.languages)) {
-                defer.resolve({
-                    lang,
-                    status: 'noexist',
-                });
+                statuses.push({ lang, status: 'noexist' });
+                return;
             }
-            else if (loadedLanguages.has(lang)) {
-                defer.resolve({
-                    lang,
-                    status: 'cached',
-                });
+            if (loadedLanguages.has(lang)) {
+                statuses.push({ lang, status: 'cached' });
+                return;
             }
-            else {
-                delete Prism.languages[lang];
-                const modulePath = `../../../../../prismjs/components/prism-${lang}.js`;
-                const loadLanguageModule = languageModules[modulePath];
-                if (!loadLanguageModule) {
-                    throw new Error(`Prism language module not found: ${lang}`);
-                }
 
-                await loadLanguageModule();
-                defer.resolve({
-                    lang,
-                    status: 'loaded',
-                });
-                loadedLanguages.add(lang);
+            delete Prism.languages[lang];
+            const loadLanguageModule = getLanguageModule(lang);
+            if (!loadLanguageModule) {
+                throw new Error(`Prism language module not found: ${lang}`);
             }
+
+            await loadLanguageModule();
+            loadedLanguages.add(lang);
+            statuses.push({ lang, status: 'loaded' });
+        };
+
+        await getLoader(components, langs, loaded).load(loadComponent, {
+            series: (before: Promise<void>, after: () => Promise<void>) =>
+                before.then(after),
+            parallel: (values: Promise<void>[]) => Promise.all(values),
         });
 
-        return Promise.all(promises);
+        return statuses;
     };
 }
 


### PR DESCRIPTION
## Upstream

Ports marktext/marktext#4861: https://github.com/marktext/marktext/pull/4861

Upstream fixed Muya's Prism language loader so dependency languages are loaded in the order Prism expects. The concrete failure is cold-loading C++ before C: `prism-cpp` extends the `c` grammar, so a parallel/racy load can fail before the dependency exists.

## Android relevance

Android uses this Muya Prism path for editor code highlighting in the WebView. The same dependency-order race applies here on cold grammar loads, especially C/C++ and other grammars with Prism dependencies.

## Changes

- Replace the deferred-status collection with an ordered async `loadComponent` callback.
- Pass Prism's dependency loader explicit `series` and `parallel` chainers so dependent components are awaited before dependents run.
- Keep returned load statuses for `loaded`, `cached`, and `noexist` outcomes.
- Add a focused regression test that loads `cpp`, asserts `c` is registered before `cpp`, and verifies tokenization does not throw.
- Android-specific correction: resolve Prism component dynamic imports from Muya's package location with `../../../node_modules/prismjs/components/prism-*.js`. The previous glob made the focused Vitest run unable to resolve several Prism modules such as `c`, `latex`, and `yaml`; this path keeps the dynamic import map tied to the actual dependency under this workspace.

## Verification

- `pnpm --dir third_party/muya exec vitest run src/utils/prism/__tests__/loadLanguageDependencyOrder.spec.ts`
- `pnpm build`