### PR TITLE
Add One Dark as the final curated custom theme

### DIFF
--- a/src/features/settings/themeRuntime.test.ts
+++ b/src/features/settings/themeRuntime.test.ts
@@ -63,9 +63,11 @@ describe('resolveAppTheme', () => {
       .toBe('ayu-light')
   })
 
-  it('resolves One Dark to the fixed dark theme until its palette ships', () => {
+  it('resolves One Dark to its dedicated palette regardless of the system scheme', () => {
     expect(resolveAppTheme({ themeMode: 'custom', customTheme: 'one-dark' }, false))
-      .toBe('cadmium-dark')
+      .toBe('one-dark')
+    expect(resolveAppTheme({ themeMode: 'custom', customTheme: 'one-dark' }, true))
+      .toBe('one-dark')
   })
 })
 
@@ -164,5 +166,6 @@ describe('isDarkAppTheme', () => {
     expect(isDarkAppTheme('graphite-light')).toBe(false)
     expect(isDarkAppTheme('cadmium-dark')).toBe(true)
     expect(isDarkAppTheme('ayu-light')).toBe(false)
+    expect(isDarkAppTheme('one-dark')).toBe(true)
   })
 })

--- a/src/features/settings/themeRuntime.ts
+++ b/src/features/settings/themeRuntime.ts
@@ -10,26 +10,24 @@ import {
  * src/styles/themes/. Adding a future custom theme means adding its palette
  * file plus one entry in CUSTOM_THEME_APP_THEMES.
  */
-export type AppThemeId = 'graphite-light' | 'cadmium-dark' | 'ayu-light'
+export type AppThemeId = 'graphite-light' | 'cadmium-dark' | 'ayu-light' | 'one-dark'
 
 export const APP_THEME_IDS = [
   'graphite-light',
   'cadmium-dark',
   'ayu-light',
+  'one-dark',
 ] as const satisfies readonly AppThemeId[]
 
-/**
- * One Dark still resolves to the fixed dark theme until its palette lands in
- * its own PR, so choosing it stays honest about light/dark and upgrades in
- * place once the dedicated palette exists.
- */
 const CUSTOM_THEME_APP_THEMES: Record<(typeof APPEARANCE_CUSTOM_THEME_IDS)[number], AppThemeId> = {
   'ayu-light': 'ayu-light',
-  'one-dark': 'cadmium-dark',
+  'one-dark': 'one-dark',
 }
 
+const DARK_APP_THEMES: readonly AppThemeId[] = ['cadmium-dark', 'one-dark']
+
 export function isDarkAppTheme(theme: AppThemeId): boolean {
-  return theme === 'cadmium-dark'
+  return DARK_APP_THEMES.includes(theme)
 }
 
 export function resolveAppTheme(

--- a/src/style.css
+++ b/src/style.css
@@ -2,8 +2,10 @@
 @import './styles/themes/graphite-light.css';
 @import './styles/themes/cadmium-dark.css';
 @import './styles/themes/ayu-light.css';
+@import './styles/themes/one-dark.css';
 @import './styles/themes/prism-cadmium.css';
 @import './styles/themes/prism-ayu-light.css';
+@import './styles/themes/prism-one-dark.css';
 
 /*
  * Graphite Ink layout + shared chrome.

--- a/src/styles/themeTokens.test.ts
+++ b/src/styles/themeTokens.test.ts
@@ -15,6 +15,7 @@ const themePaths = [
   join(themesRoot, 'graphite-light.css'),
   join(themesRoot, 'cadmium-dark.css'),
   join(themesRoot, 'ayu-light.css'),
+  join(themesRoot, 'one-dark.css'),
 ]
 
 // Tokens set from JS at runtime (inline style vars) rather than in a stylesheet.

--- a/src/styles/themes/one-dark.css
+++ b/src/styles/themes/one-dark.css
@@ -1,0 +1,100 @@
+/*
+ * One Dark — curated custom theme.
+ *
+ * Heritage: desktop MarkText one-dark theme (Atom One Dark: #282c34 ground,
+ * slate-blue #4d78cc accent, golden blockquote border, the classic
+ * red/blue/green/cyan/purple/yellow heading scale). Values are plain
+ * hex/rgba so every WebView the app can meet renders them identically.
+ *
+ * Product deviation matching the other themes: `--strong-color`/`--em-color`
+ * stay `inherit` so emphasis keeps the ink color (desktop one-dark tints
+ * bold golden and italics purple).
+ */
+
+:root[data-theme='one-dark'] {
+  color-scheme: dark;
+
+  /* Surfaces */
+  --app-bg: #21252b;
+  --surface: #282c34;
+  --surface-muted: #30363f;
+  --surface-sunken: #1c2026;
+  --surface-raised: #343a45;
+
+  /* Content */
+  --text: #b9c1cc;
+  --text-muted: #949dab;
+  --text-faint: #6f7887;
+  --on-accent: #ffffff;
+
+  /* Lines */
+  --border: #3a3f4b;
+  --border-strong: #4b5363;
+  --separator: rgba(255, 255, 255, 0.08);
+
+  /* Accent — heritage slate blue; "strong" means more contrast, so it
+     lightens here instead of darkening. */
+  --accent: #4d78cc;
+  --accent-strong: #82a7ef;
+  --accent-hover: #5d88da;
+  --accent-soft: rgba(77, 120, 204, 0.22);
+  --accent-tint-10: rgba(77, 120, 204, 0.14);
+  --accent-tint-11: rgba(77, 120, 204, 0.16);
+
+  /* State */
+  --danger: #e06c75;
+  --focus-ring: rgba(86, 138, 242, 0.45);
+  --press: rgba(255, 255, 255, 0.08);
+  --scrim: rgba(0, 0, 0, 0.6);
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-float:
+    0 12px 32px rgba(0, 0, 0, 0.5),
+    0 2px 8px rgba(0, 0, 0, 0.35);
+  --shadow-thumb: 0 2px 6px rgba(0, 0, 0, 0.4);
+  --shadow-accent: 0 2px 10px rgba(77, 120, 204, 0.35);
+
+  /* Muya bridge — desktop one-dark palette on the writing surface. */
+  --theme-color: #4d78cc;
+  --highlight-color: rgba(255, 255, 255, 0.06);
+  --selection-color: rgba(103, 118, 150, 0.38);
+  --editor-color: #9da5b4;
+  --editor-color-80: #9da5b4;
+  --editor-color-50: rgba(157, 165, 180, 0.5);
+  --editor-color-30: rgba(157, 165, 180, 0.3);
+  --editor-color-10: rgba(157, 165, 180, 0.1);
+  --editor-color-04: rgba(157, 165, 180, 0.04);
+  --editor-bg-color: var(--surface);
+  --delete-color: #ff6969;
+  --icon-color: rgba(255, 255, 255, 0.56);
+  --code-block-bg-color: #3a3f4b;
+  --table-border-color: #363839;
+  --input-bg-color: rgba(0, 0, 0, 0.1);
+  --button-font-color: #9da5b4;
+  --button-bg-color: linear-gradient(#3a3f4b, #353b45);
+  --button-border: 1px solid #181a1f;
+  --button-bg-color-hover: linear-gradient(#3e4451, #3a3f4b);
+  --button-border-hover: 1px solid #181a1f;
+  --button-bg-color-active: #2c313a;
+  --button-border-active: 1px solid #181a1f;
+  --button-border-focus: 1px solid #568af2;
+  --float-bg-color: var(--surface-raised);
+  --float-hover-color: #3a3f4b;
+  --float-border-color: #181a1f;
+  --float-shadow: var(--shadow-float);
+  --link-color: #61afef;
+  --h1-color: #e06c75;
+  --h2-color: #61afef;
+  --h3-color: #98c379;
+  --h4-color: #56b6c2;
+  --h5-color: #c678dd;
+  --h6-color: #e5c07b;
+  --blockquote-text-color: rgba(157, 165, 180, 0.6);
+  --blockquote-border-color: #e2c08d;
+  /* Emphasis keeps the ink color — see graphite-light.css. */
+  --strong-color: inherit;
+  --em-color: inherit;
+  --list-marker-color: #e06c75;
+  --hr-color: #4b5362;
+}

--- a/src/styles/themes/prism-one-dark.css
+++ b/src/styles/themes/prism-one-dark.css
@@ -1,0 +1,75 @@
+/*
+ * Prism syntax palette for One Dark.
+ *
+ * Muya bundles a generic light Prism theme unconditionally; these rules
+ * re-color the tokens whenever One Dark is active. Selectors mirror
+ * third_party/muya/src/assets/styles/prismjs/light.theme.css with a
+ * [data-theme] scope, so they win on specificity without !important.
+ * Palette ported from the desktop prism one-dark theme (Atom One Dark).
+ */
+
+[data-theme='one-dark'] .token.comment,
+[data-theme='one-dark'] .token.prolog,
+[data-theme='one-dark'] .token.doctype,
+[data-theme='one-dark'] .token.cdata {
+  color: #5c6370;
+}
+
+[data-theme='one-dark'] .token.punctuation {
+  color: #abb2bf;
+}
+
+[data-theme='one-dark'] .token.selector,
+[data-theme='one-dark'] .token.tag {
+  color: #e06c75;
+}
+
+[data-theme='one-dark'] .token.property,
+[data-theme='one-dark'] .token.boolean,
+[data-theme='one-dark'] .token.number,
+[data-theme='one-dark'] .token.constant,
+[data-theme='one-dark'] .token.symbol,
+[data-theme='one-dark'] .token.attr-name {
+  color: #d19a66;
+}
+
+[data-theme='one-dark'] .token.string,
+[data-theme='one-dark'] .token.char,
+[data-theme='one-dark'] .token.attr-value,
+[data-theme='one-dark'] .token.builtin {
+  color: #98c379;
+}
+
+[data-theme='one-dark'] .token.inserted {
+  color: #98c379;
+  background: rgba(152, 195, 121, 0.15);
+}
+
+[data-theme='one-dark'] .token.deleted {
+  color: #d19a66;
+  background: rgba(224, 108, 117, 0.15);
+}
+
+[data-theme='one-dark'] .token.operator,
+[data-theme='one-dark'] .token.entity,
+[data-theme='one-dark'] .token.url,
+[data-theme='one-dark'] .language-css .token.string,
+[data-theme='one-dark'] .style .token.string {
+  color: #56b6c2;
+}
+
+[data-theme='one-dark'] .token.atrule,
+[data-theme='one-dark'] .token.keyword {
+  color: #c678dd;
+}
+
+[data-theme='one-dark'] .token.function,
+[data-theme='one-dark'] .token.class-name {
+  color: #61afef;
+}
+
+[data-theme='one-dark'] .token.regex,
+[data-theme='one-dark'] .token.important,
+[data-theme='one-dark'] .token.variable {
+  color: #c678dd;
+}


### PR DESCRIPTION
## Summary

Ships **One Dark** as the final curated custom theme, completing the theme set on the architecture from #79: Graphite Light / Cadmium Dark as the fixed Light/Dark modes, Ayu Light (#81) and One Dark under Custom. Same extension recipe as #81 — one palette file, one Prism overlay, one registry entry. The theme model is unchanged.

## What changed

- **`src/styles/themes/one-dark.css`** (new): full semantic contract plus the Muya editor bridge under `:root[data-theme='one-dark']`. Heritage values come from the desktop `one-dark.theme.css` (Atom One Dark): `#282c34` ground, slate-blue `#4d78cc` accent, the **golden blockquote border `#e2c08d`** that signs this theme, the classic red/blue/green/cyan/purple/yellow heading scale, red list markers. App-shell layering follows the dark-theme conventions: `#21252b` app background, lighter raised surfaces for floating sheets, and `--accent-strong` lightens (`#82a7ef`) since "strong" means more contrast against a dark ground. The established product deviation applies: `--strong-color`/`--em-color` stay `inherit` (desktop tints bold golden and italics purple).
- **`src/styles/themes/prism-one-dark.css`** (new): code-block syntax palette ported from the desktop Atom One Dark Prism theme, scoped by `[data-theme='one-dark']`.
- **`themeRuntime.ts`**: `'one-dark'` joins `AppThemeId`/`APP_THEME_IDS`; the custom-theme registry switches it from the interim cadmium-dark fallback to its dedicated palette, and the interim-fallback comment is gone (both custom themes are now real). `isDarkAppTheme` becomes a dark-theme list (`cadmium-dark`, `one-dark`) so **status-bar icons correctly turn light under One Dark**.
- **`style.css`**: two `@import` lines.
- **Tests**: token parity and semantic-contract coverage extended to all four shipped themes; runtime specs assert One Dark resolves to its own palette regardless of the system scheme and classifies as dark.

## Verification

- 213 unit tests passing (four-theme token parity, contract coverage, runtime resolution, dark classification).
- `pnpm lint`, `pnpm build` clean.
- Visual: verified in the browser at mobile viewport and on the API 35 emulator via debug APK — heading scale, golden blockquote border, red list markers, Atom Prism palette, ink-colored emphasis, live switching between Ayu Light / One Dark and back to the fixed modes with no residue, and light status-bar icons under One Dark.

This completes the curated theme plan; no follow-up themes are scheduled.
