### PR TITLE
Port upstream Google Docs paste formatting fix

### DIFF
--- a/third_party/muya/src/state/__tests__/htmlToMarkdown.spec.ts
+++ b/third_party/muya/src/state/__tests__/htmlToMarkdown.spec.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import HtmlToMarkdown from '../htmlToMarkdown';
+
+function convert(html: string): string {
+    return new HtmlToMarkdown().generate(html);
+}
+
+describe('htmlToMarkdown - Google Docs style inline formatting', () => {
+    it('preserves CSS bold and italic ranges from Google Docs without bolding the wrapper', () => {
+        const html = [
+            '<b style="font-weight:normal" id="docs-internal-guid-abc">',
+            '<p dir="ltr">',
+            '<span style="font-weight:700">Bold</span>',
+            '<span> normal </span>',
+            '<span style="font-style:italic">italic</span>',
+            '</p>',
+            '</b>',
+        ].join('');
+
+        expect(convert(html)).toBe('**Bold** normal *italic*');
+    });
+
+    it('does not treat a non-bold Google Docs wrapper as strong across paragraphs', () => {
+        const html = [
+            '<b style="font-weight:normal" id="docs-internal-guid-abc">',
+            '<p>First para.</p>',
+            '<p><span style="font-weight:700">Second bold para.</span></p>',
+            '</b>',
+        ].join('');
+
+        expect(convert(html)).toBe('First para.\n\n**Second bold para.**');
+    });
+
+    it('preserves CSS formatting inside headings and list items', () => {
+        expect(
+            convert([
+                '<h1><span>Heading </span><span style="font-weight:700">Bold</span></h1>',
+                '<ul>',
+                '<li><span>bullet </span><span style="font-weight:700">bold</span></li>',
+                '<li><span>bullet </span><span style="font-style:italic">italic</span></li>',
+                '</ul>',
+            ].join('')),
+        ).toBe('# Heading **Bold**\n\n- bullet **bold**\n- bullet *italic*');
+    });
+
+    it('preserves CSS formatting inside links', () => {
+        expect(
+            convert([
+                '<p>',
+                'Plain <a href="https://example.com/plain"><span>link</span></a>',
+                ' and <a href="https://example.com/bold">',
+                '<span style="font-weight:700">boldlink</span>',
+                '</a>',
+                '</p>',
+            ].join('')),
+        ).toBe('Plain [link](https://example.com/plain) and [**boldlink**](https://example.com/bold)');
+    });
+
+    it('recognizes common CSS strong weights without treating medium weights as bold', () => {
+        expect(
+            convert([
+                '<p>',
+                '<span style="font-weight:bold">Bold keyword</span>',
+                '<span> </span>',
+                '<span style="font-weight:600">Bold numeric</span>',
+                '<span> </span>',
+                '<span style="font-weight:500">Medium</span>',
+                '</p>',
+            ].join('')),
+        ).toBe('**Bold keyword** **Bold numeric** Medium');
+    });
+
+    it('combines CSS bold and italic when both styles are on the same span', () => {
+        expect(
+            convert('<p><span style="font-weight:700;font-style:italic">Bold italic</span></p>'),
+        ).toBe('***Bold italic***');
+    });
+
+    it('lets explicit normal CSS override semantic bold and italic wrappers', () => {
+        expect(
+            convert([
+                '<p>',
+                '<b style="font-weight:normal">Not bold</b>',
+                '<span> </span>',
+                '<i style="font-style:normal">Not italic</i>',
+                '</p>',
+            ].join('')),
+        ).toBe('Not bold Not italic');
+    });
+
+    it('does not duplicate formatting when CSS spans are already inside semantic tags', () => {
+        expect(
+            convert([
+                '<p>',
+                '<strong><span style="font-weight:700">bold</span></strong>',
+                ' ',
+                '<em><span style="font-style:italic">italic</span></em>',
+                ' ',
+                '<strong><span style="font-style:italic">bold italic</span></strong>',
+                '</p>',
+            ].join('')),
+        ).toBe('**bold** *italic* ***bold italic***');
+    });
+
+    it('still applies CSS spans inside semantic tags disabled by normal CSS', () => {
+        expect(
+            convert([
+                '<p>',
+                '<b style="font-weight:normal">',
+                '<span style="font-weight:700">Bold</span>',
+                '</b>',
+                ' ',
+                '<i style="font-style:normal">',
+                '<span style="font-style:italic">italic</span>',
+                '</i>',
+                '</p>',
+            ].join('')),
+        ).toBe('**Bold** *italic*');
+    });
+
+    it('does not duplicate formatting through disabled semantic wrappers inside active ancestors', () => {
+        expect(
+            convert('<p><strong><b style="font-weight:normal"><span style="font-weight:700">Bold</span></b></strong></p>'),
+        ).toBe('**Bold**');
+
+        expect(
+            convert('<p><em><i style="font-style:normal"><span style="font-style:italic">italic</span></i></em></p>'),
+        ).toBe('*italic*');
+    });
+
+    it('keeps normal semantic strong and emphasis HTML unchanged', () => {
+        expect(
+            convert('<p>Plain <strong>boldword</strong> and <em>italicword</em> end.</p>'),
+        ).toBe('Plain **boldword** and *italicword* end.');
+    });
+});

--- a/third_party/muya/src/utils/turndownService/index.ts
+++ b/third_party/muya/src/utils/turndownService/index.ts
@@ -5,6 +5,110 @@ import { identity, isHTMLElement, isHTMLInputElement } from '../../utils';
 
 const DEFAULT_KEEPS: Filter = ['u', 'mark', 'ruby', 'rt', 'sub', 'sup'];
 
+function inlineStyleValue(node: Node, name: keyof CSSStyleDeclaration): string {
+    return isHTMLElement(node) ? String(node.style[name]).trim().toLowerCase() : '';
+}
+
+function hasStrongFontWeight(node: Node): boolean {
+    const fontWeight = inlineStyleValue(node, 'fontWeight');
+    if (/^(?:bold|bolder)$/.test(fontWeight))
+        return true;
+
+    const numericWeight = Number.parseInt(fontWeight, 10);
+    return Number.isFinite(numericWeight) && numericWeight >= 600;
+}
+
+function hasNonStrongFontWeight(node: Node): boolean {
+    const fontWeight = inlineStyleValue(node, 'fontWeight');
+    if (!fontWeight)
+        return false;
+    if (/^(?:normal|lighter)$/.test(fontWeight))
+        return true;
+
+    const numericWeight = Number.parseInt(fontWeight, 10);
+    return Number.isFinite(numericWeight) && numericWeight < 600;
+}
+
+function hasItalicFontStyle(node: Node): boolean {
+    return /^(?:italic|oblique)/.test(inlineStyleValue(node, 'fontStyle'));
+}
+
+function hasNormalFontStyle(node: Node): boolean {
+    return inlineStyleValue(node, 'fontStyle') === 'normal';
+}
+
+function isStyledSpan(node: Node): boolean {
+    return isHTMLElement(node) && node.nodeName === 'SPAN';
+}
+
+function isSemanticStrong(node: Node): boolean {
+    return isHTMLElement(node) && /^(?:B|STRONG)$/.test(node.nodeName);
+}
+
+function isSemanticEmphasis(node: Node): boolean {
+    return isHTMLElement(node) && /^(?:I|EM)$/.test(node.nodeName);
+}
+
+function hasSemanticAncestor(
+    node: Node,
+    isSemantic: (node: Node) => boolean,
+    isDisabled: (node: Node) => boolean,
+): boolean {
+    let current = node.parentElement;
+    while (current) {
+        if (isSemantic(current) && !isDisabled(current))
+            return true;
+        current = current.parentElement;
+    }
+
+    return false;
+}
+
+function hasStrongSemanticAncestor(node: Node): boolean {
+    return hasSemanticAncestor(node, isSemanticStrong, hasNonStrongFontWeight);
+}
+
+function hasEmphasisSemanticAncestor(node: Node): boolean {
+    return hasSemanticAncestor(node, isSemanticEmphasis, hasNormalFontStyle);
+}
+
+function strongDelimiter(options: TurndownService.Options): string {
+    return options.strongDelimiter ?? '**';
+}
+
+function emDelimiter(options: TurndownService.Options): string {
+    return options.emDelimiter ?? '*';
+}
+
+function formatContent(
+    content: string,
+    options: TurndownService.Options,
+    strong: boolean,
+    emphasis: boolean,
+): string {
+    if (!content)
+        return '';
+
+    let result = content;
+    if (emphasis) {
+        const delimiter = emDelimiter(options);
+        result = `${delimiter}${result}${delimiter}`;
+    }
+    if (strong) {
+        const delimiter = strongDelimiter(options);
+        result = `${delimiter}${result}${delimiter}`;
+    }
+
+    return result;
+}
+
+function getInlineStyleFormatting(node: Node) {
+    return {
+        strong: hasStrongFontWeight(node) && !hasStrongSemanticAncestor(node),
+        emphasis: hasItalicFontStyle(node) && !hasEmphasisSemanticAncestor(node),
+    };
+}
+
 function isTaskListCheckbox(node: unknown) {
     return (
         isHTMLInputElement(node)
@@ -34,6 +138,43 @@ export function usePluginsAddRules(turndownService: TurndownService) {
         filter: ['del', 's'], // <strike> is not support by the web standard, so I remove the use `strike` in filter...
         replacement(content: string) {
             return `~~${content}~~`;
+        },
+    });
+
+    turndownService.addRule('nonStrongSemantic', {
+        filter(node: Node) {
+            return isSemanticStrong(node) && hasNonStrongFontWeight(node);
+        },
+        replacement(content: string, node: Node, options: TurndownService.Options) {
+            return formatContent(content, options, false, hasItalicFontStyle(node));
+        },
+    });
+
+    turndownService.addRule('nonEmphasisSemantic', {
+        filter(node: Node) {
+            return isSemanticEmphasis(node) && hasNormalFontStyle(node);
+        },
+        replacement(content: string, node: Node, options: TurndownService.Options) {
+            return formatContent(content, options, hasStrongFontWeight(node), false);
+        },
+    });
+
+    turndownService.addRule('cssInlineStyle', {
+        filter(node: Node) {
+            if (!isStyledSpan(node))
+                return false;
+
+            const formatting = getInlineStyleFormatting(node);
+            return formatting.strong || formatting.emphasis;
+        },
+        replacement(content: string, node: Node, options: TurndownService.Options) {
+            const formatting = getInlineStyleFormatting(node);
+            return formatContent(
+                content,
+                options,
+                formatting.strong,
+                formatting.emphasis,
+            );
         },
     });
 


### PR DESCRIPTION
## Upstream

Ports marktext/marktext#4699: https://github.com/marktext/marktext/pull/4699

## Android relevance

Android paste goes through Muya's clipboard/html-to-markdown pipeline in the WebView. Google Docs mobile/desktop copied HTML can contain the same CSS-based inline formatting, so this affects pasted editor content on Android directly.

## Changes

- Treat semantic `<b>/<strong>` wrappers as transparent when inline CSS explicitly says the font weight is not strong.
- Treat semantic `<i>/<em>` wrappers as transparent when inline CSS explicitly says the font style is normal.
- Convert styled spans with strong CSS `font-weight` into Markdown strong emphasis.
- Convert styled spans with italic/oblique CSS `font-style` into Markdown emphasis.
- Avoid duplicate Markdown markers when CSS-formatted spans already sit inside active semantic strong/emphasis ancestors.
- Add focused `HtmlToMarkdown` coverage for the Google Docs wrapper shape, headings/lists/links, numeric weights, combined bold+italic, disabled semantic wrappers, and normal semantic HTML behavior.

## Verification

- `pnpm --dir third_party/muya exec vitest run src/state/__tests__/htmlToMarkdown.spec.ts src/utils/__tests__/normalizePastedHtml.spec.ts src/utils/__tests__/htmlTaskListPaste.spec.ts src/utils/__tests__/htmlNestedListPaste.spec.ts src/utils/__tests__/pastedHtmlTableColspan.spec.ts`
- `pnpm build`