### PR TITLE
Extract editor-session lifecycle from App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { App } from '@capacitor/app'
 import HomeScreen from './features/home/HomeScreen.vue'
 import EditorScreen from './features/editor/EditorScreen.vue'
@@ -34,8 +34,8 @@ import {
   isAndroidSelectionControlAvailable,
   readAndroidClipboardText,
 } from './lib/androidSelection'
-import { installAndroidSelectionDiagnostics } from './lib/androidSelectionDiagnostics'
 import { createEditorSelectionLifecycle } from './features/editor/selectionLifecycle'
+import { createEditorSession, normalizeEditorMarkdown } from './features/editor/editorSession'
 import {
   getAppBackButtonAction,
   getShowHomeAfterAndroidSaveAction,
@@ -46,10 +46,7 @@ import {
 import { isAndroidRecoveryDraftId } from './features/android-documents/androidRecoveryDrafts'
 import { rememberAndroidRecentDocument } from './features/android-documents/androidRecentDocuments'
 import { getImageSharingSettings } from './features/android-documents/imageSharingSettings'
-import {
-  createUntitledDocument,
-  updateDocumentMarkdown,
-} from './lib/documentState'
+import { createUntitledDocument } from './lib/documentState'
 import {
   createDocumentStateFromLocalDraft,
 } from './features/document-session/documentSessionState'
@@ -73,22 +70,17 @@ import {
   runEditorToolbarCommandWorkflow,
   scheduleEditorToolbarSync,
 } from './features/editor/editorToolbarWorkflow'
-import { readEditorMarkdownSnapshot } from './features/editor/editorMarkdownSnapshot'
 import {
   getEditorToolbarSettings,
 } from './features/editor/editorToolbarSettings'
 import { useEditorToolbar } from './features/editor/useEditorToolbar'
-import {
-  insertTextAtRestoredSelection,
-  resolveEditorDomNode,
-} from './features/editor/editorInlineInsert'
+import { insertTextAtRestoredSelection } from './features/editor/editorInlineInsert'
 import {
   applyMuyaAppearanceSettings,
   applyMuyaEditingSettings,
   applyMuyaEditorLocale,
   createMuyaEditor,
   destroyMuyaEditor,
-  type MuyaEditor,
 } from './features/editor/editorRuntime'
 import {
   removeLocalDraft,
@@ -181,11 +173,6 @@ const SHARED_TEXT_IMPORTED_MESSAGE = 'Imported shared text as a local draft.'
 const ANDROID_SAVE_RECOVERY_MESSAGE = 'Save failed. A local recovery draft was kept.'
 const ANDROID_EXIT_RECOVERY_MESSAGE = 'Unsaved changes were kept as a recovery draft.'
 const ANDROID_EXIT_DISCARD_MESSAGE = 'Unsaved changes were discarded.'
-const ENABLE_ANDROID_SELECTION_ACTION_MODE_SUPPRESSION = true
-// Heavy per-event selection checkpoints are a debugging tool, not a product
-// behavior: leave off unless actively diagnosing selection lifecycle issues.
-const ENABLE_ANDROID_SELECTION_DIAGNOSTICS = false
-const editorElement = ref<HTMLElement | null>(null)
 const documentState = ref(createUntitledDocument())
 const localDrafts = ref<LocalDraftRecord[]>([])
 const androidRecentDocuments = ref<RecentDocumentRecord[]>([])
@@ -199,7 +186,6 @@ const homeNotice = ref<string | null>(null)
 const currentScreen = ref<AppScreen>('home')
 const homeTab = ref<HomeTab>(DEFAULT_HOME_TAB)
 const settingsPage = ref<SettingsPage>(DEFAULT_SETTINGS_PAGE)
-const editorReady = ref(false)
 const draftExitPromptOpen = ref(false)
 const androidExitPromptOpen = ref(false)
 const promptLocalDraftSaveOnExit = ref(false)
@@ -261,18 +247,10 @@ const homeDocumentText = computed<HomeDocumentText>(() => ({
     t(count === 1 ? 'home.wordCount.one' : 'home.wordCount.other', { count }),
 }))
 
-function setEditorElement(element: HTMLElement | null) {
-  editorElement.value = element
-}
-
-let editor: MuyaEditor | null = null
-let editorInitToken = 0
 let lastContentLogAt = 0
 let appLifecycleListeners: AppLifecycleListeners | null = null
 let pendingInlineInsertRange: Range | null = null
 let startupActionTimer: number | null = null
-let editorSelectionDiagnosticCleanup: (() => void) | null = null
-let editorInputDiagnosticCleanup: (() => void) | null = null
 let systemColorSchemeCleanup: (() => void) | null = null
 
 const appLog = createLogger('app')
@@ -282,7 +260,7 @@ const androidDocumentLog = createLogger('android-document')
 const loggingLog = createLogger('logging')
 
 watch(appearanceTextSettings, settings => {
-  applyMuyaAppearanceSettings(editor, settings)
+  applyMuyaAppearanceSettings(getEditor(), settings)
 })
 
 // Runs synchronously during setup so the stored theme lands before first paint.
@@ -296,7 +274,7 @@ watch(
 )
 
 watch(editingSettings, (settings, previousSettings) => {
-  applyMuyaEditingSettings(editor, settings, previousSettings)
+  applyMuyaEditingSettings(getEditor(), settings, previousSettings)
 })
 
 watch(
@@ -341,7 +319,7 @@ watch(androidInputDiagnosticsEnabled, enabled => {
 })
 
 watch(locale, nextLocale => {
-  void applyMuyaEditorLocale(editor, nextLocale, editorLog)
+  void applyMuyaEditorLocale(getEditor(), nextLocale, editorLog)
 })
 
 const lineCount = computed(() => documentState.value.stats.lines)
@@ -457,12 +435,69 @@ const {
 } = createAutosaveScheduler({
   documentSettings,
   documentState,
-  isEditingActive: () => Boolean(editor) && currentScreen.value === 'editor',
+  // Deferred lookup: the editor session below owns the editor instance, and
+  // its own options reference this scheduler's timer handles.
+  isEditingActive: () => Boolean(getEditor()) && currentScreen.value === 'editor',
   canPersistLocalDrafts,
   // Deferred lookups: the persistence factory below provides these, and its
   // own options reference this scheduler's timer handles.
   saveDraft: () => saveDraft(),
   saveAndroidDocument: () => saveAndroidDocument(),
+})
+
+const {
+  editorReady,
+  setEditorElement,
+  getEditorElement,
+  getEditor,
+  hasEditor,
+  getEditorMarkdownSnapshot,
+  syncDocumentFromEditor,
+  openEditor,
+  destroyEditor,
+  releaseEditorFocusAfterOpen,
+  installEditorInputDiagnostics,
+  uninstallEditorInputDiagnostics,
+  describeEditorInputState,
+} = createEditorSession({
+  currentScreen,
+  documentState,
+  status,
+  locale,
+  appearanceTextSettings,
+  editingSettings,
+  androidInputDiagnosticsEnabled,
+  createMuyaEditor,
+  destroyMuyaEditor,
+  syncMarkdown: nextStatus => syncMarkdown(nextStatus),
+  onEditorFocus: () => {
+    status.value =
+      documentState.value.autosaveTarget === 'android-document' &&
+      !currentAndroidDocumentCanWrite.value
+        ? 'Read only'
+        : 'Editing'
+    editorLog.debug('editor focused')
+  },
+  onEditorBlur: () => {
+    status.value =
+      documentState.value.autosaveTarget === 'android-document'
+        ? getAndroidEditorStatus()
+        : 'Ready'
+    editorLog.debug('editor blurred')
+  },
+  ensureAndroidImageResolver,
+  getClipboardText: () =>
+    isAndroidSelectionControlAvailable() ? readAndroidClipboardText : undefined,
+  // Deferred lookups: the selection lifecycle below is created after this
+  // session, and its own options reference the session's editor accessors.
+  setEditorSelectionMenuSuppression: (suppressed, reason) =>
+    setEditorSelectionMenuSuppression(suppressed, reason),
+  installNativeSelectionTapListener: () => installNativeSelectionTapListener(),
+  uninstallNativeSelectionTapListener: () => uninstallNativeSelectionTapListener(),
+  clearDraftSaveTimer,
+  clearAndroidDocumentSaveTimer,
+  closeEditorToolbar,
+  logger: editorLog,
 })
 
 function getTransientAndroidSaveMessage() {
@@ -512,40 +547,14 @@ function getAndroidExitPromptMessage() {
   return t('editor.exit.androidSaveFailedMessage')
 }
 
-function normalizeEditorMarkdown(markdown: string) {
-  return markdown === '\n' ? '' : markdown
-}
-
-function getEditorMarkdownSnapshot(flushPending = false) {
-  if (!editor) {
-    return ''
-  }
-
-  return readEditorMarkdownSnapshot(editor, {
-    flushPending,
-    normalizeMarkdown: normalizeEditorMarkdown,
-  })
-}
-
-function syncDocumentFromEditor(markDirty = false, flushPending = false) {
-  if (!editor) {
-    return documentState.value
-  }
-
-  const value = getEditorMarkdownSnapshot(flushPending)
-  documentState.value = updateDocumentMarkdown(documentState.value, value, { markDirty })
-  return documentState.value
-}
-
 function syncMarkdown(nextStatus: unknown = 'Edited') {
-  if (!editor) {
+  if (!hasEditor()) {
     return
   }
 
   const resolvedStatus = typeof nextStatus === 'string' ? nextStatus : 'Edited'
-  const nextMarkdown = getEditorMarkdownSnapshot()
   const markDirty = resolvedStatus === 'Edited'
-  documentState.value = updateDocumentMarkdown(documentState.value, nextMarkdown, { markDirty })
+  syncDocumentFromEditor(markDirty)
   if (markDirty && documentState.value.autosaveTarget === 'android-document') {
     status.value = getAndroidEditorStatus()
     if (currentAndroidDocumentCanWrite.value && canRunIdleAndroidDocumentAutosave()) {
@@ -567,11 +576,12 @@ function syncMarkdown(nextStatus: unknown = 'Edited') {
 }
 
 function getEditorCommandTarget(): MobileEditorCommandTarget | null {
-  if (!editor) {
+  const activeEditor = getEditor()
+  if (!activeEditor) {
     return null
   }
 
-  return createMuyaMobileEditorCommandTarget(editor)
+  return createMuyaMobileEditorCommandTarget(activeEditor)
 }
 
 const {
@@ -586,25 +596,25 @@ const {
   currentScreen,
   editorReady,
   androidInputDiagnosticsEnabled,
-  getEditor: () => editor,
-  getEditorElement: () => editorElement.value,
-  describeEditorInputState: () => describeEditorInputState(),
+  getEditor,
+  getEditorElement,
+  describeEditorInputState,
   logger: editorLog,
 })
 function insertMarkdownAtPendingSelection(markdown: string) {
-  editor?.focus()
+  getEditor()?.focus()
   return insertTextAtRestoredSelection(markdown, pendingInlineInsertRange)
 }
 
 function openLinkSheet(restoreRange: Range | null = null) {
-  const hasEditor = Boolean(editor)
+  const editorPresent = hasEditor()
   const capturedRange =
-    editorReady.value && hasEditor
+    editorReady.value && editorPresent
       ? restoreRange?.cloneRange() ?? captureEditorSelection()
       : null
   const nextLinkSheet = createLinkInsertSheetWorkflow({
     editorReady: editorReady.value,
-    hasEditor,
+    hasEditor: editorPresent,
     selectedText: capturedRange?.toString() ?? '',
   })
   if (nextLinkSheet.kind !== 'open') {
@@ -624,9 +634,9 @@ function closeLinkSheet() {
 }
 
 function insertLinkFromSheet() {
-  const beforeMarkdown = editor?.getMarkdown() ?? ''
+  const beforeMarkdown = getEditor()?.getMarkdown() ?? ''
   const result = insertLinkFromSheetWorkflow({
-    hasEditor: Boolean(editor),
+    hasEditor: hasEditor(),
     linkText: linkText.value,
     linkUrl: linkUrl.value,
     beforeMarkdown,
@@ -645,7 +655,7 @@ function insertLinkFromSheet() {
 async function insertImageFromAndroidPicker(restoreRange: Range | null = null) {
   const startResult = createAndroidImageInsertStart({
     editorReady: editorReady.value,
-    hasEditor: Boolean(editor),
+    hasEditor: hasEditor(),
     importing: importingAndroidImage.value,
     isAvailable: isAndroidImageImportAvailable(),
     unavailableStatus: getAndroidImageUserMessage({ code: 'UNAVAILABLE' }),
@@ -660,11 +670,12 @@ async function insertImageFromAndroidPicker(restoreRange: Range | null = null) {
     return
   }
 
-  if (!editor) {
+  const activeEditor = getEditor()
+  if (!activeEditor) {
     return
   }
 
-  const beforeMarkdown = editor.getMarkdown()
+  const beforeMarkdown = activeEditor.getMarkdown()
   pendingInlineInsertRange = restoreRange?.cloneRange() ?? captureEditorSelection()
   const selectedText = normalizeToolbarSelectionText(pendingInlineInsertRange?.toString() ?? '')
   closeEditorMenu()
@@ -697,7 +708,7 @@ function syncAfterToolbarCommand(beforeMarkdown: string) {
   scheduleEditorToolbarSync({
     beforeMarkdown,
     requestFrame: callback => window.requestAnimationFrame(callback),
-    getMarkdown: () => editor?.getMarkdown() ?? null,
+    getMarkdown: () => getEditor()?.getMarkdown() ?? null,
     normalizeMarkdown: normalizeEditorMarkdown,
     onEdited: () => syncMarkdown('Edited'),
     onUnchanged: () => syncDocumentFromEditor(documentState.value.isDirty),
@@ -709,7 +720,7 @@ const canPasteSelection =
   (typeof navigator !== 'undefined' && Boolean(navigator.clipboard?.readText))
 
 function runEditorToolbarCommand(commandId: MobileCommandId, restoreRange: Range | null = null) {
-  const activeEditor = editorReady.value ? editor : null
+  const activeEditor = editorReady.value ? getEditor() : null
   const commandRange =
     activeEditor && isSelectionDependentMobileCommand(commandId)
       ? restoreRange?.cloneRange() ?? captureEditorSelection()
@@ -795,7 +806,7 @@ const {
   savingLocalDraftToAndroid,
   savingAndroidDocumentCopy,
   sharingCurrentDocument,
-  hasEditor: () => Boolean(editor),
+  hasEditor,
   getEditorMarkdownSnapshot,
   syncDocumentFromEditor,
   closeEditorMenu,
@@ -829,204 +840,6 @@ const {
   documentLogger: androidDocumentLog,
   draftLogger: draftLog,
 })
-async function initEditor(initialMarkdown: string) {
-  const element = editorElement.value
-  if (!element) {
-    return
-  }
-
-  try {
-    const token = ++editorInitToken
-    try {
-      await ensureAndroidImageResolver()
-    } catch (error) {
-      editorLog.warn('Android image resolver unavailable during editor init', error)
-    }
-    const nextEditor = await createMuyaEditor({
-      element,
-      markdown: initialMarkdown,
-      onContentChange: syncMarkdown,
-      onJsonChange: syncMarkdown,
-      onFocus: () => {
-        status.value =
-          documentState.value.autosaveTarget === 'android-document' &&
-          !currentAndroidDocumentCanWrite.value
-            ? 'Read only'
-            : 'Editing'
-        editorLog.debug('editor focused')
-      },
-      onBlur: () => {
-        status.value =
-          documentState.value.autosaveTarget === 'android-document'
-            ? getAndroidEditorStatus()
-            : 'Ready'
-        editorLog.debug('editor blurred')
-      },
-      appLocale: locale.value,
-      appearanceTextSettings: appearanceTextSettings.value,
-      editingSettings: editingSettings.value,
-      clipboardText: isAndroidSelectionControlAvailable() ? readAndroidClipboardText : undefined,
-      isStale: () => token !== editorInitToken || !editorElement.value,
-      logger: editorLog,
-    })
-    if (!nextEditor) {
-      await setEditorSelectionMenuSuppression(false, 'editor-init-stale')
-      return
-    }
-
-    editor = nextEditor
-    installEditorSelectionDiagnostics()
-    installEditorInputDiagnostics()
-    void installNativeSelectionTapListener()
-    await setEditorSelectionMenuSuppression(
-      ENABLE_ANDROID_SELECTION_ACTION_MODE_SUPPRESSION,
-      ENABLE_ANDROID_SELECTION_ACTION_MODE_SUPPRESSION
-        ? 'editor-init'
-        : 'editor-init-baseline-disabled',
-    )
-    syncMarkdown('Ready')
-    editorReady.value = true
-    editorLog.info('Muya init complete', {
-      characters: characterCount.value,
-      words: wordCount.value,
-      lines: lineCount.value,
-    })
-  } catch (error) {
-    status.value = 'Editor failed'
-    editorLog.error('Muya init failed', error)
-    await setEditorSelectionMenuSuppression(false, 'editor-init-failed')
-  }
-}
-
-function installEditorSelectionDiagnostics() {
-  uninstallEditorSelectionDiagnostics()
-
-  if (!ENABLE_ANDROID_SELECTION_DIAGNOSTICS) {
-    return
-  }
-
-  const root = resolveEditorDomNode(editor, editorElement.value)
-  if (!root) {
-    return
-  }
-
-  editorSelectionDiagnosticCleanup = installAndroidSelectionDiagnostics({
-    root,
-    getFallbackRoot: () => editorElement.value,
-    logger: editorLog,
-  })
-}
-
-function uninstallEditorSelectionDiagnostics() {
-  editorSelectionDiagnosticCleanup?.()
-  editorSelectionDiagnosticCleanup = null
-}
-
-function describeEditorInputState() {
-  const selection = document.getSelection()
-  const anchorNode = selection?.anchorNode ?? null
-  const anchorElement =
-    anchorNode instanceof Element ? anchorNode : anchorNode?.parentElement ?? null
-  const muyaSelection = editor?.editor.selection.getSelection() ?? null
-
-  return {
-    anchor: anchorNode
-      ? `${anchorNode.nodeName}[${String(anchorElement?.className ?? '').slice(0, 44)}]@${selection?.anchorOffset}`
-      : 'none',
-    anchorInContent: Boolean(anchorElement?.closest?.('span.mu-content')),
-    collapsed: selection?.isCollapsed ?? null,
-    muyaSelection: muyaSelection
-      ? {
-          sameBlock: muyaSelection.isSelectionInSameBlock,
-          anchorOffset: muyaSelection.anchor.offset,
-          focusOffset: muyaSelection.focus.offset,
-        }
-      : null,
-    hasActiveBlock: Boolean(editor?.editor.activeContentBlock),
-    modelCharacters: editor?.getMarkdown().length ?? -1,
-  }
-}
-
-function installEditorInputDiagnostics() {
-  uninstallEditorInputDiagnostics()
-
-  if (!androidInputDiagnosticsEnabled.value) {
-    return
-  }
-
-  const root = resolveEditorDomNode(editor, editorElement.value)
-  if (!root) {
-    return
-  }
-
-  const handler = (event: Event) => {
-    const inputEvent = event as InputEvent
-    const inputType = inputEvent.inputType ?? ''
-    const eventText = inputEvent.dataTransfer?.getData('text/plain') ?? inputEvent.data ?? ''
-    const isDelete = inputType.startsWith('delete')
-    // Paste-like inserts (IME clipboard chips commit these) are the known
-    // model-divergence trigger, so keep them in the diagnostic trail too.
-    const isPasteLike =
-      inputType === 'insertFromPaste' ||
-      inputType === 'insertReplacementText' ||
-      (inputType.startsWith('insert') && /[\r\n]/.test(eventText))
-    if (!isDelete && !isPasteLike) {
-      return
-    }
-
-    const target = event.target
-    const targetName =
-      target instanceof Element
-        ? `${target.nodeName}[${String(target.className).slice(0, 44)}]`
-        : 'none'
-    editorLog.debug('editor input event', {
-      phase: event.type,
-      inputType,
-      cancelable: event.cancelable,
-      dataLength: eventText.length,
-      target: targetName,
-      ...describeEditorInputState(),
-    })
-  }
-
-  root.addEventListener('beforeinput', handler, true)
-  root.addEventListener('input', handler, true)
-  editorInputDiagnosticCleanup = () => {
-    root.removeEventListener('beforeinput', handler, true)
-    root.removeEventListener('input', handler, true)
-  }
-}
-
-function uninstallEditorInputDiagnostics() {
-  editorInputDiagnosticCleanup?.()
-  editorInputDiagnosticCleanup = null
-}
-
-function releaseEditorFocusAfterOpen() {
-  window.requestAnimationFrame(() => {
-    const activeElement = document.activeElement
-    if (activeElement instanceof HTMLElement && editorElement.value?.contains(activeElement)) {
-      activeElement.blur()
-      editorLog.debug('editor focus released after document open')
-    }
-  })
-}
-
-async function openEditor(markdown: string) {
-  editorReady.value = false
-  closeEditorToolbar()
-  const wasEditorOpen = currentScreen.value === 'editor'
-  destroyEditor({ updateSelectionMenuSuppression: !wasEditorOpen })
-  if (wasEditorOpen) {
-    currentScreen.value = 'home'
-    await nextTick()
-  }
-
-  currentScreen.value = 'editor'
-  await nextTick()
-  await initEditor(markdown)
-}
-
 function rememberAndroidDocument(document: OpenedAndroidDocument) {
   persistAndroidRecentDocuments(rememberAndroidRecentDocument(androidRecentDocuments.value, document))
 }
@@ -1202,21 +1015,6 @@ async function installCjkBoldCompensation() {
   applyCjkBoldCompensation(compensate)
   if (compensate) {
     appLog.info('cjk bold compensation enabled', { manufacturer: diagnostics.manufacturer })
-  }
-}
-
-function destroyEditor(options: { updateSelectionMenuSuppression?: boolean } = {}) {
-  editorInitToken += 1
-  editorReady.value = false
-  clearDraftSaveTimer()
-  clearAndroidDocumentSaveTimer()
-  uninstallEditorSelectionDiagnostics()
-  uninstallEditorInputDiagnostics()
-  void uninstallNativeSelectionTapListener()
-  destroyMuyaEditor(editor)
-  editor = null
-  if (options.updateSelectionMenuSuppression !== false) {
-    void setEditorSelectionMenuSuppression(false, 'editor-destroy')
   }
 }
 
@@ -1398,7 +1196,7 @@ const incomingDocuments = createIncomingDocumentOrchestration({
   promptLocalDraftSaveOnExit,
   currentAndroidDocumentCanWrite,
   sharedTextImportedMessage: SHARED_TEXT_IMPORTED_MESSAGE,
-  hasEditor: () => Boolean(editor),
+  hasEditor,
   openEditor,
   releaseEditorFocusAfterOpen,
   closeEditorMenu,

--- a/src/features/editor/editorRuntime.ts
+++ b/src/features/editor/editorRuntime.ts
@@ -18,7 +18,7 @@ interface EditorRuntimeLogger {
   info?(message: string, context?: Record<string, unknown>): void
 }
 
-interface CreateMuyaEditorOptions {
+export interface CreateMuyaEditorOptions {
   element: HTMLElement
   markdown: string
   onContentChange: (...args: unknown[]) => void

--- a/src/features/editor/editorSession.test.ts
+++ b/src/features/editor/editorSession.test.ts
@@ -1,0 +1,395 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest'
+import { ref, watch } from 'vue'
+import { createEditorSession, normalizeEditorMarkdown } from './editorSession'
+import type { CreateMuyaEditorOptions, MuyaEditor } from './editorRuntime'
+import type { AppScreen } from '../../lib/appExitDecisions'
+import { createUntitledDocument } from '../../lib/documentState'
+import type { AppearanceTextSettings } from '../settings/appearanceSettings'
+import type { EditingSettings } from '../settings/editingSettings'
+
+function createFakeMuyaEditor(markdown: string) {
+  const domNode = document.createElement('div')
+  document.body.appendChild(domNode)
+  return {
+    markdown,
+    domNode,
+    flush: vi.fn(),
+    focus: vi.fn(),
+    getMarkdown() {
+      return this.markdown
+    },
+    editor: {
+      selection: { getSelection: vi.fn(() => null) },
+      activeContentBlock: null,
+    },
+  }
+}
+
+type FakeMuyaEditor = ReturnType<typeof createFakeMuyaEditor>
+
+function createHarness(overrides: {
+  screen?: AppScreen
+  diagnosticsEnabled?: boolean
+  createMuyaEditor?: (options: CreateMuyaEditorOptions) => Promise<MuyaEditor | null>
+} = {}) {
+  document.body.innerHTML = ''
+  const currentScreen = ref<AppScreen>(overrides.screen ?? 'home')
+  const documentState = ref(createUntitledDocument())
+  const status = ref('Ready')
+  const androidInputDiagnosticsEnabled = ref(overrides.diagnosticsEnabled ?? false)
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  const createdEditors: FakeMuyaEditor[] = []
+  const createCalls: CreateMuyaEditorOptions[] = []
+
+  const createMuyaEditor = vi.fn(async (options: CreateMuyaEditorOptions) => {
+    createCalls.push(options)
+    if (overrides.createMuyaEditor) {
+      return overrides.createMuyaEditor(options)
+    }
+    if (options.isStale?.()) {
+      return null
+    }
+    const fake = createFakeMuyaEditor(options.markdown)
+    createdEditors.push(fake)
+    return fake as unknown as MuyaEditor
+  })
+
+  const destroyMuyaEditor = vi.fn()
+  const syncMarkdown = vi.fn()
+  const setEditorSelectionMenuSuppression = vi.fn(async () => {})
+  const installNativeSelectionTapListener = vi.fn(async () => {})
+  const uninstallNativeSelectionTapListener = vi.fn(async () => {})
+  const clearDraftSaveTimer = vi.fn()
+  const clearAndroidDocumentSaveTimer = vi.fn()
+  const closeEditorToolbar = vi.fn()
+
+  const session = createEditorSession({
+    currentScreen,
+    documentState,
+    status,
+    locale: ref('en'),
+    appearanceTextSettings: ref({} as AppearanceTextSettings),
+    editingSettings: ref({} as EditingSettings),
+    androidInputDiagnosticsEnabled,
+    createMuyaEditor,
+    destroyMuyaEditor,
+    syncMarkdown,
+    onEditorFocus: vi.fn(),
+    onEditorBlur: vi.fn(),
+    ensureAndroidImageResolver: vi.fn(async () => true),
+    getClipboardText: () => undefined,
+    setEditorSelectionMenuSuppression,
+    installNativeSelectionTapListener,
+    uninstallNativeSelectionTapListener,
+    clearDraftSaveTimer,
+    clearAndroidDocumentSaveTimer,
+    closeEditorToolbar,
+    logger,
+  })
+
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  session.setEditorElement(host)
+
+  return {
+    session,
+    host,
+    currentScreen,
+    documentState,
+    status,
+    androidInputDiagnosticsEnabled,
+    logger,
+    createdEditors,
+    createCalls,
+    createMuyaEditor,
+    destroyMuyaEditor,
+    syncMarkdown,
+    setEditorSelectionMenuSuppression,
+    installNativeSelectionTapListener,
+    uninstallNativeSelectionTapListener,
+    clearDraftSaveTimer,
+    clearAndroidDocumentSaveTimer,
+    closeEditorToolbar,
+  }
+}
+
+describe('editorSession', () => {
+  it('normalizes the single-newline empty document to an empty string', () => {
+    expect(normalizeEditorMarkdown('\n')).toBe('')
+    expect(normalizeEditorMarkdown('one\n')).toBe('one\n')
+  })
+
+  it('opens the editor, wires callbacks, and reports ready', async () => {
+    const harness = createHarness()
+
+    await harness.session.openEditor('# hello')
+
+    expect(harness.currentScreen.value).toBe('editor')
+    expect(harness.session.editorReady.value).toBe(true)
+    expect(harness.session.hasEditor()).toBe(true)
+    expect(harness.closeEditorToolbar).toHaveBeenCalled()
+    expect(harness.createCalls[0].markdown).toBe('# hello')
+    expect(harness.syncMarkdown).toHaveBeenCalledWith('Ready')
+    expect(harness.installNativeSelectionTapListener).toHaveBeenCalled()
+    expect(harness.setEditorSelectionMenuSuppression).toHaveBeenCalledWith(true, 'editor-init')
+    expect(harness.logger.info).toHaveBeenCalledWith('Muya init complete', expect.any(Object))
+  })
+
+  it('does not create an editor without a host element', async () => {
+    const harness = createHarness()
+    harness.session.setEditorElement(null)
+
+    await harness.session.openEditor('text')
+
+    expect(harness.createMuyaEditor).not.toHaveBeenCalled()
+    expect(harness.session.editorReady.value).toBe(false)
+    expect(harness.session.hasEditor()).toBe(false)
+  })
+
+  it('abandons a stale initialization when a newer open supersedes it', async () => {
+    let releaseFirst: () => void = () => {}
+    const gate = new Promise<void>(resolve => {
+      releaseFirst = resolve
+    })
+    let call = 0
+    const editors: FakeMuyaEditor[] = []
+    const harness = createHarness({
+      createMuyaEditor: async options => {
+        call += 1
+        if (call === 1) {
+          await gate
+        }
+        if (options.isStale?.()) {
+          return null
+        }
+        const fake = createFakeMuyaEditor(options.markdown)
+        editors.push(fake)
+        return fake as unknown as MuyaEditor
+      },
+    })
+
+    const firstOpen = harness.session.openEditor('first')
+    await vi.waitFor(() => {
+      expect(call).toBe(1)
+    })
+    await harness.session.openEditor('second')
+
+    expect(harness.session.editorReady.value).toBe(true)
+    expect(harness.session.getEditorMarkdownSnapshot()).toBe('second')
+
+    releaseFirst()
+    await firstOpen
+
+    // The first init resolved after being superseded: it must not replace the
+    // live editor, and it resets suppression for the stale attempt.
+    expect(editors).toHaveLength(1)
+    expect(harness.session.getEditorMarkdownSnapshot()).toBe('second')
+    expect(harness.session.editorReady.value).toBe(true)
+    expect(harness.setEditorSelectionMenuSuppression).toHaveBeenCalledWith(
+      false,
+      'editor-init-stale',
+    )
+  })
+
+  it('remounts through home when the editor screen is already open', async () => {
+    const harness = createHarness()
+    await harness.session.openEditor('first')
+    const firstEditor = harness.createdEditors[0]
+    harness.setEditorSelectionMenuSuppression.mockClear()
+
+    const screens: string[] = []
+    const unwatch = watch(harness.currentScreen, value => {
+      screens.push(value)
+    }, { flush: 'sync' })
+    await harness.session.openEditor('second')
+    unwatch()
+
+    expect(screens).toEqual(['home', 'editor'])
+    expect(harness.destroyMuyaEditor).toHaveBeenCalledWith(firstEditor)
+    // Suppression stays untouched by the destroy half of a remount…
+    expect(harness.setEditorSelectionMenuSuppression).not.toHaveBeenCalledWith(
+      false,
+      'editor-destroy',
+    )
+    // …and is re-established by the new initialization.
+    expect(harness.session.getEditorMarkdownSnapshot()).toBe('second')
+    expect(harness.session.editorReady.value).toBe(true)
+  })
+
+  it('reads snapshots and syncs the document state from the editor', async () => {
+    const harness = createHarness()
+
+    // Without an editor the snapshot is empty and the state is untouched.
+    expect(harness.session.getEditorMarkdownSnapshot()).toBe('')
+    const initialState = harness.documentState.value
+    expect(harness.session.syncDocumentFromEditor(true)).toBe(initialState)
+
+    await harness.session.openEditor('draft')
+    const fake = harness.createdEditors[0]
+
+    fake.markdown = 'updated text'
+    expect(harness.session.getEditorMarkdownSnapshot()).toBe('updated text')
+    expect(fake.flush).not.toHaveBeenCalled()
+    harness.session.getEditorMarkdownSnapshot(true)
+    expect(fake.flush).toHaveBeenCalledTimes(1)
+
+    fake.markdown = '\n'
+    expect(harness.session.getEditorMarkdownSnapshot()).toBe('')
+
+    fake.markdown = 'dirty change'
+    const synced = harness.session.syncDocumentFromEditor(true)
+    expect(synced.markdown).toBe('dirty change')
+    expect(synced.isDirty).toBe(true)
+    expect(harness.documentState.value).toBe(synced)
+  })
+
+  it('destroys the editor and tears the session down', async () => {
+    const harness = createHarness()
+    await harness.session.openEditor('content')
+    const fake = harness.createdEditors[0]
+
+    harness.session.destroyEditor()
+
+    expect(harness.session.editorReady.value).toBe(false)
+    expect(harness.session.hasEditor()).toBe(false)
+    expect(harness.session.getEditor()).toBeNull()
+    expect(harness.clearDraftSaveTimer).toHaveBeenCalled()
+    expect(harness.clearAndroidDocumentSaveTimer).toHaveBeenCalled()
+    expect(harness.uninstallNativeSelectionTapListener).toHaveBeenCalled()
+    expect(harness.destroyMuyaEditor).toHaveBeenCalledWith(fake)
+    expect(harness.setEditorSelectionMenuSuppression).toHaveBeenCalledWith(
+      false,
+      'editor-destroy',
+    )
+  })
+
+  it('skips the suppression reset when destroy is part of a remount', async () => {
+    const harness = createHarness()
+    await harness.session.openEditor('content')
+    harness.setEditorSelectionMenuSuppression.mockClear()
+
+    harness.session.destroyEditor({ updateSelectionMenuSuppression: false })
+
+    expect(harness.setEditorSelectionMenuSuppression).not.toHaveBeenCalled()
+  })
+
+  it('survives repeated open and close cycles', async () => {
+    const harness = createHarness()
+
+    await harness.session.openEditor('one')
+    harness.session.destroyEditor()
+    await harness.session.openEditor('two')
+
+    expect(harness.createdEditors).toHaveLength(2)
+    expect(harness.session.editorReady.value).toBe(true)
+    expect(harness.session.getEditorMarkdownSnapshot()).toBe('two')
+    expect(harness.destroyMuyaEditor).toHaveBeenCalledWith(harness.createdEditors[0])
+  })
+
+  it('reports a failed initialization without leaving the session half-open', async () => {
+    const harness = createHarness({
+      createMuyaEditor: async () => {
+        throw new Error('muya exploded')
+      },
+    })
+
+    await harness.session.openEditor('content')
+
+    expect(harness.status.value).toBe('Editor failed')
+    expect(harness.logger.error).toHaveBeenCalledWith('Muya init failed', expect.any(Error))
+    expect(harness.setEditorSelectionMenuSuppression).toHaveBeenCalledWith(
+      false,
+      'editor-init-failed',
+    )
+    expect(harness.session.editorReady.value).toBe(false)
+    expect(harness.session.hasEditor()).toBe(false)
+  })
+
+  it('installs input diagnostics when enabled and removes them on teardown', async () => {
+    const harness = createHarness({ diagnosticsEnabled: true })
+    await harness.session.openEditor('content')
+    const fake = harness.createdEditors[0]
+
+    const deleteEvent = Object.assign(new Event('beforeinput'), {
+      inputType: 'deleteContentBackward',
+    })
+    fake.domNode.dispatchEvent(deleteEvent)
+    expect(harness.logger.debug).toHaveBeenCalledWith(
+      'editor input event',
+      expect.objectContaining({ inputType: 'deleteContentBackward' }),
+    )
+
+    // Non-delete, non-paste input stays out of the diagnostic trail.
+    harness.logger.debug.mockClear()
+    fake.domNode.dispatchEvent(Object.assign(new Event('beforeinput'), { inputType: 'insertText', data: 'a' }))
+    expect(harness.logger.debug).not.toHaveBeenCalledWith(
+      'editor input event',
+      expect.anything(),
+    )
+
+    harness.session.uninstallEditorInputDiagnostics()
+    fake.domNode.dispatchEvent(deleteEvent)
+    expect(harness.logger.debug).not.toHaveBeenCalledWith(
+      'editor input event',
+      expect.anything(),
+    )
+  })
+
+  it('does not install input diagnostics while disabled and supports late enabling', async () => {
+    const harness = createHarness({ diagnosticsEnabled: false })
+    await harness.session.openEditor('content')
+    const fake = harness.createdEditors[0]
+
+    const deleteEvent = Object.assign(new Event('beforeinput'), {
+      inputType: 'deleteContentBackward',
+    })
+    fake.domNode.dispatchEvent(deleteEvent)
+    expect(harness.logger.debug).not.toHaveBeenCalledWith(
+      'editor input event',
+      expect.anything(),
+    )
+
+    // The App watcher calls install after flipping the setting on.
+    harness.androidInputDiagnosticsEnabled.value = true
+    harness.session.installEditorInputDiagnostics()
+    fake.domNode.dispatchEvent(deleteEvent)
+    expect(harness.logger.debug).toHaveBeenCalledWith(
+      'editor input event',
+      expect.objectContaining({ inputType: 'deleteContentBackward' }),
+    )
+  })
+
+  it('releases focus after opening only when focus sits inside the editor host', async () => {
+    const harness = createHarness()
+    const input = document.createElement('input')
+    harness.host.appendChild(input)
+    input.focus()
+    expect(document.activeElement).toBe(input)
+
+    harness.session.releaseEditorFocusAfterOpen()
+    await new Promise<void>(resolve => {
+      window.requestAnimationFrame(() => resolve())
+    })
+
+    expect(document.activeElement).not.toBe(input)
+    expect(harness.logger.debug).toHaveBeenCalledWith('editor focus released after document open')
+  })
+
+  it('describes the editor input state for diagnostics collaborators', async () => {
+    const harness = createHarness()
+
+    expect(harness.session.describeEditorInputState()).toMatchObject({
+      anchor: 'none',
+      hasActiveBlock: false,
+      modelCharacters: -1,
+    })
+
+    await harness.session.openEditor('content')
+    expect(harness.session.describeEditorInputState()).toMatchObject({
+      hasActiveBlock: false,
+      modelCharacters: 'content'.length,
+    })
+  })
+})

--- a/src/features/editor/editorSession.ts
+++ b/src/features/editor/editorSession.ts
@@ -1,0 +1,349 @@
+import { nextTick, ref, type Ref } from 'vue'
+import type { AppScreen } from '../../lib/appExitDecisions'
+import { installAndroidSelectionDiagnostics } from '../../lib/androidSelectionDiagnostics'
+import {
+  updateDocumentMarkdown,
+  type MarkdownDocumentState,
+} from '../../lib/documentState'
+import type { AppearanceTextSettings } from '../settings/appearanceSettings'
+import type { EditingSettings } from '../settings/editingSettings'
+import { readEditorMarkdownSnapshot } from './editorMarkdownSnapshot'
+import { resolveEditorDomNode } from './editorInlineInsert'
+import type { CreateMuyaEditorOptions, MuyaEditor } from './editorRuntime'
+
+const ENABLE_ANDROID_SELECTION_ACTION_MODE_SUPPRESSION = true
+// Heavy per-event selection checkpoints are a debugging tool, not a product
+// behavior: leave off unless actively diagnosing selection lifecycle issues.
+const ENABLE_ANDROID_SELECTION_DIAGNOSTICS = false
+
+interface EditorSessionLogger {
+  debug(message: string, context?: unknown): void
+  info(message: string, context?: unknown): void
+  warn(message: string, context?: unknown): void
+  error(message: string, context?: unknown): void
+}
+
+export interface EditorSessionOptions {
+  // App-owned state the session reads and writes.
+  currentScreen: Ref<AppScreen>
+  documentState: Ref<MarkdownDocumentState>
+  status: Ref<string>
+  // Settings snapshots the editor is created with; live updates stay with the
+  // App watchers that call the editorRuntime apply helpers.
+  locale: Ref<string>
+  appearanceTextSettings: Ref<AppearanceTextSettings>
+  editingSettings: Ref<EditingSettings>
+  androidInputDiagnosticsEnabled: Ref<boolean>
+  // Muya runtime.
+  createMuyaEditor: (options: CreateMuyaEditorOptions) => Promise<MuyaEditor | null>
+  destroyMuyaEditor: (editor: MuyaEditor | null) => void
+  // Editor-content handlers owned by App (status + autosave coordination).
+  syncMarkdown: (nextStatus?: unknown) => void
+  onEditorFocus: () => void
+  onEditorBlur: () => void
+  // Collaborators owned by App or sibling factories.
+  ensureAndroidImageResolver: () => Promise<unknown>
+  getClipboardText: () => (() => Promise<string>) | undefined
+  setEditorSelectionMenuSuppression: (suppressed: boolean, reason: string) => Promise<void>
+  installNativeSelectionTapListener: () => Promise<void>
+  uninstallNativeSelectionTapListener: () => Promise<void>
+  clearDraftSaveTimer: () => void
+  clearAndroidDocumentSaveTimer: () => void
+  closeEditorToolbar: () => void
+  logger: EditorSessionLogger
+}
+
+export interface EditorSession {
+  editorReady: Ref<boolean>
+  setEditorElement(element: HTMLElement | null): void
+  getEditorElement(): HTMLElement | null
+  getEditor(): MuyaEditor | null
+  hasEditor(): boolean
+  getEditorMarkdownSnapshot(flushPending?: boolean): string
+  syncDocumentFromEditor(markDirty?: boolean, flushPending?: boolean): MarkdownDocumentState
+  openEditor(markdown: string): Promise<void>
+  destroyEditor(options?: { updateSelectionMenuSuppression?: boolean }): void
+  releaseEditorFocusAfterOpen(): void
+  installEditorInputDiagnostics(): void
+  uninstallEditorInputDiagnostics(): void
+  describeEditorInputState(): Record<string, unknown>
+}
+
+// Muya reports an empty document as a single newline; treat that as empty for
+// titles, autosave, and change detection.
+export function normalizeEditorMarkdown(markdown: string) {
+  return markdown === '\n' ? '' : markdown
+}
+
+/**
+ * Owns the Muya editor instance and its runtime lifecycle: initialization with
+ * stale-init token protection, the destroy/remount cycle behind opening a
+ * document, Markdown snapshots and document-state sync, post-open focus
+ * release, and the input/selection diagnostic hooks. Status text, autosave
+ * scheduling, toolbar behavior, and navigation policy stay with App and are
+ * reached only through the injected collaborators.
+ */
+export function createEditorSession(options: EditorSessionOptions): EditorSession {
+  const editorElement = ref<HTMLElement | null>(null)
+  const editorReady = ref(false)
+
+  let editor: MuyaEditor | null = null
+  let editorInitToken = 0
+  let editorSelectionDiagnosticCleanup: (() => void) | null = null
+  let editorInputDiagnosticCleanup: (() => void) | null = null
+
+  function setEditorElement(element: HTMLElement | null) {
+    editorElement.value = element
+  }
+
+  function getEditorElement() {
+    return editorElement.value
+  }
+
+  function getEditor() {
+    return editor
+  }
+
+  function hasEditor() {
+    return Boolean(editor)
+  }
+
+  function getEditorMarkdownSnapshot(flushPending = false) {
+    if (!editor) {
+      return ''
+    }
+
+    return readEditorMarkdownSnapshot(editor, {
+      flushPending,
+      normalizeMarkdown: normalizeEditorMarkdown,
+    })
+  }
+
+  function syncDocumentFromEditor(markDirty = false, flushPending = false) {
+    if (!editor) {
+      return options.documentState.value
+    }
+
+    const value = getEditorMarkdownSnapshot(flushPending)
+    options.documentState.value = updateDocumentMarkdown(options.documentState.value, value, {
+      markDirty,
+    })
+    return options.documentState.value
+  }
+
+  async function initEditor(initialMarkdown: string) {
+    const element = editorElement.value
+    if (!element) {
+      return
+    }
+
+    try {
+      const token = ++editorInitToken
+      try {
+        await options.ensureAndroidImageResolver()
+      } catch (error) {
+        options.logger.warn('Android image resolver unavailable during editor init', error)
+      }
+      const nextEditor = await options.createMuyaEditor({
+        element,
+        markdown: initialMarkdown,
+        onContentChange: options.syncMarkdown,
+        onJsonChange: options.syncMarkdown,
+        onFocus: options.onEditorFocus,
+        onBlur: options.onEditorBlur,
+        appLocale: options.locale.value,
+        appearanceTextSettings: options.appearanceTextSettings.value,
+        editingSettings: options.editingSettings.value,
+        clipboardText: options.getClipboardText(),
+        isStale: () => token !== editorInitToken || !editorElement.value,
+        logger: options.logger,
+      })
+      if (!nextEditor) {
+        await options.setEditorSelectionMenuSuppression(false, 'editor-init-stale')
+        return
+      }
+
+      editor = nextEditor
+      installEditorSelectionDiagnostics()
+      installEditorInputDiagnostics()
+      void options.installNativeSelectionTapListener()
+      await options.setEditorSelectionMenuSuppression(
+        ENABLE_ANDROID_SELECTION_ACTION_MODE_SUPPRESSION,
+        ENABLE_ANDROID_SELECTION_ACTION_MODE_SUPPRESSION
+          ? 'editor-init'
+          : 'editor-init-baseline-disabled',
+      )
+      options.syncMarkdown('Ready')
+      editorReady.value = true
+      options.logger.info('Muya init complete', {
+        characters: options.documentState.value.stats.characters,
+        words: options.documentState.value.stats.words,
+        lines: options.documentState.value.stats.lines,
+      })
+    } catch (error) {
+      options.status.value = 'Editor failed'
+      options.logger.error('Muya init failed', error)
+      await options.setEditorSelectionMenuSuppression(false, 'editor-init-failed')
+    }
+  }
+
+  async function openEditor(markdown: string) {
+    editorReady.value = false
+    options.closeEditorToolbar()
+    const wasEditorOpen = options.currentScreen.value === 'editor'
+    destroyEditor({ updateSelectionMenuSuppression: !wasEditorOpen })
+    if (wasEditorOpen) {
+      options.currentScreen.value = 'home'
+      await nextTick()
+    }
+
+    options.currentScreen.value = 'editor'
+    await nextTick()
+    await initEditor(markdown)
+  }
+
+  function destroyEditor(destroyOptions: { updateSelectionMenuSuppression?: boolean } = {}) {
+    editorInitToken += 1
+    editorReady.value = false
+    options.clearDraftSaveTimer()
+    options.clearAndroidDocumentSaveTimer()
+    uninstallEditorSelectionDiagnostics()
+    uninstallEditorInputDiagnostics()
+    void options.uninstallNativeSelectionTapListener()
+    options.destroyMuyaEditor(editor)
+    editor = null
+    if (destroyOptions.updateSelectionMenuSuppression !== false) {
+      void options.setEditorSelectionMenuSuppression(false, 'editor-destroy')
+    }
+  }
+
+  function releaseEditorFocusAfterOpen() {
+    window.requestAnimationFrame(() => {
+      const activeElement = document.activeElement
+      if (activeElement instanceof HTMLElement && editorElement.value?.contains(activeElement)) {
+        activeElement.blur()
+        options.logger.debug('editor focus released after document open')
+      }
+    })
+  }
+
+  function installEditorSelectionDiagnostics() {
+    uninstallEditorSelectionDiagnostics()
+
+    if (!ENABLE_ANDROID_SELECTION_DIAGNOSTICS) {
+      return
+    }
+
+    const root = resolveEditorDomNode(editor, editorElement.value)
+    if (!root) {
+      return
+    }
+
+    editorSelectionDiagnosticCleanup = installAndroidSelectionDiagnostics({
+      root,
+      getFallbackRoot: () => editorElement.value,
+      logger: options.logger,
+    })
+  }
+
+  function uninstallEditorSelectionDiagnostics() {
+    editorSelectionDiagnosticCleanup?.()
+    editorSelectionDiagnosticCleanup = null
+  }
+
+  function describeEditorInputState() {
+    const selection = document.getSelection()
+    const anchorNode = selection?.anchorNode ?? null
+    const anchorElement =
+      anchorNode instanceof Element ? anchorNode : anchorNode?.parentElement ?? null
+    const muyaSelection = editor?.editor.selection.getSelection() ?? null
+
+    return {
+      anchor: anchorNode
+        ? `${anchorNode.nodeName}[${String(anchorElement?.className ?? '').slice(0, 44)}]@${selection?.anchorOffset}`
+        : 'none',
+      anchorInContent: Boolean(anchorElement?.closest?.('span.mu-content')),
+      collapsed: selection?.isCollapsed ?? null,
+      muyaSelection: muyaSelection
+        ? {
+            sameBlock: muyaSelection.isSelectionInSameBlock,
+            anchorOffset: muyaSelection.anchor.offset,
+            focusOffset: muyaSelection.focus.offset,
+          }
+        : null,
+      hasActiveBlock: Boolean(editor?.editor.activeContentBlock),
+      modelCharacters: editor?.getMarkdown().length ?? -1,
+    }
+  }
+
+  function installEditorInputDiagnostics() {
+    uninstallEditorInputDiagnostics()
+
+    if (!options.androidInputDiagnosticsEnabled.value) {
+      return
+    }
+
+    const root = resolveEditorDomNode(editor, editorElement.value)
+    if (!root) {
+      return
+    }
+
+    const handler = (event: Event) => {
+      const inputEvent = event as InputEvent
+      const inputType = inputEvent.inputType ?? ''
+      const eventText = inputEvent.dataTransfer?.getData('text/plain') ?? inputEvent.data ?? ''
+      const isDelete = inputType.startsWith('delete')
+      // Paste-like inserts (IME clipboard chips commit these) are the known
+      // model-divergence trigger, so keep them in the diagnostic trail too.
+      const isPasteLike =
+        inputType === 'insertFromPaste' ||
+        inputType === 'insertReplacementText' ||
+        (inputType.startsWith('insert') && /[\r\n]/.test(eventText))
+      if (!isDelete && !isPasteLike) {
+        return
+      }
+
+      const target = event.target
+      const targetName =
+        target instanceof Element
+          ? `${target.nodeName}[${String(target.className).slice(0, 44)}]`
+          : 'none'
+      options.logger.debug('editor input event', {
+        phase: event.type,
+        inputType,
+        cancelable: event.cancelable,
+        dataLength: eventText.length,
+        target: targetName,
+        ...describeEditorInputState(),
+      })
+    }
+
+    root.addEventListener('beforeinput', handler, true)
+    root.addEventListener('input', handler, true)
+    editorInputDiagnosticCleanup = () => {
+      root.removeEventListener('beforeinput', handler, true)
+      root.removeEventListener('input', handler, true)
+    }
+  }
+
+  function uninstallEditorInputDiagnostics() {
+    editorInputDiagnosticCleanup?.()
+    editorInputDiagnosticCleanup = null
+  }
+
+  return {
+    editorReady,
+    setEditorElement,
+    getEditorElement,
+    getEditor,
+    hasEditor,
+    getEditorMarkdownSnapshot,
+    syncDocumentFromEditor,
+    openEditor,
+    destroyEditor,
+    releaseEditorFocusAfterOpen,
+    installEditorInputDiagnostics,
+    uninstallEditorInputDiagnostics,
+    describeEditorInputState,
+  }
+}


### PR DESCRIPTION
## Summary

Final proactive decomposition PR: the Muya editor instance and its runtime lifecycle move out of `App.vue` into a dedicated editor-session boundary, `createEditorSession` in `src/features/editor/editorSession.ts`. `App.vue` drops from 1,659 to 1,457 lines and no longer owns any low-level editor machinery — it composes screens and coordinates workflows, reaching the editor only through session accessors.

## Ownership boundary

**Before:** `App.vue` held the module-scope `editor` variable, the init token, the host-element ref, `initEditor` / `openEditor` / `destroyEditor`, Markdown snapshot + document-state sync, post-open focus release, and the input/selection diagnostic hooks — ~250 lines of editor internals interleaved with page composition.

**After — owned by the session:**
- the Muya instance, host element, and `editorReady` state
- initialization with stale-init token protection, including the failure path
- the destroy → (remount through home) → init cycle behind `openEditor`
- `getEditorMarkdownSnapshot` / `syncDocumentFromEditor` (and the shared `normalizeEditorMarkdown`)
- post-open focus release
- input/selection diagnostics install/teardown and `describeEditorInputState`
- cleanup on destroy (timers, diagnostics, native tap listener, suppression reset)

**Intentionally still in `App.vue`:** navigation and screen composition, `syncMarkdown` (status text + autosave scheduling policy), focus/blur status handlers, Android document open/save/share workflows, persistence orchestration, home actions, back-button/exit decisions, toolbar and link/image business actions, settings maintenance, notices.

## Why this is a session boundary, not a second app controller

The session receives App policy as injected collaborators — `syncMarkdown`, focus/blur handlers, the selection-lifecycle functions, autosave timer handles, `closeEditorToolbar` — and never decides status wording, autosave timing, or navigation policy itself. This is the same factory-with-injected-options pattern as `createEditorSelectionLifecycle`, `createAutosaveScheduler`, and `createCurrentDocumentPersistence`; the mutual references between session, scheduler, and selection lifecycle use the deferred-closure convention already established in `App.vue`.

## Behavior equivalence

Every moved function is verbatim except two documented equivalence rewrites:
- `syncMarkdown` now calls the extracted `syncDocumentFromEditor(markDirty)` — same editor guard, same normalization, same `updateDocumentMarkdown` call it previously inlined.
- The init-complete log reads `documentState.value.stats.*` directly; the App computeds it previously used resolve to exactly those fields.

Initialization ordering, suppression reasons (`editor-init`, `editor-init-stale`, `editor-init-failed`, `editor-destroy`), token-based race protection, remount semantics (screen flip through home with suppression update skipped), unmount cleanup, and all logging are unchanged. `editorRuntime` gains only an `export` on `CreateMuyaEditorOptions` so the session can type the injected factory. No UI, persistence, navigation, or Android bridge changes; `third_party/muya` untouched.

## Testing

- New `editorSession.test.ts` (14 tests, happy-dom): open/ready wiring, missing host element, **stale-init supersession** (a superseded init resolving late must not replace the live editor), remount-through-home cycle, snapshot/sync incl. flush and single-newline normalization, destroy/teardown, suppression skip on remount destroy, repeated open/close cycles, init failure, diagnostics install/teardown + late enabling via the settings watcher path, focus release, input-state description.
- Full unit suite: **326/326** (54 files). ESLint clean. `pnpm build` (includes `vue-tsc -b`) clean.
- Mobile WebView e2e contract specs covering editor startup/shutdown/navigation: `mobile-home-navigation`, `mobile-local-draft-lifecycle`, `mobile-android-document-lifecycle`, `mobile-markdown-editing` — **23/23 passed**.

Per the decomposition plan, this is the last size-driven extraction; further refactoring should be driven by product changes, bugs, or ownership conflicts.