### PR TITLE
Add Ayu Light as a real curated custom theme

### DIFF
--- a/src/features/settings/themeRuntime.test.ts
+++ b/src/features/settings/themeRuntime.test.ts
@@ -53,13 +53,19 @@ describe('resolveAppTheme', () => {
       .toBe('cadmium-dark')
   })
 
-  it('resolves custom themes to their base mode until dedicated palettes ship', () => {
+  it('resolves Ayu Light to its dedicated palette regardless of the system scheme', () => {
     expect(resolveAppTheme({ themeMode: 'custom', customTheme: 'ayu-light' }, true))
-      .toBe('graphite-light')
+      .toBe('ayu-light')
+    expect(resolveAppTheme({ themeMode: 'custom', customTheme: 'ayu-light' }, false))
+      .toBe('ayu-light')
+    // Unknown ids normalize to the default custom theme (ayu-light).
+    expect(resolveAppTheme({ themeMode: 'custom', customTheme: 'not-a-theme' }, false))
+      .toBe('ayu-light')
+  })
+
+  it('resolves One Dark to the fixed dark theme until its palette ships', () => {
     expect(resolveAppTheme({ themeMode: 'custom', customTheme: 'one-dark' }, false))
       .toBe('cadmium-dark')
-    expect(resolveAppTheme({ themeMode: 'custom', customTheme: 'not-a-theme' }, false))
-      .toBe('graphite-light')
   })
 })
 
@@ -157,5 +163,6 @@ describe('isDarkAppTheme', () => {
   it('classifies shipped themes', () => {
     expect(isDarkAppTheme('graphite-light')).toBe(false)
     expect(isDarkAppTheme('cadmium-dark')).toBe(true)
+    expect(isDarkAppTheme('ayu-light')).toBe(false)
   })
 })

--- a/src/features/settings/themeRuntime.ts
+++ b/src/features/settings/themeRuntime.ts
@@ -10,18 +10,21 @@ import {
  * src/styles/themes/. Adding a future custom theme means adding its palette
  * file plus one entry in CUSTOM_THEME_APP_THEMES.
  */
-export type AppThemeId = 'graphite-light' | 'cadmium-dark'
+export type AppThemeId = 'graphite-light' | 'cadmium-dark' | 'ayu-light'
 
-export const APP_THEME_IDS = ['graphite-light', 'cadmium-dark'] as const satisfies readonly AppThemeId[]
+export const APP_THEME_IDS = [
+  'graphite-light',
+  'cadmium-dark',
+  'ayu-light',
+] as const satisfies readonly AppThemeId[]
 
 /**
- * Interim mapping until the Ayu Light / One Dark palettes land in their own
- * PRs: each custom theme resolves to the fixed theme of its base mode, so
- * choosing Custom is honest about light/dark today and upgrades in place
- * once the dedicated palettes exist.
+ * One Dark still resolves to the fixed dark theme until its palette lands in
+ * its own PR, so choosing it stays honest about light/dark and upgrades in
+ * place once the dedicated palette exists.
  */
 const CUSTOM_THEME_APP_THEMES: Record<(typeof APPEARANCE_CUSTOM_THEME_IDS)[number], AppThemeId> = {
-  'ayu-light': 'graphite-light',
+  'ayu-light': 'ayu-light',
   'one-dark': 'cadmium-dark',
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,7 +1,9 @@
 @import './styles/theme-tokens.css';
 @import './styles/themes/graphite-light.css';
 @import './styles/themes/cadmium-dark.css';
+@import './styles/themes/ayu-light.css';
 @import './styles/themes/prism-cadmium.css';
+@import './styles/themes/prism-ayu-light.css';
 
 /*
  * Graphite Ink layout + shared chrome.

--- a/src/styles/themeTokens.test.ts
+++ b/src/styles/themeTokens.test.ts
@@ -7,8 +7,15 @@ import { describe, expect, it } from 'vitest'
 const sourceRoot = join(process.cwd(), 'src')
 const themesRoot = join(sourceRoot, 'styles', 'themes')
 const structuralTokensPath = join(sourceRoot, 'styles', 'theme-tokens.css')
-const lightThemePath = join(themesRoot, 'graphite-light.css')
-const darkThemePath = join(themesRoot, 'cadmium-dark.css')
+
+// Every shipped palette; the first entry is the canonical token set the
+// others are compared against. Prism overlay files are rule-only (no token
+// definitions) and stay out of this list.
+const themePaths = [
+  join(themesRoot, 'graphite-light.css'),
+  join(themesRoot, 'cadmium-dark.css'),
+  join(themesRoot, 'ayu-light.css'),
+]
 
 // Tokens set from JS at runtime (inline style vars) rather than in a stylesheet.
 const RUNTIME_DEFINED_TOKENS = new Set(['--editor-area-width'])
@@ -77,19 +84,23 @@ describe('theme token architecture', () => {
     expect(offenders).toEqual([])
   })
 
-  it('defines the same token set in the light and dark themes', () => {
-    const lightTokens = collectDefinedTokens(readFileSync(lightThemePath, 'utf8'))
-    const darkTokens = collectDefinedTokens(readFileSync(darkThemePath, 'utf8'))
+  it('defines the same token set in every shipped theme', () => {
+    const [canonicalPath, ...otherPaths] = themePaths
+    const canonical = collectDefinedTokens(readFileSync(canonicalPath, 'utf8'))
 
-    const missingInDark = [...lightTokens].filter(token => !darkTokens.has(token)).sort()
-    const missingInLight = [...darkTokens].filter(token => !lightTokens.has(token)).sort()
+    for (const path of otherPaths) {
+      const tokens = collectDefinedTokens(readFileSync(path, 'utf8'))
+      const name = relative(process.cwd(), path)
+      const missing = [...canonical].filter(token => !tokens.has(token)).sort()
+      const extra = [...tokens].filter(token => !canonical.has(token)).sort()
 
-    expect(missingInDark).toEqual([])
-    expect(missingInLight).toEqual([])
+      expect(missing, `missing in ${name}`).toEqual([])
+      expect(extra, `extra in ${name}`).toEqual([])
+    }
   })
 
-  it('covers the documented semantic contract in both themes', () => {
-    for (const path of [lightThemePath, darkThemePath]) {
+  it('covers the documented semantic contract in every theme', () => {
+    for (const path of themePaths) {
       const tokens = collectDefinedTokens(readFileSync(path, 'utf8'))
       const missing = REQUIRED_SEMANTIC_TOKENS.filter(token => !tokens.has(token))
       expect(missing, `missing in ${relative(process.cwd(), path)}`).toEqual([])
@@ -98,7 +109,7 @@ describe('theme token architecture', () => {
 
   it('never references an undefined token from app styles', () => {
     const definedTokens = new Set<string>(RUNTIME_DEFINED_TOKENS)
-    for (const path of [structuralTokensPath, lightThemePath, darkThemePath]) {
+    for (const path of [structuralTokensPath, ...themePaths]) {
       for (const token of collectDefinedTokens(readFileSync(path, 'utf8'))) {
         definedTokens.add(token)
       }

--- a/src/styles/themes/ayu-light.css
+++ b/src/styles/themes/ayu-light.css
@@ -1,0 +1,102 @@
+/*
+ * Ayu Light — curated custom theme.
+ *
+ * Heritage: desktop MarkText ayu-light theme (bright near-white paper, warm
+ * #399ee6 blue, orange list markers, multicolor headings). Values are plain
+ * hex/rgba so every WebView the app can meet renders them identically.
+ *
+ * Product deviations from the desktop palette, matching the fixed themes:
+ * - `--accent` deepens the heritage blue so interactive text holds WCAG AA
+ *   on light surfaces; `--theme-color` keeps the heritage hue for editorial
+ *   accents (cursor, highlights, headings).
+ * - `--strong-color`/`--em-color` stay `inherit`: emphasis keeps the ink
+ *   color so Markdown structure never reads as broken syntax highlighting
+ *   (desktop ayu tints italics tan).
+ */
+
+:root[data-theme='ayu-light'] {
+  color-scheme: light;
+
+  /* Surfaces */
+  --app-bg: #eff1f2;
+  --surface: #fafafa;
+  --surface-muted: #f0f0f0;
+  --surface-sunken: #e5e7e9;
+  --surface-raised: #ffffff;
+
+  /* Content */
+  --text: #454c54;
+  --text-muted: #6c7680;
+  --text-faint: #949ea8;
+  --on-accent: #ffffff;
+
+  /* Lines */
+  --border: #dcdfe2;
+  --border-strong: #cbd0d5;
+  --separator: rgba(87, 95, 102, 0.16);
+
+  /* Accent — ayu blue; --accent holds AA on light surfaces. */
+  --accent: #1c72b8;
+  --accent-strong: #155b94;
+  --accent-hover: #1b6aab;
+  --accent-soft: #d9ecfb;
+  --accent-tint-10: rgba(57, 158, 230, 0.12);
+  --accent-tint-11: rgba(57, 158, 230, 0.14);
+
+  /* State */
+  --danger: #bc5152;
+  --focus-ring: rgba(57, 158, 230, 0.38);
+  --press: rgba(87, 95, 102, 0.08);
+  --scrim: rgba(30, 35, 40, 0.42);
+
+  /* Shadows — reserved for genuinely floating surfaces. */
+  --shadow-sm: 0 1px 2px rgba(38, 44, 50, 0.06);
+  --shadow-float:
+    0 12px 32px rgba(38, 44, 50, 0.16),
+    0 2px 8px rgba(38, 44, 50, 0.08);
+  --shadow-thumb: 0 2px 6px rgba(38, 44, 50, 0.22);
+  --shadow-accent: 0 2px 10px rgba(57, 158, 230, 0.35);
+
+  /* Muya bridge — desktop ayu-light palette on the writing surface. */
+  --theme-color: #399ee6;
+  --highlight-color: rgba(57, 158, 230, 0.3);
+  --selection-color: rgba(214, 226, 235, 0.8);
+  --editor-color: #575f66;
+  --editor-color-80: rgba(87, 95, 102, 0.8);
+  --editor-color-50: rgba(87, 95, 102, 0.5);
+  --editor-color-30: rgba(87, 95, 102, 0.3);
+  --editor-color-10: rgba(87, 95, 102, 0.1);
+  --editor-color-04: rgba(87, 95, 102, 0.04);
+  --editor-bg-color: var(--surface);
+  --delete-color: #f07171;
+  --icon-color: rgba(87, 95, 102, 0.56);
+  --code-block-bg-color: #f0f0f0;
+  --table-border-color: #dbdbdb;
+  --input-bg-color: #f3f3f3;
+  --button-font-color: rgba(87, 95, 102, 0.7);
+  --button-bg-color: #f0f0f0;
+  --button-border: 1px solid rgba(0, 0, 0, 0.08);
+  --button-bg-color-hover: #e5e5e5;
+  --button-border-hover: 1px solid rgba(0, 0, 0, 0.12);
+  --button-bg-color-active: #dbdbdb;
+  --button-border-active: 1px solid rgba(0, 0, 0, 0.08);
+  --button-border-focus: 1px solid var(--accent);
+  --float-bg-color: var(--surface-raised);
+  --float-hover-color: rgba(87, 95, 102, 0.06);
+  --float-border-color: rgba(0, 0, 0, 0.08);
+  --float-shadow: var(--shadow-float);
+  --link-color: var(--accent);
+  --h1-color: #fa8d3e;
+  --h2-color: #399ee6;
+  --h3-color: #86b300;
+  --h4-color: #55b4d4;
+  --h5-color: #a37acc;
+  --h6-color: #f07171;
+  --blockquote-text-color: rgba(87, 95, 102, 0.6);
+  --blockquote-border-color: #abb0b6;
+  /* Emphasis keeps the ink color — see graphite-light.css. */
+  --strong-color: inherit;
+  --em-color: inherit;
+  --list-marker-color: #fa8d3e;
+  --hr-color: #dbdbdb;
+}

--- a/src/styles/themes/prism-ayu-light.css
+++ b/src/styles/themes/prism-ayu-light.css
@@ -1,0 +1,73 @@
+/*
+ * Prism syntax palette for Ayu Light.
+ *
+ * Muya bundles a generic light Prism theme unconditionally; these rules
+ * re-color the tokens whenever Ayu Light is active. Selectors mirror
+ * third_party/muya/src/assets/styles/prismjs/light.theme.css with a
+ * [data-theme] scope, so they win on specificity without !important.
+ * Palette ported from the desktop prism ayu-light theme.
+ */
+
+[data-theme='ayu-light'] .token.comment,
+[data-theme='ayu-light'] .token.prolog,
+[data-theme='ayu-light'] .token.doctype,
+[data-theme='ayu-light'] .token.cdata {
+  color: #abb0b6;
+}
+
+[data-theme='ayu-light'] .token.punctuation {
+  color: #575f66;
+}
+
+[data-theme='ayu-light'] .token.property,
+[data-theme='ayu-light'] .token.tag,
+[data-theme='ayu-light'] .token.constant,
+[data-theme='ayu-light'] .token.symbol {
+  color: #f07171;
+}
+
+[data-theme='ayu-light'] .token.boolean,
+[data-theme='ayu-light'] .token.number {
+  color: #a37acc;
+}
+
+[data-theme='ayu-light'] .token.selector,
+[data-theme='ayu-light'] .token.attr-name,
+[data-theme='ayu-light'] .token.string,
+[data-theme='ayu-light'] .token.char,
+[data-theme='ayu-light'] .token.builtin {
+  color: #86b300;
+}
+
+[data-theme='ayu-light'] .token.inserted {
+  color: #86b300;
+}
+
+[data-theme='ayu-light'] .token.deleted {
+  color: #f07171;
+}
+
+[data-theme='ayu-light'] .token.operator,
+[data-theme='ayu-light'] .token.entity,
+[data-theme='ayu-light'] .token.url,
+[data-theme='ayu-light'] .language-css .token.string,
+[data-theme='ayu-light'] .style .token.string {
+  color: #4cbf99;
+}
+
+[data-theme='ayu-light'] .token.atrule,
+[data-theme='ayu-light'] .token.attr-value,
+[data-theme='ayu-light'] .token.function,
+[data-theme='ayu-light'] .token.class-name {
+  color: #f2ae49;
+}
+
+[data-theme='ayu-light'] .token.keyword {
+  color: #fa8d3e;
+}
+
+[data-theme='ayu-light'] .token.regex,
+[data-theme='ayu-light'] .token.important,
+[data-theme='ayu-light'] .token.variable {
+  color: #399ee6;
+}


### PR DESCRIPTION
## Summary

Ships **Ayu Light** as a real curated custom theme on the theme architecture from #79 — the first theme to use the intended extension path: one palette file, one Prism overlay, one registry entry. The theme model is unchanged (System / Light / Dark / Custom); Custom → Ayu Light now applies its dedicated palette instead of falling back to graphite-light. One Dark keeps its interim fixed-dark mapping until its own palette lands in a separate PR.

## What changed

- **`src/styles/themes/ayu-light.css`** (new): full semantic contract plus the Muya editor bridge under `:root[data-theme='ayu-light']`. Heritage values come from the desktop `ayu-light.theme.css` — bright `#fafafa` paper, warm `#399ee6` blue, the six-color heading scale (orange/blue/green/cyan/purple/red), orange list markers — with the two product deviations already established for the fixed themes:
  - interactive text uses an AA-deepened accent (`#1c72b8`; the heritage blue is ~2.8:1 on light surfaces) while `--theme-color` keeps the heritage hue for editorial accents;
  - `--strong-color`/`--em-color` stay `inherit` so emphasis keeps the ink color (desktop ayu tints italics tan).
- **`src/styles/themes/prism-ayu-light.css`** (new): code-block syntax palette ported from the desktop prism ayu-light theme, scoped by `[data-theme='ayu-light']` — wins over Muya's bundled light Prism theme on specificity, no `!important`.
- **`themeRuntime.ts`**: `'ayu-light'` joins `AppThemeId`/`APP_THEME_IDS`; the custom-theme registry maps it to its own palette. `isDarkAppTheme` needed no change, so status-bar icons automatically stay dark-on-light.
- **`style.css`**: two `@import` lines.
- **Tests**: the token parity and semantic-contract tests are generalized from a light/dark pair to *every shipped theme* compared against a canonical set (graphite-light), so future palettes are automatically held to the same contract. Theme-runtime specs updated: Ayu Light resolves to its own palette regardless of the system scheme (including unknown-id normalization), One Dark keeps the documented fallback.

No settings descriptors, frontend structure, or theme-model changes.

## Verification

- 213 unit tests passing (three-theme token parity, contract coverage, runtime resolution).
- `pnpm lint`, `pnpm build` clean.
- Visual: verified in the browser at mobile viewport and on the API 35 emulator via debug APK — heading scale, orange list markers, ayu Prism palette, AA link blue, ink-colored emphasis, live switching from Settings → Appearance → Custom → Ayu Light, and dark status-bar icons.

## Follow-up (out of scope)

- One Dark as its own palette PR — same recipe; its registry entry and the interim-fallback comment in `themeRuntime.ts` flip at that point.
