### PR TITLE
Resolve derived titles to plain text

### DIFF
--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -34,6 +34,43 @@ describe('documentState', () => {
     expect(getDocumentTitle('1. step one\n2. step two')).toBe('step one')
   })
 
+  it('drops inline HTML tags from derived titles', () => {
+    // Styled first lines always resolve to plain text — with or without
+    // emphasis around the tags, the title is the same readable content.
+    expect(getDocumentTitle('***<u>alpha</u>*** bravo charlie delta'))
+      .toBe('alpha bravo charlie delta')
+    expect(getDocumentTitle('<u>alpha</u> bravo charlie delta'))
+      .toBe('alpha bravo charlie delta')
+    expect(getDocumentTitle('<mark>note</mark> for later')).toBe('note for later')
+    expect(getDocumentTitle('alpha<br>beta')).toBe('alpha beta')
+    // Autolinks are content, not markup.
+    expect(getDocumentTitle('<https://example.com> reading list'))
+      .toBe('<https://example.com> reading list')
+  })
+
+  it('reduces styled headings to plain-text titles', () => {
+    expect(getDocumentTitle('# **Trip** to <u>Paris</u>')).toBe('Trip to Paris')
+    // A pure-markup heading names nothing; the content below wins.
+    expect(getDocumentTitle('# ***\n\nreal text')).toBe('real text')
+  })
+
+  it('keeps literal Markdown punctuation that is not paired markup', () => {
+    expect(getDocumentTitle('# file_name')).toBe('file_name')
+    expect(getDocumentTitle('# snake_case_name here')).toBe('snake_case_name here')
+    expect(getDocumentTitle('# `file_name`')).toBe('file_name')
+    expect(getDocumentTitle('# 2*3 benchmark')).toBe('2*3 benchmark')
+    expect(getDocumentTitle('# foo~bar')).toBe('foo~bar')
+    expect(getDocumentTitle('# ~~done~~ next steps')).toBe('done next steps')
+    expect(getDocumentTitle('# _emphasized_ word')).toBe('emphasized word')
+  })
+
+  it('strips custom elements and tags with quoted attribute values', () => {
+    expect(getDocumentTitle('<my-widget>alpha</my-widget> beta')).toBe('alpha beta')
+    expect(getDocumentTitle('<span title="a>b">alpha</span> beta')).toBe('alpha beta')
+    expect(getDocumentTitle('<user@example.com> contact line'))
+      .toBe('<user@example.com> contact line')
+  })
+
   it('skips front matter and pure-syntax lines when deriving draft titles', () => {
     expect(getDocumentTitle('---\ntitle: meta\n---\nActual first line')).toBe('Actual first line')
     expect(getDocumentTitle('---\n\nBelow a thematic break')).toBe('Below a thematic break')

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -137,6 +137,34 @@ const THEMATIC_BREAK_REGEXP = /^\s*([-*_])(\s*\1){2,}\s*$/
 const CODE_FENCE_REGEXP = /^\s*(?:`{3,}|~{3,})/
 const TITLE_MAX_LENGTH = 48
 
+// Matches inline HTML tags the way CommonMark treats raw HTML: a letter-led
+// tag name (hyphenated custom elements included), attributes whose quoted
+// values may contain '>', optional self-close. Autolinks like
+// <https://example.com> and <user@example.com> do not match because ':' and
+// '@' follow the leading letters directly.
+const INLINE_HTML_TAG_REGEXP = /<\/?[a-z][a-z0-9-]*(?:[\s/](?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi
+
+// Best-effort plain-text reduction of inline Markdown for use as a title:
+// keeps link/image text, drops inline HTML tags, and unwraps paired
+// delimiters only — literal punctuation like `file_name`, `2*3`, or
+// `foo~bar` is content, not markup, and survives. Underscores follow
+// CommonMark's rule that intraword `_` never emphasizes.
+function stripInlineMarkdown(text: string) {
+  const reduced = text
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(INLINE_HTML_TAG_REGEXP, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*{1,3}([^*]+)\*{1,3}/g, '$1')
+    .replace(/(?<![\p{L}\p{N}])_{1,3}([^_]+)_{1,3}(?![\p{L}\p{N}])/gu, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  // Unpaired marker runs ("***", "**") carry no title content.
+  return /^[`*_~\s]+$/.test(reduced) ? '' : reduced
+}
+
 // Best-effort plain-text reduction of a Markdown line for use as a title:
 // strips the common block prefixes and inline markers without a full parse.
 // Lines that are pure syntax (fences, thematic breaks) reduce to nothing.
@@ -146,16 +174,13 @@ function extractTitleTextFromLine(line: string) {
     return ''
   }
 
-  return trimmed
-    .replace(/^#{1,6}\s+/, '')
-    .replace(/^(?:>\s*)+/, '')
-    .replace(/^(?:[-*+]|\d+[.)])\s+/, '')
-    .replace(/^\[[ xX]\]\s+/, '')
-    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-    .replace(/[`*_~]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim()
+  return stripInlineMarkdown(
+    trimmed
+      .replace(/^#{1,6}\s+/, '')
+      .replace(/^(?:>\s*)+/, '')
+      .replace(/^(?:[-*+]|\d+[.)])\s+/, '')
+      .replace(/^\[[ xX]\]\s+/, ''),
+  )
 }
 
 // The first line of the document that still reads as text once Markdown
@@ -257,8 +282,12 @@ export function getDocumentTitle(markdown: string, displayName = DEFAULT_UNTITLE
     .map(line => line.match(/^#{1,6}\s+(.+)$/)?.[1]?.trim())
     .find(Boolean)
 
-  if (heading) {
-    return heading
+  // Titles are plain text: a styled heading like `# ***<u>alpha</u>***` must
+  // not leak its markers or tags. A pure-markup heading reduces to nothing
+  // and falls through to the display-name / leading-text fallbacks.
+  const headingText = heading ? stripInlineMarkdown(heading) : ''
+  if (headingText) {
+    return headingText
   }
 
   // A real display name (an opened file's name) still wins over content, but


### PR DESCRIPTION
## Summary

Fixes the clunky titles reported for styled first lines: a draft starting with `***<u>alpha</u>*** bravo charlie delta` used to lose its emphasis markers but keep the raw `<u>` tags, so the home list showed `<u>alpha</u> bravo charlie delta`. Derived titles now always resolve to plain text — `<u>alpha</u> …` and `***<u>alpha</u>*** …` both title as `alpha bravo charlie delta`.

Kept deliberately separate from #93: this is a user-visible behavior fix on the web side, while the decomposition series PRs are behavior-preserving by contract.

## Change

- New shared `stripInlineMarkdown` reduction in `documentState.ts`: keeps link/image text, drops inline HTML tags and emphasis markers, collapses whitespace.
- Applied on **both** title paths, since the same leak existed one `#` away: the leading-line heuristic from #83 and the heading branch (`# **Trip** to <u>Paris</u>` now titles as `Trip to Paris`).
- The tag pattern matches raw HTML the way CommonMark does (letter-led tag name, optional attributes, optional self-close), so autolinks like `<https://example.com>` are treated as content and preserved.
- A heading that reduces to pure markup (`# ***`) now names nothing and falls through to the display-name/leading-text fallbacks instead of titling the document as a row of asterisks.

Titles are derived, never stored as user input, so existing documents pick up clean titles on their next open/save with no migration.

## Testing

- Three new/extended unit cases lock the reported case verbatim (with and without emphasis), tag variants (`<mark>`, `<br>` word spacing), autolink preservation, styled-heading reduction, and the pure-markup-heading fall-through. `documentState` suite 23/23.
- Full unit suite 310/310, ESLint, vue-tsc, production build green.