### PR TITLE
Extract Android incoming-document orchestration from App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,10 +15,7 @@ import {
   shareAndroidMarkdownDocument,
   shareAndroidMarkdownDocuments,
   writeAndroidMarkdownDocument,
-  type AndroidOpenWithDocumentEvent,
-  type AndroidShareDocumentEvent,
   type OpenedAndroidDocument,
-  type SharedAndroidDocument,
 } from './lib/androidDocuments'
 import {
   ensureAndroidImageResolver,
@@ -31,9 +28,8 @@ import {
   type AppLifecycleListeners,
 } from './lib/appLifecycleListeners'
 import {
-  installAndroidDocumentIntentListeners as installAndroidDocumentIntentListenerHandles,
-  type AndroidDocumentIntentListeners,
-} from './features/android-documents/androidDocumentIntentListeners'
+  createIncomingDocumentOrchestration,
+} from './features/android-documents/incomingDocumentOrchestration'
 import {
   addAndroidSelectionTapListener,
   finishAndroidEditorSelectionActionMode,
@@ -80,12 +76,7 @@ import {
 } from './features/document-session/documentSettings'
 import {
   createAndroidDocumentOpenResult,
-  createAndroidOpenWithDocumentEventAction,
-  createAndroidShareDocumentEventAction,
-  createSharedTextDocumentOpenResult,
-  getIncomingDocumentPreservationAction,
   openAndroidMarkdownDocumentWorkflow,
-  shouldKeepAndroidRecoveryAfterPreserveFailure,
   type AndroidDocumentOpenSource,
 } from './features/android-documents/androidDocumentOpenWorkflow'
 import {
@@ -310,7 +301,6 @@ let androidSaveTimer: number | null = null
 let androidSaveInFlight = false
 let androidSaveRequestedAfterCurrent = false
 let appLifecycleListeners: AppLifecycleListeners | null = null
-let androidDocumentIntentListeners: AndroidDocumentIntentListeners | null = null
 let pendingInlineInsertRange: Range | null = null
 let startupActionTimer: number | null = null
 let editorSelectionDiagnosticCleanup: (() => void) | null = null
@@ -1787,24 +1777,6 @@ async function openAndroidDocumentResult(
   releaseEditorFocusAfterOpen()
 }
 
-async function openSharedTextDocument(document: SharedAndroidDocument) {
-  const openResult = createSharedTextDocumentOpenResult(document, {
-    sharedTextImportedMessage: SHARED_TEXT_IMPORTED_MESSAGE,
-    logger: androidDocumentLog,
-  })
-
-  if (canPersistLocalDrafts()) {
-    persistLocalDrafts(upsertLocalDraft(localDrafts.value, openResult.localDraft))
-  }
-  homeNotice.value = openResult.homeNotice
-  promptLocalDraftSaveOnExit.value = openResult.promptLocalDraftSaveOnExit
-  currentAndroidDocumentCanWrite.value = openResult.currentAndroidDocumentCanWrite
-  documentState.value = openResult.documentState
-  await openEditor(openResult.markdown)
-  status.value = openResult.statusAfterOpen
-  releaseEditorFocusAfterOpen()
-}
-
 async function openFileFromAndroid() {
   homeNotice.value = null
 
@@ -1820,84 +1792,6 @@ async function openFileFromAndroid() {
   } else if (result.kind === 'failed') {
     homeNotice.value = result.homeNotice
   }
-}
-
-async function preserveCurrentDocumentBeforeIncomingOpen() {
-  const preservationAction = getIncomingDocumentPreservationAction({
-    currentScreen: currentScreen.value,
-    hasEditor: Boolean(editor),
-    autosaveTarget: documentState.value.autosaveTarget,
-  })
-
-  if (preservationAction.kind === 'none') {
-    return
-  }
-
-  appLog.info('preserve current document before incoming Android document')
-
-  if (preservationAction.kind === 'save-android-document') {
-    syncDocumentFromEditor(documentState.value.isDirty, true)
-    const sourceUri = documentState.value.sourceUri
-    const saved = await saveAndroidDocument()
-    if (sourceUri && shouldKeepAndroidRecoveryAfterPreserveFailure(saved, sourceUri, documentState.value.markdown)) {
-      persistAndroidRecoveryDraft(sourceUri, documentState.value.markdown)
-    }
-    return
-  }
-
-  saveDraft()
-}
-
-async function handleAndroidOpenWithDocumentEvent(event: AndroidOpenWithDocumentEvent) {
-  const action = createAndroidOpenWithDocumentEventAction(event, {
-    getAndroidDocumentUserMessage,
-    logger: androidDocumentLog,
-  })
-
-  if (action.kind === 'rejected') {
-    homeNotice.value = action.message
-    status.value = action.message
-    return
-  }
-
-  await preserveCurrentDocumentBeforeIncomingOpen()
-  draftExitPromptOpen.value = false
-  androidExitPromptOpen.value = false
-  closeEditorMenu()
-  closeEditorToolbar()
-  await openAndroidDocumentResult(action.document, {
-    source: action.source,
-    remember: action.remember,
-  })
-}
-
-async function handleAndroidShareDocumentEvent(event: AndroidShareDocumentEvent) {
-  const action = createAndroidShareDocumentEventAction(event, {
-    getAndroidDocumentUserMessage,
-    logger: androidDocumentLog,
-  })
-
-  if (action.kind === 'rejected') {
-    homeNotice.value = action.message
-    status.value = action.message
-    return
-  }
-
-  await preserveCurrentDocumentBeforeIncomingOpen()
-  draftExitPromptOpen.value = false
-  androidExitPromptOpen.value = false
-  closeEditorMenu()
-  closeEditorToolbar()
-
-  if (action.kind === 'open-document') {
-    await openAndroidDocumentResult(action.document, {
-      source: action.source,
-      remember: action.remember,
-    })
-    return
-  }
-
-  await openSharedTextDocument(action.document)
 }
 
 function getSelectedDocumentRecords() {
@@ -2390,28 +2284,39 @@ function installAppLifecycleListeners() {
   })
 }
 
-function installAndroidDocumentIntentListeners() {
-  if (androidDocumentIntentListeners) {
-    return
-  }
-
-  androidDocumentIntentListeners = installAndroidDocumentIntentListenerHandles({
-    onOpenWithDocument: event => {
-      void handleAndroidOpenWithDocumentEvent(event)
-    },
-    onShareDocument: event => {
-      void handleAndroidShareDocumentEvent(event)
-    },
-    logger: androidDocumentLog,
-  })
-}
+const incomingDocuments = createIncomingDocumentOrchestration({
+  currentScreen,
+  documentState,
+  localDrafts,
+  homeNotice,
+  status,
+  draftExitPromptOpen,
+  androidExitPromptOpen,
+  promptLocalDraftSaveOnExit,
+  currentAndroidDocumentCanWrite,
+  sharedTextImportedMessage: SHARED_TEXT_IMPORTED_MESSAGE,
+  hasEditor: () => Boolean(editor),
+  openEditor,
+  releaseEditorFocusAfterOpen,
+  closeEditorMenu,
+  closeEditorToolbar,
+  openAndroidDocumentResult,
+  saveAndroidDocument,
+  saveDraft,
+  syncDocumentFromEditor,
+  persistAndroidRecoveryDraft,
+  canPersistLocalDrafts,
+  persistLocalDrafts,
+  getAndroidDocumentUserMessage,
+  appLogger: appLog,
+  documentLogger: androidDocumentLog,
+})
 
 function removeAppLifecycleListeners() {
   appLifecycleListeners?.remove()
   appLifecycleListeners = null
 
-  androidDocumentIntentListeners?.remove()
-  androidDocumentIntentListeners = null
+  incomingDocuments.removeListeners()
 }
 
 function keepLocalDraftAndShowHome() {
@@ -2515,7 +2420,7 @@ onMounted(() => {
     characters: characterCount.value,
   })
 
-  installAndroidDocumentIntentListeners()
+  incomingDocuments.installListeners()
   startupActionTimer = window.setTimeout(() => {
     startupActionTimer = null
     applyDocumentStartupAction()

--- a/src/features/android-documents/incomingDocumentOrchestration.test.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createIncomingDocumentOrchestration } from './incomingDocumentOrchestration'
+import { installAndroidDocumentIntentListeners } from './androidDocumentIntentListeners'
+import { getAndroidDocumentUserMessage, AndroidDocumentError } from '../../lib/androidDocuments'
+import { createUntitledDocument } from '../../lib/documentState'
+import type { AppScreen } from '../../lib/appExitDecisions'
+import type { LocalDraftRecord } from '../../lib/localDrafts'
+
+vi.mock('./androidDocumentIntentListeners', () => ({
+  installAndroidDocumentIntentListeners: vi.fn(() => ({ remove: vi.fn() })),
+}))
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+const incomingDocument = {
+  canceled: false as const,
+  sourceUri: 'content://test/incoming.md',
+  displayName: 'incoming.md',
+  providerName: 'Documents',
+  pathHint: 'incoming.md',
+  mimeType: 'text/markdown',
+  markdown: '# Incoming',
+  canWrite: true,
+  persisted: true,
+}
+
+const sharedTextDocument = {
+  canceled: false as const,
+  sourceUri: null,
+  displayName: 'Shared text',
+  providerName: null,
+  pathHint: null,
+  mimeType: 'text/plain',
+  markdown: '# Shared note',
+  canWrite: false,
+  persisted: false,
+  shareKind: 'text' as const,
+}
+
+function createOrchestration(overrides: {
+  currentScreen?: AppScreen
+  documentState?: ReturnType<typeof createUntitledDocument>
+  hasEditor?: boolean
+  saveResult?: boolean
+  canPersistDrafts?: boolean
+} = {}) {
+  const options = {
+    currentScreen: ref<AppScreen>(overrides.currentScreen ?? 'home'),
+    documentState: ref(
+      overrides.documentState
+      ?? createUntitledDocument({ markdown: '', autosaveTarget: 'local-draft' }),
+    ),
+    localDrafts: ref<LocalDraftRecord[]>([]),
+    homeNotice: ref<string | null>(null),
+    status: ref('Ready'),
+    draftExitPromptOpen: ref(true),
+    androidExitPromptOpen: ref(true),
+    promptLocalDraftSaveOnExit: ref(false),
+    currentAndroidDocumentCanWrite: ref(true),
+    sharedTextImportedMessage: 'Imported shared text as a local draft.',
+    hasEditor: () => overrides.hasEditor ?? false,
+    openEditor: vi.fn().mockResolvedValue(undefined),
+    releaseEditorFocusAfterOpen: vi.fn(),
+    closeEditorMenu: vi.fn(),
+    closeEditorToolbar: vi.fn(),
+    openAndroidDocumentResult: vi.fn().mockResolvedValue(undefined),
+    saveAndroidDocument: vi.fn().mockResolvedValue(overrides.saveResult ?? true),
+    saveDraft: vi.fn(),
+    syncDocumentFromEditor: vi.fn(),
+    persistAndroidRecoveryDraft: vi.fn(),
+    canPersistLocalDrafts: () => overrides.canPersistDrafts ?? true,
+    persistLocalDrafts: vi.fn(),
+    getAndroidDocumentUserMessage,
+    appLogger: noopLogger,
+    documentLogger: noopLogger,
+  }
+
+  return { orchestration: createIncomingDocumentOrchestration(options), options }
+}
+
+describe('incomingDocumentOrchestration', () => {
+  it('surfaces rejected open-with events without opening anything', async () => {
+    const { orchestration, options } = createOrchestration()
+    const error = new AndroidDocumentError(
+      'UNSUPPORTED_OPEN_WITH_DOCUMENT',
+      'Open a Markdown document',
+    )
+
+    await orchestration.handleOpenWithDocumentEvent({ document: null, error })
+
+    expect(options.homeNotice.value).toBe('Open a Markdown file.')
+    expect(options.status.value).toBe('Open a Markdown file.')
+    expect(options.openAndroidDocumentResult).not.toHaveBeenCalled()
+    expect(options.saveDraft).not.toHaveBeenCalled()
+  })
+
+  it('opens an open-with document from home without preserving anything', async () => {
+    const { orchestration, options } = createOrchestration({ currentScreen: 'home' })
+
+    await orchestration.handleOpenWithDocumentEvent({ document: incomingDocument, error: null })
+
+    expect(options.saveDraft).not.toHaveBeenCalled()
+    expect(options.saveAndroidDocument).not.toHaveBeenCalled()
+    expect(options.draftExitPromptOpen.value).toBe(false)
+    expect(options.androidExitPromptOpen.value).toBe(false)
+    expect(options.closeEditorMenu).toHaveBeenCalled()
+    expect(options.closeEditorToolbar).toHaveBeenCalled()
+    expect(options.openAndroidDocumentResult).toHaveBeenCalledWith(incomingDocument, {
+      source: 'open-with',
+      remember: true,
+    })
+  })
+
+  it('preserves an open local draft before an incoming open', async () => {
+    const { orchestration, options } = createOrchestration({
+      currentScreen: 'editor',
+      hasEditor: true,
+      documentState: createUntitledDocument({ markdown: '# Draft', autosaveTarget: 'local-draft' }),
+    })
+
+    await orchestration.handleOpenWithDocumentEvent({ document: incomingDocument, error: null })
+
+    expect(options.saveDraft).toHaveBeenCalled()
+    expect(options.saveAndroidDocument).not.toHaveBeenCalled()
+  })
+
+  it('keeps a recovery draft when preserving an Android document fails to save', async () => {
+    const documentState = {
+      ...createUntitledDocument({
+        markdown: '# Device doc',
+        autosaveTarget: 'android-document',
+        sourceUri: 'content://test/current.md',
+      }),
+      isDirty: true,
+    }
+    const { orchestration, options } = createOrchestration({
+      currentScreen: 'editor',
+      hasEditor: true,
+      documentState,
+      saveResult: false,
+    })
+
+    await orchestration.handleOpenWithDocumentEvent({ document: incomingDocument, error: null })
+
+    expect(options.syncDocumentFromEditor).toHaveBeenCalledWith(true, true)
+    expect(options.saveAndroidDocument).toHaveBeenCalled()
+    expect(options.persistAndroidRecoveryDraft).toHaveBeenCalledWith(
+      'content://test/current.md',
+      '# Device doc',
+    )
+    expect(options.openAndroidDocumentResult).toHaveBeenCalled()
+  })
+
+  it('routes a shared Markdown file through the shared open path', async () => {
+    const { orchestration, options } = createOrchestration()
+
+    await orchestration.handleShareDocumentEvent({
+      document: { ...sharedTextDocument, sourceUri: 'content://test/shared.md', shareKind: 'stream' },
+      error: null,
+    })
+
+    expect(options.openAndroidDocumentResult).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceUri: 'content://test/shared.md' }),
+      { source: 'share', remember: false },
+    )
+  })
+
+  it('imports shared text as a local draft and opens it', async () => {
+    const { orchestration, options } = createOrchestration()
+
+    await orchestration.handleShareDocumentEvent({ document: sharedTextDocument, error: null })
+
+    expect(options.persistLocalDrafts).toHaveBeenCalledTimes(1)
+    const [drafts] = options.persistLocalDrafts.mock.calls[0]
+    expect(drafts[0].markdown).toBe('# Shared note')
+    expect(options.documentState.value.autosaveTarget).toBe('local-draft')
+    expect(options.promptLocalDraftSaveOnExit.value).toBe(true)
+    expect(options.openEditor).toHaveBeenCalledWith('# Shared note')
+    expect(options.status.value).toBe('Imported shared text as a local draft.')
+    expect(options.releaseEditorFocusAfterOpen).toHaveBeenCalled()
+  })
+
+  it('still opens shared text when local drafts are disabled', async () => {
+    const { orchestration, options } = createOrchestration({ canPersistDrafts: false })
+
+    await orchestration.handleShareDocumentEvent({ document: sharedTextDocument, error: null })
+
+    expect(options.persistLocalDrafts).not.toHaveBeenCalled()
+    expect(options.openEditor).toHaveBeenCalledWith('# Shared note')
+  })
+
+  it('installs intent listeners once and can reinstall after removal', () => {
+    const installMock = vi.mocked(installAndroidDocumentIntentListeners)
+    installMock.mockClear()
+    const { orchestration } = createOrchestration()
+
+    orchestration.installListeners()
+    orchestration.installListeners()
+    expect(installMock).toHaveBeenCalledTimes(1)
+
+    const handle = installMock.mock.results[0].value
+    orchestration.removeListeners()
+    expect(handle.remove).toHaveBeenCalledTimes(1)
+
+    orchestration.installListeners()
+    expect(installMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/features/android-documents/incomingDocumentOrchestration.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.ts
@@ -1,0 +1,207 @@
+import type { Ref } from 'vue'
+import {
+  installAndroidDocumentIntentListeners,
+  type AndroidDocumentIntentListeners,
+} from './androidDocumentIntentListeners'
+import {
+  createAndroidOpenWithDocumentEventAction,
+  createAndroidShareDocumentEventAction,
+  createSharedTextDocumentOpenResult,
+  getIncomingDocumentPreservationAction,
+  shouldKeepAndroidRecoveryAfterPreserveFailure,
+  type AndroidDocumentOpenSource,
+} from './androidDocumentOpenWorkflow'
+import type {
+  AndroidOpenWithDocumentEvent,
+  AndroidShareDocumentEvent,
+  OpenedAndroidDocument,
+  SharedAndroidDocument,
+} from '../../lib/androidDocuments'
+import type { AppScreen } from '../../lib/appExitDecisions'
+import type { MarkdownDocumentState } from '../../lib/documentState'
+import { upsertLocalDraft, type LocalDraftRecord } from '../../lib/localDrafts'
+
+interface OrchestrationLogger {
+  info(message: string, context?: unknown): void
+  warn(message: string, context?: unknown): void
+  error(message: string, context?: unknown): void
+}
+
+export interface IncomingDocumentOrchestrationOptions {
+  // App-owned state the incoming flows read and write.
+  currentScreen: Ref<AppScreen>
+  documentState: Ref<MarkdownDocumentState>
+  localDrafts: Ref<LocalDraftRecord[]>
+  homeNotice: Ref<string | null>
+  status: Ref<string>
+  draftExitPromptOpen: Ref<boolean>
+  androidExitPromptOpen: Ref<boolean>
+  promptLocalDraftSaveOnExit: Ref<boolean>
+  currentAndroidDocumentCanWrite: Ref<boolean>
+  sharedTextImportedMessage: string
+  // Collaborators that stay in App: shared open/save paths and editor chrome.
+  hasEditor: () => boolean
+  openEditor: (markdown: string) => Promise<void>
+  releaseEditorFocusAfterOpen: () => void
+  closeEditorMenu: () => void
+  closeEditorToolbar: () => void
+  openAndroidDocumentResult: (
+    document: OpenedAndroidDocument,
+    options?: { source?: AndroidDocumentOpenSource, remember?: boolean },
+  ) => Promise<void>
+  saveAndroidDocument: () => Promise<boolean>
+  saveDraft: () => void
+  syncDocumentFromEditor: (markDirty: boolean, flushPending: boolean) => void
+  persistAndroidRecoveryDraft: (sourceUri: string, markdown: string) => void
+  canPersistLocalDrafts: () => boolean
+  persistLocalDrafts: (drafts: LocalDraftRecord[]) => void
+  getAndroidDocumentUserMessage: (error: unknown) => string
+  appLogger: OrchestrationLogger
+  documentLogger: OrchestrationLogger
+}
+
+export interface IncomingDocumentOrchestration {
+  installListeners(): void
+  removeListeners(): void
+  handleOpenWithDocumentEvent(event: AndroidOpenWithDocumentEvent): Promise<void>
+  handleShareDocumentEvent(event: AndroidShareDocumentEvent): Promise<void>
+}
+
+/**
+ * Orchestrates Android open-with/share intents: rejects bad events, preserves
+ * the currently edited document, closes editor chrome, and routes the incoming
+ * document through the shared open paths. Owns the intent-listener lifecycle.
+ */
+export function createIncomingDocumentOrchestration(
+  options: IncomingDocumentOrchestrationOptions,
+): IncomingDocumentOrchestration {
+  let listeners: AndroidDocumentIntentListeners | null = null
+
+  async function openSharedTextDocument(document: SharedAndroidDocument) {
+    const openResult = createSharedTextDocumentOpenResult(document, {
+      sharedTextImportedMessage: options.sharedTextImportedMessage,
+      logger: options.documentLogger,
+    })
+
+    if (options.canPersistLocalDrafts()) {
+      options.persistLocalDrafts(upsertLocalDraft(options.localDrafts.value, openResult.localDraft))
+    }
+    options.homeNotice.value = openResult.homeNotice
+    options.promptLocalDraftSaveOnExit.value = openResult.promptLocalDraftSaveOnExit
+    options.currentAndroidDocumentCanWrite.value = openResult.currentAndroidDocumentCanWrite
+    options.documentState.value = openResult.documentState
+    await options.openEditor(openResult.markdown)
+    options.status.value = openResult.statusAfterOpen
+    options.releaseEditorFocusAfterOpen()
+  }
+
+  async function preserveCurrentDocumentBeforeIncomingOpen() {
+    const preservationAction = getIncomingDocumentPreservationAction({
+      currentScreen: options.currentScreen.value,
+      hasEditor: options.hasEditor(),
+      autosaveTarget: options.documentState.value.autosaveTarget,
+    })
+
+    if (preservationAction.kind === 'none') {
+      return
+    }
+
+    options.appLogger.info('preserve current document before incoming Android document')
+
+    if (preservationAction.kind === 'save-android-document') {
+      options.syncDocumentFromEditor(options.documentState.value.isDirty, true)
+      const sourceUri = options.documentState.value.sourceUri
+      const saved = await options.saveAndroidDocument()
+      if (
+        sourceUri
+        && shouldKeepAndroidRecoveryAfterPreserveFailure(saved, sourceUri, options.documentState.value.markdown)
+      ) {
+        options.persistAndroidRecoveryDraft(sourceUri, options.documentState.value.markdown)
+      }
+      return
+    }
+
+    options.saveDraft()
+  }
+
+  function closeEditorChromeForIncomingOpen() {
+    options.draftExitPromptOpen.value = false
+    options.androidExitPromptOpen.value = false
+    options.closeEditorMenu()
+    options.closeEditorToolbar()
+  }
+
+  async function handleOpenWithDocumentEvent(event: AndroidOpenWithDocumentEvent) {
+    const action = createAndroidOpenWithDocumentEventAction(event, {
+      getAndroidDocumentUserMessage: options.getAndroidDocumentUserMessage,
+      logger: options.documentLogger,
+    })
+
+    if (action.kind === 'rejected') {
+      options.homeNotice.value = action.message
+      options.status.value = action.message
+      return
+    }
+
+    await preserveCurrentDocumentBeforeIncomingOpen()
+    closeEditorChromeForIncomingOpen()
+    await options.openAndroidDocumentResult(action.document, {
+      source: action.source,
+      remember: action.remember,
+    })
+  }
+
+  async function handleShareDocumentEvent(event: AndroidShareDocumentEvent) {
+    const action = createAndroidShareDocumentEventAction(event, {
+      getAndroidDocumentUserMessage: options.getAndroidDocumentUserMessage,
+      logger: options.documentLogger,
+    })
+
+    if (action.kind === 'rejected') {
+      options.homeNotice.value = action.message
+      options.status.value = action.message
+      return
+    }
+
+    await preserveCurrentDocumentBeforeIncomingOpen()
+    closeEditorChromeForIncomingOpen()
+
+    if (action.kind === 'open-document') {
+      await options.openAndroidDocumentResult(action.document, {
+        source: action.source,
+        remember: action.remember,
+      })
+      return
+    }
+
+    await openSharedTextDocument(action.document)
+  }
+
+  function installListeners() {
+    if (listeners) {
+      return
+    }
+
+    listeners = installAndroidDocumentIntentListeners({
+      onOpenWithDocument: (event) => {
+        void handleOpenWithDocumentEvent(event)
+      },
+      onShareDocument: (event) => {
+        void handleShareDocumentEvent(event)
+      },
+      logger: options.documentLogger,
+    })
+  }
+
+  function removeListeners() {
+    listeners?.remove()
+    listeners = null
+  }
+
+  return {
+    installListeners,
+    removeListeners,
+    handleOpenWithDocumentEvent,
+    handleShareDocumentEvent,
+  }
+}


### PR DESCRIPTION
## Summary

First of the semantic-decomposition series: moves Android open-with/share intent orchestration out of `App.vue` into a dedicated `createIncomingDocumentOrchestration` factory in `features/android-documents`. Behavior-preserving refactor — no product behavior, storage format, event name, or Capacitor payload changes.

## Boundary

The new module owns exactly what arrives via incoming intents:

- open-with / share event handling (routing through the existing pure event-action creators),
- current-document preservation before an incoming open, including the recovery-draft fallback when preserving an Android document fails to save,
- shared-text import into a local draft,
- editor-chrome dismissal on incoming opens (exit prompts, menu, toolbar),
- the intent-listener install/remove lifecycle with its idempotence guard.

`openAndroidDocumentResult` deliberately stays in `App.vue` and is injected: it is shared by three paths (file picker, recent-list open, incoming intents), so pulling it into an "incoming" module would give the other two paths a backwards dependency. All state the flows read/write (document state, notices, prompt flags) is passed in as refs; all collaborators (save paths, editor open/focus, chrome closers, loggers) as functions. Log lines are preserved verbatim.

`App.vue` shrinks by ~130 lines of orchestration and now wires the factory where the old listener wrapper lived.

## Testing

- New `incomingDocumentOrchestration.test.ts` (8 tests) exercises the real event-action creators and preservation decision logic with mocked App collaborators: rejected events, home vs editor preservation, local-draft vs Android-document preservation with failed-save recovery, shared file vs shared text routing, drafts-disabled import skip, and listener install idempotence/reinstall.
- Full unit suite 266/266, ESLint, vue-tsc, production build green.
- Contract E2E suites for exactly this behavior — `mobile-share-intent.spec.ts` and `mobile-android-document-lifecycle.spec.ts` — pass 15/15 (open-with on launch, warm open-with preserving the active draft, shared file with temporary access, shared text import, rejection notices).