### PR TITLE
Resolve WrongConstant lint in persistable URI permission grant

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -1103,8 +1103,17 @@ public class AndroidDocumentsPlugin extends Plugin {
             return;
         }
 
-        int grantFlags = data.getFlags() &
-            (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        // Rebuild the mask from the two allowed constants instead of masking the
+        // raw Intent flags; lint's WrongConstant check cannot narrow a bitwise-and
+        // of the broader @Intent.Flags value down to the persistable grant set.
+        int intentFlags = data.getFlags();
+        int grantFlags = 0;
+        if ((intentFlags & Intent.FLAG_GRANT_READ_URI_PERMISSION) != 0) {
+            grantFlags |= Intent.FLAG_GRANT_READ_URI_PERMISSION;
+        }
+        if ((intentFlags & Intent.FLAG_GRANT_WRITE_URI_PERMISSION) != 0) {
+            grantFlags |= Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
+        }
         if (grantFlags == 0) {
             return;
         }


### PR DESCRIPTION
## Summary

Fixes the project's only Android lint **error**: `WrongConstant` at `AndroidDocumentsPlugin.persistUriPermission()`, present since PR #4. `takePersistableUriPermission(uri, grantFlags)` was called with `data.getFlags() & (FLAG_GRANT_READ_URI_PERMISSION | FLAG_GRANT_WRITE_URI_PERMISSION)`. That mask is correct at runtime, but lint's `WrongConstant` dataflow cannot narrow a bitwise-and of the broader `@Intent.Flags` return value of `Intent.getFlags()` down to the persistable grant set, so `gradlew lint` failed with `abortOnError`.

The fix rebuilds the mode mask explicitly from the two allowed constants (start at `0`, `|=` each flag the grant Intent actually carries). Semantics are unchanged — the same bits survive and a zero mask still returns early — but every assignment is now statically provable to lint, so no suppression is needed. The literal-flag call site in `renameDocument` was never flagged and is untouched.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX change
- [x] Android native integration
- [ ] CI/build/documentation

## Test plan

- [x] `gradlew :app:lintDebug` — **0 errors** (was 1), 18 warnings unchanged from the reviewed baseline
- [x] `gradlew :app:testDebugUnitTest` — 20 tests green (IncomingIntentParser, MarkdownCodec, SharePreparation)
- [x] `gradlew :app:assembleDebug` — clean
- Web suites untouched (no web code changed); no emulator run — behavior is bit-identical, no UI or flow change

## Android notes

`persistUriPermission()` backs all five persistable-grant call sites (open, create, open-with, shared-stream, rename re-grant). The read/write subset taken still exactly mirrors what the granting Intent carried, and `SecurityException` handling is unchanged.

## Reviewer notes

Deliberately not a `@SuppressLint`: the lint contract is genuinely satisfiable, so the code was rewritten into the form lint can verify. Coverage note: the logic is four lines of bit arithmetic inside a private method with a framework dependency (`getContext()`); adding Robolectric or extracting an API solely to test two bit checks was judged disproportionate — lint itself now verifies the constant contract. The remaining 18 lint warnings are pre-existing and out of scope.