### PR TITLE
Extend the floating selection toolbar with long-press caret states

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidSelectionPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidSelectionPlugin.java
@@ -69,6 +69,10 @@ public class AndroidSelectionPlugin extends Plugin {
         notifyListeners("selectionTap", data);
     }
 
+    void emitSelectionContextRequest() {
+        notifyListeners("selectionContextRequest", new JSObject());
+    }
+
     @PluginMethod
     public void performNativeSelectAll(PluginCall call) {
         String reason = call.getString("reason", "unspecified");

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
@@ -98,6 +98,14 @@ public class MainActivity extends BridgeActivity {
         activeSelectionActionMode = mode;
         activeSelectionActionModeStartUptimeMs = SystemClock.uptimeMillis();
         recordSelectionActionModeEvent("action-mode-started", modeDescription(mode));
+
+        // The suppressed floating ActionMode starting is exactly the moment
+        // Android would have shown its clipboard menu (long-press selection,
+        // double-tap word select, insertion-caret menu). Hand that moment to
+        // the web layer so the app-owned toolbar can offer clipboard actions.
+        if (isSuppressedSelectionActionMode(mode)) {
+            notifySelectionContextRequest();
+        }
     }
 
     @Override
@@ -193,6 +201,20 @@ public class MainActivity extends BridgeActivity {
             builder.append(menu.getItem(index).getItemId());
         }
         return builder.toString();
+    }
+
+    void notifySelectionContextRequest() {
+        recordSelectionActionModeEvent("selection-context-request", "notify");
+
+        if (getBridge() == null) {
+            return;
+        }
+
+        PluginHandle handle = getBridge().getPlugin("AndroidSelection");
+        Plugin plugin = handle == null ? null : handle.getInstance();
+        if (plugin instanceof AndroidSelectionPlugin) {
+            ((AndroidSelectionPlugin) plugin).emitSelectionContextRequest();
+        }
     }
 
     void notifySelectionTap(float cssX, float cssY) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -608,12 +608,6 @@ const {
   logger: editorLog,
 })
 
-const canWriteSelectionDocument = computed(() =>
-  documentState.value.autosaveTarget === 'android-document'
-    ? currentAndroidDocumentCanWrite.value
-    : true,
-)
-
 // Whether the clipboard currently holds pasteable text. Read through the
 // native bridge on Android; on the web the Clipboard API may refuse to be
 // inspected (permissions) — offering Paste then beats silently losing it.
@@ -1710,7 +1704,6 @@ onBeforeUnmount(() => {
     :text-direction="appearanceTextSettings.textDirection"
     :editor-style-vars="editorStyleVars"
     :can-paste-selection="selectionClipboardHasText"
-    :can-write-selection="canWriteSelectionDocument"
     :selection-caret-session="selectionCaretSessionActive"
     :search-open="editorSearchOpen"
     :search-query="editorSearchQuery"

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,6 +37,8 @@ import {
 } from './lib/androidSelection'
 import { createDocumentOutline, waitForViewportSettle } from './features/editor/documentOutline'
 import { createDocumentSearch } from './features/editor/documentSearch'
+import { createSelectionToolbarLongPress } from './features/editor/selectionToolbarLongPress'
+import type { SelectionToolbarCommandId } from './features/editor/selectionToolbar'
 import { createResumePosition } from './features/editor/resumePosition'
 import {
   readStoredResumePosition,
@@ -606,6 +608,69 @@ const {
   logger: editorLog,
 })
 
+const canWriteSelectionDocument = computed(() =>
+  documentState.value.autosaveTarget === 'android-document'
+    ? currentAndroidDocumentCanWrite.value
+    : true,
+)
+
+// Whether the clipboard currently holds pasteable text. Read through the
+// native bridge on Android; on the web the Clipboard API may refuse to be
+// inspected (permissions) — offering Paste then beats silently losing it.
+async function queryClipboardHasText() {
+  if (isAndroidSelectionControlAvailable()) {
+    return (await readAndroidClipboardText()).length > 0
+  }
+
+  if (!navigator.clipboard?.readText) {
+    return false
+  }
+
+  try {
+    return (await navigator.clipboard.readText()).length > 0
+  } catch {
+    return true
+  }
+}
+
+const {
+  caretSessionActive: selectionCaretSessionActive,
+  clipboardHasText: selectionClipboardHasText,
+  enterFromContextRequest: enterSelectionToolbarContext,
+  notifyCommandRun: notifySelectionToolbarCommandRun,
+  notifyDocumentEdited: notifySelectionToolbarDocumentEdited,
+  endCaretSession: endSelectionCaretSession,
+  attachWebFallbacks: attachSelectionToolbarWebFallbacks,
+  resetForNewDocument: resetSelectionToolbarLongPress,
+} = createSelectionToolbarLongPress({
+  isEditorReady: () => editorReady.value,
+  getEditorHost: () => getEditor()?.domNode ?? null,
+  canActivate: () =>
+    currentScreen.value === 'editor' &&
+    !editorMenuOpen.value &&
+    !editorSearchOpen.value &&
+    !editorOutlineOpen.value &&
+    !linkSheetOpen.value &&
+    !draftExitPromptOpen.value &&
+    !androidExitPromptOpen.value,
+  queryClipboardHasText,
+  logger: editorLog,
+})
+
+// The suppressed native floating ActionMode started: refresh the clipboard
+// state and open a caret session when the long-press placed a caret.
+function handleSelectionContextRequest() {
+  void enterSelectionToolbarContext('native action mode')
+}
+
+async function runEditorSelectionCommand(
+  commandId: SelectionToolbarCommandId,
+  restoreRange: Range | null,
+) {
+  await runSelectionToolbarCommand(commandId, restoreRange)
+  notifySelectionToolbarCommandRun()
+}
+
 function openEditorOutline() {
   if (!hasEditor()) {
     return
@@ -617,6 +682,7 @@ function openEditorOutline() {
   // overlays coexist. No cursor restore — that would reopen the keyboard.
   closeEditorSearch({ restoreCursor: false })
   standDownResume('outline opened')
+  endSelectionCaretSession('outline opened')
   void openEditorOutlineSheet()
   appLog.info('editor outline opened')
 }
@@ -628,6 +694,7 @@ function openEditorOutline() {
 function toggleEditorMenuExclusive() {
   closeEditorOutline()
   standDownResume('menu opened')
+  endSelectionCaretSession('menu opened')
   toggleEditorMenu()
 }
 
@@ -644,10 +711,16 @@ async function openEditor(markdown: string) {
   // cached key (documentState already points at the incoming document here).
   void persistResumePosition('document replaced')
   resetResumeForNewDocument()
+  resetSelectionToolbarLongPress()
   resetEditorSearchForNewDocument()
   resetEditorOutlineForNewDocument()
   await openEditorSessionDocument(markdown)
   void startResumeForOpenedDocument()
+  // Long-press entry: Android uses the native suppressed-ActionMode signal;
+  // web dev/e2e fall back to in-page contextmenu + selection watching.
+  if (!isAndroidSelectionControlAvailable()) {
+    attachSelectionToolbarWebFallbacks()
+  }
 }
 
 function getTransientAndroidSaveMessage() {
@@ -709,8 +782,10 @@ function syncMarkdown(nextStatus: unknown = 'Edited') {
     // Content edits invalidate match offsets; re-run the open query so the
     // highlights and the match counter stay truthful.
     refreshEditorSearchAfterEdit()
-    // Edits also invalidate the resume offer and any in-flight re-pinning.
+    // Edits also invalidate the resume offer and any in-flight re-pinning,
+    // and end a long-press caret session (typing owns the caret now).
     notifyResumeDocumentEdited()
+    notifySelectionToolbarDocumentEdited()
   }
   if (markDirty && documentState.value.autosaveTarget === 'android-document') {
     status.value = getAndroidEditorStatus()
@@ -756,6 +831,7 @@ const {
   getEditor,
   getEditorElement,
   describeEditorInputState,
+  onSelectionContextRequest: handleSelectionContextRequest,
   logger: editorLog,
 })
 function insertMarkdownAtPendingSelection(markdown: string) {
@@ -781,6 +857,7 @@ function openLinkSheet(restoreRange: Range | null = null) {
   pendingInlineInsertRange = capturedRange
   closeEditorOutline()
   standDownResume('link sheet opened')
+  endSelectionCaretSession('link sheet opened')
   openEditorLinkSheet({
     text: nextLinkSheet.linkText,
     url: nextLinkSheet.linkUrl,
@@ -873,10 +950,6 @@ function syncAfterToolbarCommand(beforeMarkdown: string) {
     onUnchanged: () => syncDocumentFromEditor(documentState.value.isDirty),
   })
 }
-
-const canPasteSelection =
-  isAndroidSelectionControlAvailable() ||
-  (typeof navigator !== 'undefined' && Boolean(navigator.clipboard?.readText))
 
 function runEditorToolbarCommand(commandId: MobileCommandId, restoreRange: Range | null = null) {
   const activeEditor = editorReady.value ? getEditor() : null
@@ -1181,6 +1254,7 @@ function openEditorSearch() {
   // so the two surfaces can never end up open at the same time.
   closeEditorOutline()
   standDownResume('search opened')
+  endSelectionCaretSession('search opened')
   openEditorSearchBar()
   appLog.info('editor search opened')
 }
@@ -1227,6 +1301,7 @@ async function showHome() {
   closeEditorToolbar()
   closeEditorOutline()
   standDownResume('leaving editor')
+  endSelectionCaretSession('leaving editor')
   // Leaving the editor: clear highlights without refocusing the editor.
   closeEditorSearch({ restoreCursor: false })
 
@@ -1634,7 +1709,9 @@ onBeforeUnmount(() => {
     :android-saving="savingAndroidDocumentCopy"
     :text-direction="appearanceTextSettings.textDirection"
     :editor-style-vars="editorStyleVars"
-    :can-paste-selection="canPasteSelection"
+    :can-paste-selection="selectionClipboardHasText"
+    :can-write-selection="canWriteSelectionDocument"
+    :selection-caret-session="selectionCaretSessionActive"
     :search-open="editorSearchOpen"
     :search-query="editorSearchQuery"
     :search-match-count="editorSearchMatchCount"
@@ -1661,7 +1738,7 @@ onBeforeUnmount(() => {
     @save-to-device="saveLocalDraftToAndroidDocument"
     @save-copy="saveAndroidDocumentCopy"
     @run-toolbar-command="runEditorToolbarCommand"
-    @run-selection-command="runSelectionToolbarCommand"
+    @run-selection-command="runEditorSelectionCommand"
     @dismiss-selection="finishSelectionToolbarOutsideTap"
     @toggle-toolbar="toggleEditorToolbarExclusive"
     @set-toolbar-panel="setEditorToolbarPanel"

--- a/src/features/editor/EditorScreen.vue
+++ b/src/features/editor/EditorScreen.vue
@@ -55,7 +55,6 @@ const props = defineProps<{
   textDirection: 'ltr' | 'rtl'
   editorStyleVars: CSSProperties
   canPasteSelection: boolean
-  canWriteSelection: boolean
   selectionCaretSession: boolean
   searchOpen: boolean
   searchQuery: string
@@ -341,7 +340,6 @@ onBeforeUnmount(() => {
       :suspended="selectionToolbarSuspended"
       :host="editorShell"
       :can-paste="canPasteSelection"
-      :can-write="canWriteSelection"
       :caret-session="selectionCaretSession"
       @run-command="
         (commandId, restoreRange) => emit('run-selection-command', commandId, restoreRange)

--- a/src/features/editor/EditorScreen.vue
+++ b/src/features/editor/EditorScreen.vue
@@ -55,6 +55,8 @@ const props = defineProps<{
   textDirection: 'ltr' | 'rtl'
   editorStyleVars: CSSProperties
   canPasteSelection: boolean
+  canWriteSelection: boolean
+  selectionCaretSession: boolean
   searchOpen: boolean
   searchQuery: string
   searchMatchCount: number
@@ -339,6 +341,8 @@ onBeforeUnmount(() => {
       :suspended="selectionToolbarSuspended"
       :host="editorShell"
       :can-paste="canPasteSelection"
+      :can-write="canWriteSelection"
+      :caret-session="selectionCaretSession"
       @run-command="
         (commandId, restoreRange) => emit('run-selection-command', commandId, restoreRange)
       "

--- a/src/features/editor/components/MobileSelectionToolbar.vue
+++ b/src/features/editor/components/MobileSelectionToolbar.vue
@@ -16,7 +16,6 @@ const props = defineProps<{
   suspended: boolean
   host: HTMLElement | null
   canPaste: boolean
-  canWrite: boolean
   caretSession: boolean
 }>()
 
@@ -29,6 +28,12 @@ const { t } = useI18n()
 const visible = ref(false)
 // Drives the state-table action set: selection rows vs caret rows.
 const hasSelection = ref(false)
+// The EDITOR's actual editability — deliberately not the source-URI write
+// capability: an Android document whose URI cannot be overwritten is still
+// fully editable in memory (the Save-copy workflow), so it keeps Cut and
+// Paste. The read-only table rows apply only when the editable surface
+// itself is non-editable.
+const canWrite = ref(true)
 const left = ref(0)
 const top = ref(0)
 const placement = ref<'above' | 'below'>('above')
@@ -60,9 +65,14 @@ const toolbarCommands = computed(() =>
   getSelectionToolbarCommands({
     hasSelection: hasSelection.value,
     canPaste: props.canPaste,
-    canWrite: props.canWrite,
+    canWrite: canWrite.value,
   }),
 )
+
+function readEditorEditability() {
+  const editorRoot = props.host?.querySelector('.mu-editor')
+  return editorRoot ? editorRoot.getAttribute('contenteditable') !== 'false' : true
+}
 
 function updateFromSelection() {
   const snapshot = getDomSelectionSnapshot(props.host)
@@ -79,6 +89,7 @@ function updateFromSelection() {
   }
 
   hasSelection.value = !snapshot.collapsed
+  canWrite.value = readEditorEditability()
 
   const box = toolbarElement.value
     ? {
@@ -258,7 +269,6 @@ watch(
       props.suspended,
       props.host,
       props.canPaste,
-      props.canWrite,
       props.caretSession,
     ] as const,
   scheduleUpdate,

--- a/src/features/editor/components/MobileSelectionToolbar.vue
+++ b/src/features/editor/components/MobileSelectionToolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import {
   caretRangeAtPoint,
   captureNonCollapsedSelectionRange,
@@ -16,6 +16,8 @@ const props = defineProps<{
   suspended: boolean
   host: HTMLElement | null
   canPaste: boolean
+  canWrite: boolean
+  caretSession: boolean
 }>()
 
 const emit = defineEmits<{
@@ -25,6 +27,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const visible = ref(false)
+// Drives the state-table action set: selection rows vs caret rows.
+const hasSelection = ref(false)
 const left = ref(0)
 const top = ref(0)
 const placement = ref<'above' | 'below'>('above')
@@ -52,18 +56,29 @@ function scheduleUpdate() {
   })
 }
 
+const toolbarCommands = computed(() =>
+  getSelectionToolbarCommands({
+    hasSelection: hasSelection.value,
+    canPaste: props.canPaste,
+    canWrite: props.canWrite,
+  }),
+)
+
 function updateFromSelection() {
   const snapshot = getDomSelectionSnapshot(props.host)
   const nextVisible = shouldShowSelectionToolbar({
     editorReady: props.editorReady,
     suspended: props.suspended,
     snapshot,
+    caretSession: props.caretSession,
   })
 
   if (!nextVisible || !snapshot?.rect) {
     visible.value = false
     return
   }
+
+  hasSelection.value = !snapshot.collapsed
 
   const box = toolbarElement.value
     ? {
@@ -96,7 +111,9 @@ function runCommand(commandId: SelectionToolbarCommandId) {
     return
   }
 
-  emit('runCommand', commandId, lastEditorSelectionRange)
+  // Caret rows must not resurrect a stale earlier selection: paste lands at
+  // the long-pressed caret, not at whatever was selected minutes ago.
+  emit('runCommand', commandId, hasSelection.value ? lastEditorSelectionRange : null)
 }
 
 // Touch path: the toolbar container prevents touchstart, because on Android
@@ -235,7 +252,15 @@ onBeforeUnmount(() => {
 })
 
 watch(
-  () => [props.editorReady, props.suspended, props.host, props.canPaste] as const,
+  () =>
+    [
+      props.editorReady,
+      props.suspended,
+      props.host,
+      props.canPaste,
+      props.canWrite,
+      props.caretSession,
+    ] as const,
   scheduleUpdate,
 )
 </script>
@@ -257,7 +282,7 @@ watch(
     @mousedown.prevent
   >
     <button
-      v-for="command in getSelectionToolbarCommands(canPaste)"
+      v-for="command in toolbarCommands"
       :key="command.commandId"
       class="selection-toolbar-button"
       :class="{ 'is-pressed': pressedCommandId === command.commandId }"

--- a/src/features/editor/selectionLifecycle.ts
+++ b/src/features/editor/selectionLifecycle.ts
@@ -3,6 +3,7 @@ import type { MuyaEditor } from './editorRuntime'
 import { captureSelectionWithin, resolveEditorDomNode } from './editorInlineInsert'
 import { caretRangeAtPoint, type SelectionToolbarCommandId } from './selectionToolbar'
 import {
+  addAndroidSelectionContextListener,
   addAndroidSelectionTapListener,
   finishAndroidEditorSelectionActionMode,
   isAndroidSelectionControlAvailable,
@@ -24,6 +25,12 @@ export interface EditorSelectionLifecycleOptions {
   getEditor: () => MuyaEditor | null
   getEditorElement: () => HTMLElement | null
   describeEditorInputState: () => Record<string, unknown>
+  /**
+   * The suppressed native floating ActionMode started — the moment Android
+   * would have shown its own clipboard menu (long-press selection,
+   * double-tap word select, insertion-caret menu).
+   */
+  onSelectionContextRequest?: () => void
   logger: SelectionLogger
 }
 
@@ -52,6 +59,7 @@ export function createEditorSelectionLifecycle(
   options: EditorSelectionLifecycleOptions,
 ): EditorSelectionLifecycle {
   let nativeSelectionTapCleanup: (() => Promise<void>) | null = null
+  let nativeSelectionContextCleanup: (() => Promise<void>) | null = null
 
   function captureEditorSelection() {
     return captureSelectionWithin(
@@ -329,7 +337,14 @@ export function createEditorSelectionLifecycle(
           getCurrentSelectionRangeClone(),
         )
       } else if (commandId === 'paste') {
-        restoreEditorSelectionRange(activeEditor, restoreRange)
+        const restored = restoreEditorSelectionRange(activeEditor, restoreRange)
+        if (!restored) {
+          // Long-press caret paste: no expanded range to restore. Adopt the
+          // live collapsed DOM caret into Muya's selection model so the
+          // paste lands at the long-pressed position instead of a stale
+          // cached selection.
+          syncMuyaSelectionFromDom(activeEditor)
+        }
         await activeEditor.editor.clipboard.pasteAsPlainText()
         await finishEditorSelectionActionModeAndRestoreCaret(
           'selection-toolbar-paste',
@@ -392,19 +407,41 @@ export function createEditorSelectionLifecycle(
     finishSelectionToolbarOutsideTap(caret)
   }
 
+  function handleNativeSelectionContextRequest() {
+    if (options.currentScreen.value !== 'editor' || !options.editorReady.value) {
+      return
+    }
+
+    options.onSelectionContextRequest?.()
+  }
+
   async function installNativeSelectionTapListener() {
     await uninstallNativeSelectionTapListener()
     nativeSelectionTapCleanup = await addAndroidSelectionTapListener(handleNativeSelectionTap)
+    if (options.onSelectionContextRequest) {
+      nativeSelectionContextCleanup = await addAndroidSelectionContextListener(
+        handleNativeSelectionContextRequest,
+      )
+    }
   }
 
   async function uninstallNativeSelectionTapListener() {
     const cleanup = nativeSelectionTapCleanup
+    const contextCleanup = nativeSelectionContextCleanup
     nativeSelectionTapCleanup = null
+    nativeSelectionContextCleanup = null
     if (cleanup) {
       try {
         await cleanup()
       } catch (error) {
         options.logger.debug('native selection tap listener cleanup failed', { error })
+      }
+    }
+    if (contextCleanup) {
+      try {
+        await contextCleanup()
+      } catch (error) {
+        options.logger.debug('native selection context listener cleanup failed', { error })
       }
     }
   }

--- a/src/features/editor/selectionToolbar.test.ts
+++ b/src/features/editor/selectionToolbar.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import {
-  SELECTION_TOOLBAR_COMMANDS,
   computeSelectionToolbarPlacement,
   getSelectionToolbarCommands,
   shouldShowSelectionToolbar,
@@ -22,29 +21,53 @@ function createRect(overrides: Partial<SelectionRect> = {}): SelectionRect {
   }
 }
 
+function commandIds(input: { hasSelection: boolean; canPaste: boolean; canWrite: boolean }) {
+  return getSelectionToolbarCommands(input).map(command => command.commandId)
+}
+
 describe('selection toolbar commands', () => {
-  it('exposes copy, cut, paste, and select all in order', () => {
-    expect(SELECTION_TOOLBAR_COMMANDS.map(command => command.commandId)).toEqual([
-      'copy',
-      'cut',
+  it('matches the product state table row by row', () => {
+    // Editable, no selection, clipboard has pasteable content.
+    expect(commandIds({ hasSelection: false, canPaste: true, canWrite: true })).toEqual([
       'paste',
       'selectAll',
     ])
-    expect(SELECTION_TOOLBAR_COMMANDS.map(command => command.iconName)).toEqual([
-      'copy',
+    // Editable, no selection, clipboard empty.
+    expect(commandIds({ hasSelection: false, canPaste: false, canWrite: true })).toEqual([
+      'selectAll',
+    ])
+    // Editable, selection, clipboard has pasteable content.
+    expect(commandIds({ hasSelection: true, canPaste: true, canWrite: true })).toEqual([
       'cut',
+      'copy',
       'paste',
+      'selectAll',
+    ])
+    // Editable, selection, clipboard empty.
+    expect(commandIds({ hasSelection: true, canPaste: false, canWrite: true })).toEqual([
+      'cut',
+      'copy',
+      'selectAll',
+    ])
+    // Read-only with selection: no cut, no paste even with clipboard content.
+    expect(commandIds({ hasSelection: true, canPaste: true, canWrite: false })).toEqual([
+      'copy',
+      'selectAll',
+    ])
+    // Read-only without a selection.
+    expect(commandIds({ hasSelection: false, canPaste: true, canWrite: false })).toEqual([
       'selectAll',
     ])
   })
 
-  it('drops paste when clipboard read is unavailable', () => {
-    expect(getSelectionToolbarCommands(false).map(command => command.commandId)).toEqual([
-      'copy',
-      'cut',
-      'selectAll',
-    ])
-    expect(getSelectionToolbarCommands(true)).toEqual(SELECTION_TOOLBAR_COMMANDS)
+  it('keeps select all available in every state', () => {
+    for (const hasSelection of [true, false]) {
+      for (const canPaste of [true, false]) {
+        for (const canWrite of [true, false]) {
+          expect(commandIds({ hasSelection, canPaste, canWrite })).toContain('selectAll')
+        }
+      }
+    }
   })
 })
 
@@ -127,6 +150,56 @@ describe('selection toolbar visibility', () => {
         editorReady: true,
         suspended: false,
         snapshot: { ...visibleSnapshot, rect: null },
+      }),
+    ).toBe(false)
+  })
+
+  it('shows a collapsed caret only during a long-press session', () => {
+    const caretSnapshot = { ...visibleSnapshot, collapsed: true, text: '' }
+
+    // Ordinary caret placement never opens the toolbar...
+    expect(
+      shouldShowSelectionToolbar({
+        editorReady: true,
+        suspended: false,
+        snapshot: caretSnapshot,
+      }),
+    ).toBe(false)
+
+    // ...a long-press caret session does — including with empty text
+    // (empty document), as long as a placement rect exists.
+    expect(
+      shouldShowSelectionToolbar({
+        editorReady: true,
+        suspended: false,
+        snapshot: caretSnapshot,
+        caretSession: true,
+      }),
+    ).toBe(true)
+
+    // The session never overrides suspension, editor readiness, or bounds.
+    expect(
+      shouldShowSelectionToolbar({
+        editorReady: true,
+        suspended: true,
+        snapshot: caretSnapshot,
+        caretSession: true,
+      }),
+    ).toBe(false)
+    expect(
+      shouldShowSelectionToolbar({
+        editorReady: true,
+        suspended: false,
+        snapshot: { ...caretSnapshot, withinEditor: false },
+        caretSession: true,
+      }),
+    ).toBe(false)
+    expect(
+      shouldShowSelectionToolbar({
+        editorReady: true,
+        suspended: false,
+        snapshot: { ...caretSnapshot, rect: null },
+        caretSession: true,
       }),
     ).toBe(false)
   })

--- a/src/features/editor/selectionToolbar.ts
+++ b/src/features/editor/selectionToolbar.ts
@@ -9,17 +9,63 @@ export interface SelectionToolbarCommand {
   iconName: SelectionToolbarIconName
 }
 
-export const SELECTION_TOOLBAR_COMMANDS: readonly SelectionToolbarCommand[] = [
-  { commandId: 'copy', labelKey: 'editor.selection.copy', iconName: 'copy' },
-  { commandId: 'cut', labelKey: 'editor.selection.cut', iconName: 'cut' },
-  { commandId: 'paste', labelKey: 'editor.selection.paste', iconName: 'paste' },
-  { commandId: 'selectAll', labelKey: 'editor.selection.selectAll', iconName: 'selectAll' },
-]
+const CUT: SelectionToolbarCommand = {
+  commandId: 'cut',
+  labelKey: 'editor.selection.cut',
+  iconName: 'cut',
+}
+const COPY: SelectionToolbarCommand = {
+  commandId: 'copy',
+  labelKey: 'editor.selection.copy',
+  iconName: 'copy',
+}
+const PASTE: SelectionToolbarCommand = {
+  commandId: 'paste',
+  labelKey: 'editor.selection.paste',
+  iconName: 'paste',
+}
+const SELECT_ALL: SelectionToolbarCommand = {
+  commandId: 'selectAll',
+  labelKey: 'editor.selection.selectAll',
+  iconName: 'selectAll',
+}
 
-export function getSelectionToolbarCommands(canPaste: boolean) {
-  return canPaste
-    ? SELECTION_TOOLBAR_COMMANDS
-    : SELECTION_TOOLBAR_COMMANDS.filter(command => command.commandId !== 'paste')
+/**
+ * The floating toolbar's action set, straight from the product state table:
+ *
+ *   editable + selection  → Cut, Copy, [Paste], Select all
+ *   editable + caret      → [Paste], Select all
+ *   read-only + selection → Copy, Select all
+ *   read-only + caret     → Select all
+ *
+ * Paste appears only when the clipboard actually holds pasteable content.
+ * Select all is always offered — including in an empty document.
+ */
+export function getSelectionToolbarCommands({
+  hasSelection,
+  canPaste,
+  canWrite,
+}: {
+  hasSelection: boolean
+  canPaste: boolean
+  canWrite: boolean
+}): SelectionToolbarCommand[] {
+  const commands: SelectionToolbarCommand[] = []
+
+  if (hasSelection && canWrite) {
+    commands.push(CUT)
+  }
+
+  if (hasSelection) {
+    commands.push(COPY)
+  }
+
+  if (canWrite && canPaste) {
+    commands.push(PASTE)
+  }
+
+  commands.push(SELECT_ALL)
+  return commands
 }
 
 export interface SelectionRect {
@@ -42,20 +88,27 @@ export function shouldShowSelectionToolbar(input: {
   editorReady: boolean
   suspended: boolean
   snapshot: SelectionSnapshot | null
+  /** A long-press placed a caret: the toolbar shows for it too. */
+  caretSession?: boolean
 }): boolean {
-  const { editorReady, suspended, snapshot } = input
+  const { editorReady, suspended, snapshot, caretSession = false } = input
   if (!editorReady || suspended || !snapshot) {
     return false
   }
 
+  if (!snapshot.withinEditor || snapshot.rect === null) {
+    return false
+  }
+
+  // A long-press caret session shows the toolbar at the collapsed caret —
+  // including in an empty document (paste / select-all need no text).
+  if (snapshot.collapsed) {
+    return caretSession
+  }
+
   // A selection without visible text (an empty block or the quick-insert
   // placeholder hint) has nothing for copy/cut/select-all to operate on.
-  return (
-    !snapshot.collapsed &&
-    snapshot.withinEditor &&
-    snapshot.rect !== null &&
-    snapshot.text.trim().length > 0
-  )
+  return snapshot.text.trim().length > 0
 }
 
 export interface SelectionToolbarBox {
@@ -146,6 +199,30 @@ export function getDomSelectionSnapshot(host: HTMLElement | null): SelectionSnap
     host.contains(range.startContainer) && host.contains(range.endContainer)
   const rect = range.getBoundingClientRect()
   const hasVisibleRect = rect.width > 0 || rect.height > 0
+
+  // A collapsed caret in an empty block reports an all-zero range rect;
+  // anchor the toolbar to the caret's block element instead so a long-press
+  // in an empty document still has a placement target.
+  if (!hasVisibleRect && selection.isCollapsed && withinEditor) {
+    const node = range.startContainer
+    const element = node instanceof Element ? node : node.parentElement
+    const elementRect = element?.getBoundingClientRect()
+    if (elementRect && (elementRect.width > 0 || elementRect.height > 0)) {
+      return {
+        collapsed: true,
+        withinEditor,
+        text: '',
+        rect: {
+          left: elementRect.left,
+          top: elementRect.top,
+          right: elementRect.left,
+          bottom: elementRect.bottom,
+          width: 0,
+          height: elementRect.height,
+        },
+      }
+    }
+  }
 
   return {
     collapsed: selection.isCollapsed,

--- a/src/features/editor/selectionToolbarLongPress.test.ts
+++ b/src/features/editor/selectionToolbarLongPress.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createSelectionToolbarLongPress } from './selectionToolbarLongPress'
+
+function buildEditorHost() {
+  const host = document.createElement('div')
+  const paragraph = document.createElement('p')
+  paragraph.textContent = 'Alpha bravo charlie'
+  host.append(paragraph)
+  document.body.append(host)
+  return { host, paragraph }
+}
+
+function placeCaret(node: Node, offset = 0) {
+  const range = document.createRange()
+  range.setStart(node.firstChild ?? node, offset)
+  range.collapse(true)
+  const selection = document.getSelection()!
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
+
+function selectText(node: Node) {
+  const range = document.createRange()
+  range.selectNodeContents(node)
+  const selection = document.getSelection()!
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
+
+// happy-dom does not dispatch selectionchange on its own; fire it manually
+// after mutating the selection, the way real browsers do asynchronously.
+function fireSelectionChange() {
+  document.dispatchEvent(new Event('selectionchange'))
+}
+
+interface HarnessOverrides {
+  canActivate?: () => boolean
+  clipboardText?: () => Promise<boolean>
+}
+
+function createHarness(overrides: HarnessOverrides = {}) {
+  const { host, paragraph } = buildEditorHost()
+  const longPress = createSelectionToolbarLongPress({
+    isEditorReady: () => true,
+    getEditorHost: () => host,
+    canActivate: overrides.canActivate ?? (() => true),
+    queryClipboardHasText: overrides.clipboardText ?? (() => Promise.resolve(true)),
+    logger: { debug: vi.fn() },
+  })
+  return { longPress, host, paragraph }
+}
+
+afterEach(() => {
+  document.getSelection()?.removeAllRanges()
+  document.body.innerHTML = ''
+})
+
+describe('createSelectionToolbarLongPress', () => {
+  it('opens a caret session for a collapsed caret and refreshes the clipboard state', async () => {
+    const { longPress, paragraph } = createHarness()
+    placeCaret(paragraph, 2)
+
+    await longPress.enterFromContextRequest('test')
+
+    expect(longPress.caretSessionActive.value).toBe(true)
+    expect(longPress.clipboardHasText.value).toBe(true)
+  })
+
+  it('only refreshes the clipboard state when a selection already exists', async () => {
+    const { longPress, paragraph } = createHarness({
+      clipboardText: () => Promise.resolve(false),
+    })
+    selectText(paragraph)
+
+    await longPress.enterFromContextRequest('test')
+
+    expect(longPress.caretSessionActive.value).toBe(false)
+    expect(longPress.clipboardHasText.value).toBe(false)
+  })
+
+  it('refuses to enter while a competing surface owns the interaction', async () => {
+    const { longPress, paragraph } = createHarness({ canActivate: () => false })
+    placeCaret(paragraph)
+
+    await longPress.enterFromContextRequest('test')
+
+    expect(longPress.caretSessionActive.value).toBe(false)
+  })
+
+  it('ends the caret session on an ordinary tap outside the floating toolbar', async () => {
+    const { longPress, paragraph } = createHarness()
+    placeCaret(paragraph)
+    await longPress.enterFromContextRequest('test')
+
+    document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+
+    expect(longPress.caretSessionActive.value).toBe(false)
+  })
+
+  it('keeps the session alive for taps on the floating toolbar itself', async () => {
+    const { longPress, paragraph } = createHarness()
+    const toolbar = document.createElement('div')
+    toolbar.dataset.testid = 'mobile-selection-toolbar'
+    const button = document.createElement('button')
+    toolbar.append(button)
+    document.body.append(toolbar)
+    placeCaret(paragraph)
+    await longPress.enterFromContextRequest('test')
+
+    button.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+
+    expect(longPress.caretSessionActive.value).toBe(true)
+  })
+
+  it('ends the caret session when the caret moves', async () => {
+    const { longPress, paragraph } = createHarness()
+    placeCaret(paragraph, 1)
+    await longPress.enterFromContextRequest('test')
+
+    placeCaret(paragraph, 5)
+    fireSelectionChange()
+
+    expect(longPress.caretSessionActive.value).toBe(false)
+  })
+
+  it('hands over to the selection-driven display when the caret widens', async () => {
+    const { longPress, paragraph } = createHarness()
+    placeCaret(paragraph, 1)
+    await longPress.enterFromContextRequest('test')
+
+    selectText(paragraph)
+    fireSelectionChange()
+
+    // The caret session ends; the selection itself keeps the toolbar shown
+    // through the existing selection-driven path.
+    expect(longPress.caretSessionActive.value).toBe(false)
+  })
+
+  it('ends the caret session on edits, command runs, and document replacement', async () => {
+    const { longPress, paragraph } = createHarness()
+
+    placeCaret(paragraph)
+    await longPress.enterFromContextRequest('edit case')
+    longPress.notifyDocumentEdited()
+    expect(longPress.caretSessionActive.value).toBe(false)
+
+    placeCaret(paragraph)
+    await longPress.enterFromContextRequest('command case')
+    longPress.notifyCommandRun()
+    expect(longPress.caretSessionActive.value).toBe(false)
+
+    placeCaret(paragraph)
+    await longPress.enterFromContextRequest('reset case')
+    longPress.resetForNewDocument()
+    expect(longPress.caretSessionActive.value).toBe(false)
+    expect(longPress.clipboardHasText.value).toBe(false)
+  })
+
+  it('drops a stale entry when a surface opened during the clipboard query', async () => {
+    let activatable = true
+    let resolveClipboard: (value: boolean) => void = () => {}
+    const { longPress, paragraph } = createHarness({
+      canActivate: () => activatable,
+      clipboardText: () => new Promise(resolve => (resolveClipboard = resolve)),
+    })
+    placeCaret(paragraph)
+
+    const entry = longPress.enterFromContextRequest('test')
+    activatable = false
+    resolveClipboard(true)
+    await entry
+
+    expect(longPress.caretSessionActive.value).toBe(false)
+  })
+})

--- a/src/features/editor/selectionToolbarLongPress.test.ts
+++ b/src/features/editor/selectionToolbarLongPress.test.ts
@@ -174,4 +174,69 @@ describe('createSelectionToolbarLongPress', () => {
 
     expect(longPress.caretSessionActive.value).toBe(false)
   })
+
+  it('drops a pending request when the caret moves during the clipboard query', async () => {
+    let resolveClipboard: (value: boolean) => void = () => {}
+    const { longPress, paragraph } = createHarness({
+      clipboardText: () => new Promise(resolve => (resolveClipboard = resolve)),
+    })
+    placeCaret(paragraph, 1)
+
+    // Long-press at caret A; an ordinary tap moves the caret to B while the
+    // clipboard query is still pending. B came from an ordinary interaction
+    // and must not get a toolbar.
+    const entry = longPress.enterFromContextRequest('test')
+    placeCaret(paragraph, 5)
+    resolveClipboard(true)
+    await entry
+
+    expect(longPress.caretSessionActive.value).toBe(false)
+  })
+
+  it('drops a pending request invalidated by an edit during the clipboard query', async () => {
+    let resolveClipboard: (value: boolean) => void = () => {}
+    const { longPress, paragraph } = createHarness({
+      clipboardText: () => new Promise(resolve => (resolveClipboard = resolve)),
+    })
+    placeCaret(paragraph, 1)
+
+    const entry = longPress.enterFromContextRequest('test')
+    // Typing both edits the document and (in this harness) leaves the caret
+    // where it was — the generation bump alone must kill the request.
+    longPress.notifyDocumentEdited()
+    resolveClipboard(true)
+    await entry
+
+    expect(longPress.caretSessionActive.value).toBe(false)
+  })
+
+  it('drops a pending request ended by a competing surface during the query', async () => {
+    let resolveClipboard: (value: boolean) => void = () => {}
+    const { longPress, paragraph } = createHarness({
+      clipboardText: () => new Promise(resolve => (resolveClipboard = resolve)),
+    })
+    placeCaret(paragraph, 1)
+
+    const entry = longPress.enterFromContextRequest('test')
+    longPress.endCaretSession('search opened')
+    resolveClipboard(true)
+    await entry
+
+    expect(longPress.caretSessionActive.value).toBe(false)
+  })
+
+  it('still opens when the caret is unchanged after a deferred clipboard query', async () => {
+    let resolveClipboard: (value: boolean) => void = () => {}
+    const { longPress, paragraph } = createHarness({
+      clipboardText: () => new Promise(resolve => (resolveClipboard = resolve)),
+    })
+    placeCaret(paragraph, 1)
+
+    const entry = longPress.enterFromContextRequest('test')
+    resolveClipboard(true)
+    await entry
+
+    expect(longPress.caretSessionActive.value).toBe(true)
+    expect(longPress.clipboardHasText.value).toBe(true)
+  })
 })

--- a/src/features/editor/selectionToolbarLongPress.ts
+++ b/src/features/editor/selectionToolbarLongPress.ts
@@ -171,21 +171,35 @@ export function createSelectionToolbarLongPress({
       return
     }
 
+    // The request is bound to the caret that existed at the long-press
+    // itself, BEFORE the asynchronous clipboard query: anything that moves
+    // the caret during the query (an ordinary tap, typing, arrow keys) came
+    // from an ordinary interaction and must not open the toolbar.
+    const entryCaret = getCollapsedEditorCaret()
+
     generation += 1
     const requestGeneration = generation
     await refreshClipboardHasText()
+    // Every dismissal path (surfaces, edits, command runs, document
+    // replacement) advances the generation and invalidates this request
+    // even though the toolbar never became visible.
     if (generation !== requestGeneration || !isEditorReady() || !canActivate()) {
       return
     }
 
     // A non-collapsed selection is already handled by the selection-driven
     // display; the clipboard refresh above was all it needed.
-    const caret = getCollapsedEditorCaret()
-    if (!caret) {
+    if (!entryCaret) {
       logger?.debug('selection toolbar clipboard state refreshed', {
         source,
         canPaste: clipboardHasText.value,
       })
+      return
+    }
+
+    const caret = getCollapsedEditorCaret()
+    if (!caret || caret.node !== entryCaret.node || caret.offset !== entryCaret.offset) {
+      logger?.debug('selection toolbar caret session dropped: caret became stale', { source })
       return
     }
 
@@ -210,12 +224,15 @@ export function createSelectionToolbarLongPress({
   }
 
   function notifyDocumentEdited() {
-    if (caretSessionActive.value) {
-      endCaretSession('document edited')
-    }
+    // Unconditional: an edit must also invalidate a context request whose
+    // clipboard query is still pending, not just an already-visible session.
+    endCaretSession('document edited')
   }
 
   function endCaretSession(reason: string) {
+    // Also invalidates a context request whose clipboard query is still in
+    // flight — dismissal applies before the toolbar ever becomes visible.
+    generation += 1
     removeCaretSessionWatch()
     sessionAnchorNode = null
     sessionAnchorOffset = -1

--- a/src/features/editor/selectionToolbarLongPress.ts
+++ b/src/features/editor/selectionToolbarLongPress.ts
@@ -1,0 +1,305 @@
+import { ref, type Ref } from 'vue'
+
+interface SelectionToolbarLongPressLogger {
+  debug(message: string, context?: Record<string, unknown>): void
+}
+
+export interface CreateSelectionToolbarLongPressOptions {
+  isEditorReady: () => boolean
+  /** Muya's live editor root; taps and carets are qualified against it. */
+  getEditorHost: () => HTMLElement | null
+  /** False while a sheet/prompt/menu owns the interaction surface. */
+  canActivate: () => boolean
+  /** Resolve whether the clipboard currently holds pasteable text. */
+  queryClipboardHasText: () => Promise<boolean>
+  logger?: SelectionToolbarLongPressLogger
+}
+
+export interface SelectionToolbarLongPress {
+  /** A long-press placed a collapsed caret and the toolbar shows for it. */
+  caretSessionActive: Ref<boolean>
+  /** Content-aware paste availability, refreshed on every context request. */
+  clipboardHasText: Ref<boolean>
+  /**
+   * The suppressed native ActionMode started (long-press selection,
+   * double-tap word select, insertion-caret menu) — refresh the clipboard
+   * state and, for a collapsed caret, open a caret session.
+   */
+  enterFromContextRequest(source: string): Promise<void>
+  /** A toolbar command finished; paste and select-all end the caret session. */
+  notifyCommandRun(): void
+  /** Content changed through typing or other edits. */
+  notifyDocumentEdited(): void
+  /** A competing surface takes the interaction. */
+  endCaretSession(reason: string): void
+  /**
+   * In-page fallbacks for environments without the native ActionMode signal
+   * (web dev and e2e): Chromium fires contextmenu for long-press and
+   * right-click, and a selection created without any signal still refreshes
+   * the clipboard state. Deliberately NOT used on Android, where the native
+   * signal covers every entry path and preventing contextmenu can interfere
+   * with the native touch-selection flow.
+   */
+  attachWebFallbacks(): void
+  /** Drop everything on document replacement or editor destruction. */
+  resetForNewDocument(): void
+}
+
+/**
+ * Long-press session state for the floating selection toolbar. The existing
+ * selection-driven display is untouched: this only adds the caret rows of
+ * the state table (paste / select-all without a selection) and keeps the
+ * paste action truthful to the actual clipboard content. A caret session
+ * follows the native insertion-menu conventions: it ends on an ordinary tap,
+ * on caret movement, on edits, when a competing surface opens, or when the
+ * caret widens into a selection (the selection-driven display takes over).
+ */
+export function createSelectionToolbarLongPress({
+  isEditorReady,
+  getEditorHost,
+  canActivate,
+  queryClipboardHasText,
+  logger,
+}: CreateSelectionToolbarLongPressOptions): SelectionToolbarLongPress {
+  const caretSessionActive = ref(false)
+  const clipboardHasText = ref(false)
+
+  let generation = 0
+  let sessionCleanup: (() => void) | null = null
+  let contextMenuCleanup: (() => void) | null = null
+  let selectionRefreshCleanup: (() => void) | null = null
+  // The DOM caret the session was opened for; movement ends the session.
+  let sessionAnchorNode: Node | null = null
+  let sessionAnchorOffset = -1
+
+  function getCollapsedEditorCaret(): { node: Node; offset: number } | null {
+    const host = getEditorHost()
+    const selection = document.getSelection()
+    if (!host || !selection || selection.rangeCount === 0 || !selection.isCollapsed) {
+      return null
+    }
+
+    const range = selection.getRangeAt(0)
+    if (!host.contains(range.startContainer)) {
+      return null
+    }
+
+    return { node: range.startContainer, offset: range.startOffset }
+  }
+
+  function hasEditorSelection(): boolean {
+    const host = getEditorHost()
+    const selection = document.getSelection()
+    if (!host || !selection || selection.rangeCount === 0 || selection.isCollapsed) {
+      return false
+    }
+
+    const range = selection.getRangeAt(0)
+    return host.contains(range.startContainer) && host.contains(range.endContainer)
+  }
+
+  async function refreshClipboardHasText() {
+    const requestGeneration = generation
+    let hasText: boolean
+    try {
+      hasText = await queryClipboardHasText()
+    } catch {
+      hasText = false
+    }
+
+    if (generation === requestGeneration) {
+      clipboardHasText.value = hasText
+    }
+  }
+
+  function installCaretSessionWatch() {
+    removeCaretSessionWatch()
+
+    const onPointerDown = (event: Event) => {
+      // Taps on the floating toolbar belong to the session; anything else —
+      // an ordinary tap, a caret move — ends it, matching the native
+      // insertion menu.
+      if (
+        event.target instanceof Node &&
+        event.target instanceof Element &&
+        event.target.closest('[data-testid="mobile-selection-toolbar"]')
+      ) {
+        return
+      }
+
+      endCaretSession('pointer down')
+    }
+
+    const onSelectionChange = () => {
+      if (!caretSessionActive.value) {
+        return
+      }
+
+      if (hasEditorSelection()) {
+        // The insertion handle was dragged into a selection: the existing
+        // selection-driven display takes over seamlessly.
+        endCaretSession('selection created')
+        return
+      }
+
+      const caret = getCollapsedEditorCaret()
+      if (
+        !caret ||
+        caret.node !== sessionAnchorNode ||
+        caret.offset !== sessionAnchorOffset
+      ) {
+        // Ordinary caret movement (or the caret left the editor entirely).
+        endCaretSession('caret moved')
+      }
+    }
+
+    document.addEventListener('pointerdown', onPointerDown, true)
+    document.addEventListener('selectionchange', onSelectionChange)
+    sessionCleanup = () => {
+      document.removeEventListener('pointerdown', onPointerDown, true)
+      document.removeEventListener('selectionchange', onSelectionChange)
+    }
+  }
+
+  function removeCaretSessionWatch() {
+    sessionCleanup?.()
+    sessionCleanup = null
+  }
+
+  async function enterFromContextRequest(source: string) {
+    if (!isEditorReady() || !canActivate() || !getEditorHost()) {
+      return
+    }
+
+    generation += 1
+    const requestGeneration = generation
+    await refreshClipboardHasText()
+    if (generation !== requestGeneration || !isEditorReady() || !canActivate()) {
+      return
+    }
+
+    // A non-collapsed selection is already handled by the selection-driven
+    // display; the clipboard refresh above was all it needed.
+    const caret = getCollapsedEditorCaret()
+    if (!caret) {
+      logger?.debug('selection toolbar clipboard state refreshed', {
+        source,
+        canPaste: clipboardHasText.value,
+      })
+      return
+    }
+
+    sessionAnchorNode = caret.node
+    sessionAnchorOffset = caret.offset
+    installCaretSessionWatch()
+
+    if (!caretSessionActive.value) {
+      caretSessionActive.value = true
+      logger?.debug('selection toolbar caret session entered', {
+        source,
+        canPaste: clipboardHasText.value,
+      })
+    }
+  }
+
+  function notifyCommandRun() {
+    // Paste ends the caret interaction; select-all replaces it with a real
+    // selection that the selection-driven display owns. Either way the caret
+    // session itself is over. (Selection-driven copy/cut never involve it.)
+    endCaretSession('command run')
+  }
+
+  function notifyDocumentEdited() {
+    if (caretSessionActive.value) {
+      endCaretSession('document edited')
+    }
+  }
+
+  function endCaretSession(reason: string) {
+    removeCaretSessionWatch()
+    sessionAnchorNode = null
+    sessionAnchorOffset = -1
+
+    if (!caretSessionActive.value) {
+      return
+    }
+
+    caretSessionActive.value = false
+    logger?.debug('selection toolbar caret session ended', { reason })
+  }
+
+  function detachContextMenuFallback() {
+    contextMenuCleanup?.()
+    contextMenuCleanup = null
+  }
+
+  function attachContextMenuFallback() {
+    detachContextMenuFallback()
+    const host = getEditorHost()
+    if (!host) {
+      return
+    }
+
+    const onContextMenu = (event: Event) => {
+      if (!isEditorReady() || !canActivate()) {
+        return
+      }
+
+      event.preventDefault()
+      void enterFromContextRequest('contextmenu')
+    }
+
+    host.addEventListener('contextmenu', onContextMenu)
+    contextMenuCleanup = () => host.removeEventListener('contextmenu', onContextMenu)
+  }
+
+  // Without the native signal (web dev/e2e), a selection created by other
+  // means still needs a truthful paste action: refresh the clipboard state
+  // when a selection appears inside the editor.
+  function installSelectionRefreshWatch() {
+    removeSelectionRefreshWatch()
+
+    let hadSelection = false
+    const onSelectionChange = () => {
+      const nowHasSelection = hasEditorSelection()
+      if (nowHasSelection && !hadSelection) {
+        void refreshClipboardHasText()
+      }
+      hadSelection = nowHasSelection
+    }
+
+    document.addEventListener('selectionchange', onSelectionChange)
+    selectionRefreshCleanup = () => {
+      document.removeEventListener('selectionchange', onSelectionChange)
+    }
+  }
+
+  function removeSelectionRefreshWatch() {
+    selectionRefreshCleanup?.()
+    selectionRefreshCleanup = null
+  }
+
+  function resetForNewDocument() {
+    generation += 1
+    endCaretSession('document replaced')
+    detachContextMenuFallback()
+    removeSelectionRefreshWatch()
+    clipboardHasText.value = false
+  }
+
+  function attachWebFallbacks() {
+    installSelectionRefreshWatch()
+    attachContextMenuFallback()
+  }
+
+  return {
+    caretSessionActive,
+    clipboardHasText,
+    enterFromContextRequest,
+    notifyCommandRun,
+    notifyDocumentEdited,
+    endCaretSession,
+    attachWebFallbacks,
+    resetForNewDocument,
+  }
+}

--- a/src/lib/androidSelection.ts
+++ b/src/lib/androidSelection.ts
@@ -28,6 +28,10 @@ interface AndroidSelectionPlugin {
     eventName: 'selectionTap',
     listener: (event: AndroidSelectionTapEvent) => void,
   ): Promise<{ remove: () => Promise<void> }>
+  addListener(
+    eventName: 'selectionContextRequest',
+    listener: () => void,
+  ): Promise<{ remove: () => Promise<void> }>
 }
 
 export interface AndroidSelectionTapEvent {
@@ -159,6 +163,24 @@ export async function addAndroidSelectionTapListener(
 
   try {
     const handle = await AndroidSelection.addListener('selectionTap', listener)
+    return () => handle.remove()
+  } catch {
+    return null
+  }
+}
+
+// Fired when the suppressed floating ActionMode starts — the exact moment
+// Android would have shown its own clipboard menu (long-press selection,
+// double-tap word select, insertion-caret menu).
+export async function addAndroidSelectionContextListener(
+  listener: () => void,
+): Promise<(() => Promise<void>) | null> {
+  if (!isAndroidSelectionControlAvailable()) {
+    return null
+  }
+
+  try {
+    const handle = await AndroidSelection.addListener('selectionContextRequest', listener)
     return () => handle.remove()
   } catch {
     return null

--- a/tests/e2e/helpers/androidAppMock.ts
+++ b/tests/e2e/helpers/androidAppMock.ts
@@ -6,6 +6,7 @@ export interface MockCapacitorWindow {
   __emitCapacitorAppPause?: () => void
   __emitCapacitorAppStateChange?: (isActive: boolean) => void
   __emitAndroidOpenWithDocument?: (event: MockAndroidOpenWithEvent) => void
+  __emitAndroidSelectionContextRequest?: () => void
   __appListenerCount?: (eventName: string) => number
   __androidDocumentListenerCount?: (eventName: string) => number
   __lastAndroidCreateOptions?: Record<string, unknown>
@@ -192,6 +193,7 @@ export async function installAndroidAppMock(
     const win = window as unknown as MockCapacitorWindow
     const appListeners = new Map<string, Array<(data: unknown) => void>>()
     const androidDocumentListeners = new Map<string, Array<(data: unknown) => void>>()
+    const androidSelectionListeners = new Map<string, Array<(data: unknown) => void>>()
     let pendingOpenWithEvent = mockOptions.pendingOpenWithEvent ?? null
     const emitAppEvent = (eventName: string, data: unknown) => {
       for (const listener of appListeners.get(eventName) ?? []) {
@@ -200,6 +202,11 @@ export async function installAndroidAppMock(
     }
     const emitAndroidDocumentEvent = (eventName: string, data: unknown) => {
       for (const listener of androidDocumentListeners.get(eventName) ?? []) {
+        listener(data)
+      }
+    }
+    const emitAndroidSelectionEvent = (eventName: string, data: unknown) => {
+      for (const listener of androidSelectionListeners.get(eventName) ?? []) {
         listener(data)
       }
     }
@@ -216,6 +223,11 @@ export async function installAndroidAppMock(
     }
     win.__emitAndroidOpenWithDocument = (event: MockAndroidOpenWithEvent) => {
       emitAndroidDocumentEvent('openWithDocument', event)
+    }
+    // Simulates MainActivity.notifySelectionContextRequest: the suppressed
+    // native floating ActionMode started (long-press / double-tap select).
+    win.__emitAndroidSelectionContextRequest = () => {
+      emitAndroidSelectionEvent('selectionContextRequest', {})
     }
     win.__appListenerCount = (eventName: string) => appListeners.get(eventName)?.length ?? 0
     win.__androidDocumentListenerCount = (eventName: string) =>
@@ -244,6 +256,19 @@ export async function installAndroidAppMock(
             { name: 'writeMarkdownDocument', rtype: 'promise' },
           ],
         },
+        {
+          name: 'AndroidSelection',
+          methods: [
+            { name: 'addListener', rtype: 'callback' },
+            { name: 'removeListener', rtype: 'promise' },
+            { name: 'setEditorSelectionActionModeSuppressed', rtype: 'promise' },
+            { name: 'getEditorSelectionActionModeState', rtype: 'promise' },
+            { name: 'finishEditorSelectionActionMode', rtype: 'promise' },
+            { name: 'performNativeSelectAll', rtype: 'promise' },
+            { name: 'readClipboardText', rtype: 'promise' },
+            { name: 'writeClipboardText', rtype: 'promise' },
+          ],
+        },
       ],
       nativeCallback(pluginName, methodName, options, callback) {
         if (pluginName === 'App' && methodName === 'addListener') {
@@ -253,6 +278,15 @@ export async function installAndroidAppMock(
             appListeners.set(options.eventName, listeners)
           }
           return Promise.resolve(`app-listener-${String(options.eventName)}`)
+        }
+
+        if (pluginName === 'AndroidSelection' && methodName === 'addListener') {
+          if (typeof options.eventName === 'string' && callback) {
+            const listeners = androidSelectionListeners.get(options.eventName) ?? []
+            listeners.push(callback)
+            androidSelectionListeners.set(options.eventName, listeners)
+          }
+          return Promise.resolve(`android-selection-listener-${String(options.eventName)}`)
         }
 
         if (pluginName === 'AndroidDocuments' && methodName === 'addListener') {
@@ -284,6 +318,54 @@ export async function installAndroidAppMock(
 
         if (pluginName === 'AndroidDocuments' && methodName === 'removeListener') {
           return Promise.resolve()
+        }
+
+        if (pluginName === 'AndroidSelection') {
+          if (methodName === 'removeListener') {
+            return Promise.resolve()
+          }
+
+          if (
+            methodName === 'setEditorSelectionActionModeSuppressed' ||
+            methodName === 'getEditorSelectionActionModeState'
+          ) {
+            return Promise.resolve({
+              suppressed: Boolean(options.suppressed),
+              hookInstalled: true,
+              suppressedCreateCount: 0,
+              suppressedStartCount: 0,
+              allowedCreateCount: 0,
+              allowedStartCount: 0,
+              finishCount: 0,
+              nativeEvents: '',
+            })
+          }
+
+          if (methodName === 'finishEditorSelectionActionMode') {
+            return Promise.resolve({ finished: false })
+          }
+
+          // Fall through to Muya's JS select-all: no native ActionMode exists.
+          if (methodName === 'performNativeSelectAll') {
+            return Promise.resolve({ performed: false })
+          }
+
+          // Bridge the mock clipboard onto the page clipboard so the state
+          // table can be exercised with real clipboard content.
+          if (methodName === 'readClipboardText') {
+            return navigator.clipboard.readText().then(
+              text => ({ text, available: text.length > 0 }),
+              () => ({ text: '', available: false }),
+            )
+          }
+
+          if (methodName === 'writeClipboardText') {
+            const text = typeof options.text === 'string' ? options.text : ''
+            return navigator.clipboard.writeText(text).then(
+              () => ({ written: true }),
+              () => ({ written: false }),
+            )
+          }
         }
 
         if (documentMock && pluginName === 'AndroidDocuments') {

--- a/tests/e2e/mobile-selection-toolbar.spec.ts
+++ b/tests/e2e/mobile-selection-toolbar.spec.ts
@@ -313,7 +313,7 @@ test('a subsequent tap dismisses the long-press caret toolbar', async ({ page })
   await expect(toolbar).toBeHidden()
 })
 
-test('a read-only document offers copy and select all per the state table', async ({ page }) => {
+test('an unwritable source URI keeps the full editing clipboard actions', async ({ page }) => {
   const now = '2026-07-12T08:00:00.000Z'
   const document = {
     sourceUri: 'content://test/read-only-selection',
@@ -360,31 +360,57 @@ test('a read-only document offers copy and select all per the state table', asyn
     page.evaluate(() =>
       (window as unknown as MockCapacitorWindow).__emitAndroidSelectionContextRequest?.(),
     )
+  const placeCaretInParagraph = () =>
+    page.evaluate(() => {
+      const paragraph = Array.from(
+        document.querySelectorAll('[data-testid="editor-host"] .mu-editor p'),
+      ).find(node => node.textContent?.includes('Protected paragraph'))!
+      const walker = document.createTreeWalker(paragraph, NodeFilter.SHOW_TEXT)
+      const text = walker.nextNode() as Text
+      const range = document.createRange()
+      range.setStart(text, 2)
+      range.collapse(true)
+      const selection = document.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+    })
   const toolbar = page.getByTestId('mobile-selection-toolbar')
 
-  // Read-only with a selection: Copy, Select all — no cut, no paste even
-  // though the clipboard has content.
+  // The source URI cannot be overwritten (canWrite: false), but the EDITOR
+  // is still fully editable — the user can modify the content and save it
+  // as a copy. Cut and Paste therefore stay available; the read-only table
+  // rows are about editor editability, not source-write capability.
+  await selectParagraph(page, 'Protected paragraph')
+  await emitContextRequest()
+  await expect(toolbar).toBeVisible()
+  await expect
+    .poll(() => toolbarCommandIds(page))
+    .toEqual(['cut', 'copy', 'paste', 'selectAll'])
+
+  await page.evaluate(() => document.getSelection()?.removeAllRanges())
+  await expect(toolbar).toBeHidden()
+  await placeCaretInParagraph()
+  await emitContextRequest()
+  await expect(toolbar).toBeVisible()
+  await expect.poll(() => toolbarCommandIds(page)).toEqual(['paste', 'selectAll'])
+
+  // A genuinely non-editable editor surface DOES activate the read-only
+  // rows: Copy + Select all with a selection, Select all alone at a caret.
+  await page.evaluate(() => document.getSelection()?.removeAllRanges())
+  await expect(toolbar).toBeHidden()
+  await page.evaluate(() =>
+    document
+      .querySelector('[data-testid="editor-host"] .mu-editor')
+      ?.setAttribute('contenteditable', 'false'),
+  )
   await selectParagraph(page, 'Protected paragraph')
   await emitContextRequest()
   await expect(toolbar).toBeVisible()
   await expect.poll(() => toolbarCommandIds(page)).toEqual(['copy', 'selectAll'])
 
-  // Read-only caret long-press: Select all only.
   await page.evaluate(() => document.getSelection()?.removeAllRanges())
   await expect(toolbar).toBeHidden()
-  await page.evaluate(() => {
-    const paragraph = Array.from(
-      document.querySelectorAll('[data-testid="editor-host"] .mu-editor p'),
-    ).find(node => node.textContent?.includes('Protected paragraph'))!
-    const walker = document.createTreeWalker(paragraph, NodeFilter.SHOW_TEXT)
-    const text = walker.nextNode() as Text
-    const range = document.createRange()
-    range.setStart(text, 2)
-    range.collapse(true)
-    const selection = document.getSelection()
-    selection?.removeAllRanges()
-    selection?.addRange(range)
-  })
+  await placeCaretInParagraph()
   await emitContextRequest()
   await expect(toolbar).toBeVisible()
   await expect.poll(() => toolbarCommandIds(page)).toEqual(['selectAll'])

--- a/tests/e2e/mobile-selection-toolbar.spec.ts
+++ b/tests/e2e/mobile-selection-toolbar.spec.ts
@@ -1,7 +1,26 @@
 import { expect, test, type Page } from '@playwright/test'
+import { installAndroidAppMock, type MockCapacitorWindow } from './helpers/androidAppMock'
 import { expectEditorReady } from './helpers/editor'
 
 test.use({ permissions: ['clipboard-read', 'clipboard-write'] })
+
+function toolbarCommandIds(page: Page) {
+  return page.evaluate(() =>
+    Array.from(
+      document.querySelectorAll('[data-testid="mobile-selection-toolbar"] [data-command-id]'),
+    ).map(button => button.getAttribute('data-command-id')),
+  )
+}
+
+// The long-press entry: on the web build the contextmenu event is the
+// fallback signal (real Android uses the suppressed native ActionMode).
+async function longPressParagraph(page: Page, needle: string) {
+  await page
+    .locator('[data-testid="editor-host"] .mu-editor p')
+    .filter({ hasText: needle })
+    .first()
+    .click({ button: 'right' })
+}
 
 async function openDraft(page: Page) {
   const now = '2026-07-01T09:00:00.000Z'
@@ -142,6 +161,233 @@ test('paste replaces the selection with clipboard text', async ({ page }) => {
 
   await expect(page.getByTestId('editor-host')).toContainText('pasted-payload-123')
   await expect(page.getByTestId('editor-host')).not.toContainText('Alpha bravo charlie')
+})
+
+test('selection actions follow the state table with clipboard content', async ({ page }) => {
+  await openDraft(page)
+
+  // Selected + clipboard has content: Cut, Copy, Paste, Select all.
+  await page.evaluate(() => navigator.clipboard.writeText('clipboard-payload'))
+  await selectParagraph(page, 'Alpha bravo')
+  const toolbar = page.getByTestId('mobile-selection-toolbar')
+  await expect(toolbar).toBeVisible()
+  await expect
+    .poll(() => toolbarCommandIds(page))
+    .toEqual(['cut', 'copy', 'paste', 'selectAll'])
+
+  // Selected + clipboard empty: Cut, Copy, Select all.
+  await page.evaluate(() => document.getSelection()?.removeAllRanges())
+  await expect(toolbar).toBeHidden()
+  await page.evaluate(() => navigator.clipboard.writeText(''))
+  await selectParagraph(page, 'Alpha bravo')
+  await expect(toolbar).toBeVisible()
+  await expect.poll(() => toolbarCommandIds(page)).toEqual(['cut', 'copy', 'selectAll'])
+})
+
+test('a long-press caret offers paste and select all', async ({ page }) => {
+  await openDraft(page)
+  await page.evaluate(() => navigator.clipboard.writeText('clipboard-payload'))
+
+  await longPressParagraph(page, 'Alpha bravo')
+
+  const toolbar = page.getByTestId('mobile-selection-toolbar')
+  await expect(toolbar).toBeVisible()
+  await expect.poll(() => toolbarCommandIds(page)).toEqual(['paste', 'selectAll'])
+})
+
+test('a long-press caret with an empty clipboard offers select all only', async ({ page }) => {
+  await openDraft(page)
+  await page.evaluate(() => navigator.clipboard.writeText(''))
+
+  await longPressParagraph(page, 'Alpha bravo')
+
+  await expect(page.getByTestId('mobile-selection-toolbar')).toBeVisible()
+  await expect.poll(() => toolbarCommandIds(page)).toEqual(['selectAll'])
+})
+
+test('a long-press in an empty document still offers select all', async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+  await page.getByTestId('new-document-button').click()
+  await expectEditorReady(page)
+  await page.evaluate(() => navigator.clipboard.writeText(''))
+
+  await page
+    .locator('[data-testid="editor-host"] .mu-editor p')
+    .first()
+    .click({ button: 'right' })
+
+  await expect(page.getByTestId('mobile-selection-toolbar')).toBeVisible()
+  await expect.poll(() => toolbarCommandIds(page)).toEqual(['selectAll'])
+})
+
+test('paste lands at the long-pressed caret and ends the session', async ({ page }) => {
+  await openDraft(page)
+  await page.evaluate(() => navigator.clipboard.writeText('pasted-at-caret'))
+
+  await longPressParagraph(page, 'Second paragraph tail')
+  const toolbar = page.getByTestId('mobile-selection-toolbar')
+  await expect(toolbar).toBeVisible()
+
+  await toolbar.getByTestId('selection-command-paste').click()
+
+  await expect(page.getByTestId('editor-host')).toContainText('pasted-at-caret')
+  // Nothing was replaced: the other paragraph survives untouched.
+  await expect(page.getByTestId('editor-host')).toContainText('Alpha bravo charlie delta echo')
+  // The payload landed INSIDE the long-pressed paragraph (the caret sits at
+  // the click point, so the needle text is split around the insertion).
+  const paragraphWithPayload = await page.evaluate(
+    () =>
+      Array.from(document.querySelectorAll('[data-testid="editor-host"] .mu-editor p'))
+        .map(node => node.textContent ?? '')
+        .find(text => text.includes('pasted-at-caret')) ?? '',
+  )
+  expect(paragraphWithPayload).toMatch(/^Second.*pasted-at-caret.*tail$/s)
+  await expect(toolbar).toBeHidden()
+})
+
+test('select all from a long-press caret selects progressively and keeps the toolbar', async ({
+  page,
+}) => {
+  await openDraft(page)
+  await page.evaluate(() => navigator.clipboard.writeText(''))
+
+  await longPressParagraph(page, 'Alpha bravo')
+  const toolbar = page.getByTestId('mobile-selection-toolbar')
+  await expect(toolbar).toBeVisible()
+  await toolbar.getByTestId('selection-command-selectAll').click()
+
+  // Muya's select-all is progressive: from a caret it first selects the
+  // long-pressed block — which also proves the caret landed in it — and the
+  // selection-driven display takes over with the selection actions.
+  await expect
+    .poll(() => page.evaluate(() => document.getSelection()?.toString() ?? ''))
+    .toContain('Alpha bravo charlie delta echo')
+  await expect(toolbar).toBeVisible()
+  await expect.poll(() => toolbarCommandIds(page)).toEqual(['cut', 'copy', 'selectAll'])
+
+  // A second select-all widens to the whole document.
+  await toolbar.getByTestId('selection-command-selectAll').click()
+  await expect
+    .poll(() => page.evaluate(() => document.getSelection()?.toString() ?? ''))
+    .toContain('Second paragraph tail')
+  await expect(toolbar).toBeVisible()
+})
+
+test('an ordinary tap or typing never opens the toolbar', async ({ page }) => {
+  await openDraft(page)
+  await page.evaluate(() => navigator.clipboard.writeText('clipboard-payload'))
+  const toolbar = page.getByTestId('mobile-selection-toolbar')
+
+  // Ordinary caret placement.
+  await page
+    .locator('[data-testid="editor-host"] .mu-editor p')
+    .filter({ hasText: 'Alpha bravo' })
+    .first()
+    .click()
+  await page.waitForTimeout(400)
+  await expect(toolbar).toBeHidden()
+
+  // Normal typing and caret movement.
+  await page.keyboard.type('x')
+  await page.keyboard.press('ArrowLeft')
+  await page.waitForTimeout(400)
+  await expect(toolbar).toBeHidden()
+})
+
+test('a subsequent tap dismisses the long-press caret toolbar', async ({ page }) => {
+  await openDraft(page)
+  await page.evaluate(() => navigator.clipboard.writeText('clipboard-payload'))
+
+  await longPressParagraph(page, 'Alpha bravo')
+  const toolbar = page.getByTestId('mobile-selection-toolbar')
+  await expect(toolbar).toBeVisible()
+
+  await page
+    .locator('[data-testid="editor-host"] .mu-editor p')
+    .filter({ hasText: 'Second paragraph tail' })
+    .first()
+    .click()
+
+  await expect(toolbar).toBeHidden()
+})
+
+test('a read-only document offers copy and select all per the state table', async ({ page }) => {
+  const now = '2026-07-12T08:00:00.000Z'
+  const document = {
+    sourceUri: 'content://test/read-only-selection',
+    displayName: 'Read Only Probe.md',
+    markdown: '# Read Only Probe\n\nProtected paragraph body\n',
+    canWrite: false,
+  }
+  await installAndroidAppMock(page, document)
+  await page.goto('/')
+  await page.evaluate(
+    ({ now, document }) => {
+      localStorage.clear()
+      localStorage.setItem(
+        'marktext-for-android:recent-documents',
+        JSON.stringify([
+          {
+            id: `android-document:${document.sourceUri}`,
+            kind: 'android-document',
+            displayName: document.displayName,
+            title: 'Read Only Probe',
+            sourceUri: document.sourceUri,
+            providerName: 'Test Documents',
+            pathHint: document.displayName,
+            markdownPreview: null,
+            updatedAt: now,
+            lastOpenedAt: now,
+            lastSavedAt: null,
+            autosaveState: 'clean',
+            canWrite: false,
+          },
+        ]),
+      )
+    },
+    { now, document },
+  )
+  await page.reload()
+  await page.getByRole('button', { name: /Read Only Probe/ }).click()
+  await expectEditorReady(page)
+  await page.evaluate(() => navigator.clipboard.writeText('clipboard-payload'))
+
+  // Under the Android mock the app takes the NATIVE entry path: the
+  // suppressed-ActionMode signal, not the web contextmenu fallback.
+  const emitContextRequest = () =>
+    page.evaluate(() =>
+      (window as unknown as MockCapacitorWindow).__emitAndroidSelectionContextRequest?.(),
+    )
+  const toolbar = page.getByTestId('mobile-selection-toolbar')
+
+  // Read-only with a selection: Copy, Select all — no cut, no paste even
+  // though the clipboard has content.
+  await selectParagraph(page, 'Protected paragraph')
+  await emitContextRequest()
+  await expect(toolbar).toBeVisible()
+  await expect.poll(() => toolbarCommandIds(page)).toEqual(['copy', 'selectAll'])
+
+  // Read-only caret long-press: Select all only.
+  await page.evaluate(() => document.getSelection()?.removeAllRanges())
+  await expect(toolbar).toBeHidden()
+  await page.evaluate(() => {
+    const paragraph = Array.from(
+      document.querySelectorAll('[data-testid="editor-host"] .mu-editor p'),
+    ).find(node => node.textContent?.includes('Protected paragraph'))!
+    const walker = document.createTreeWalker(paragraph, NodeFilter.SHOW_TEXT)
+    const text = walker.nextNode() as Text
+    const range = document.createRange()
+    range.setStart(text, 2)
+    range.collapse(true)
+    const selection = document.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+  })
+  await emitContextRequest()
+  await expect(toolbar).toBeVisible()
+  await expect.poll(() => toolbarCommandIds(page)).toEqual(['selectAll'])
 })
 
 test('toolbar stays hidden for the empty-document placeholder selection', async ({ page }) => {


### PR DESCRIPTION
## What

A long-press inside the editor now opens the existing floating `MobileSelectionToolbar` — for a collapsed caret as well as a text selection, including in an empty document. The floating toolbar remains the only clipboard-action UI: the bottom formatting `MobileEditorToolbar` has a zero-line diff in this PR, and the native Android floating action toolbar stays suppressed.

| Editor state | Floating toolbar actions |
| --- | --- |
| Editable, no selection, clipboard has content | Paste, Select all |
| Editable, no selection, clipboard empty | Select all |
| Editable, selection, clipboard has content | Cut, Copy, Paste, Select all |
| Editable, selection, clipboard empty | Cut, Copy, Select all |
| Read-only, selection | Copy, Select all |
| Read-only, no selection | Select all |

Select all stays available in an empty document. Ordinary taps, ordinary caret placement, typing, and caret movement never open the toolbar; the existing selection-driven behavior (appearance, placement, dismissal, drag handles, live Muya selection, clipboard command pipeline) is preserved unchanged.

## How

**Long-press signal.** `MainActivity.onActionModeStarted` forwards the suppressed floating ActionMode start — the exact moment Android would have shown its own clipboard menu (long-press selection, double-tap word select, insertion-caret menu) — to the web layer as a `selectionContextRequest` event on the existing AndroidSelection plugin (~20 native lines). Web dev/e2e use an in-page `contextmenu` fallback, deliberately not installed on Android where the native signal covers every entry path.

**Caret sessions** (`selectionToolbarLongPress.ts`). A context request with a collapsed editor caret opens a caret session; with an existing selection it only refreshes the clipboard state (the selection-driven display already owns that case). Sessions follow the native insertion-menu conventions: they end on an ordinary tap (toolbar taps excluded), caret movement, edits, command completion, competing surfaces through the App orchestration layer, and document replacement; a caret widened into a selection via the insertion handle hands over to the unchanged selection-driven display. Entries are generation-guarded against surfaces opening during the async clipboard query.

**State table** (`selectionToolbar.ts`). `getSelectionToolbarCommands` now derives from `{hasSelection, canPaste, canWrite}`; Paste is truthful to actual clipboard content (native `readClipboardText` on Android; the web Clipboard API with a capability-optimistic fallback, refreshed on every context request and whenever a selection appears). `shouldShowSelectionToolbar` admits a collapsed caret only during a session, never overriding suspension/readiness/bounds; an all-zero collapsed-caret rect in an empty block falls back to the caret's block element for placement.

**Two caret-specific correctness details:** paste from a caret session adopts the live DOM caret into Muya's selection model (`syncMuyaSelectionFromDom`), so it lands at the long-pressed position instead of Muya's stale cached selection — the emulator smoke and a dedicated e2e prove the payload lands inside the long-pressed paragraph; and caret rows pass a null restore range so they can never resurrect an earlier expanded selection.

## Verification

- Unit: 425 passing (19 new — the state table exhaustively row by row, caret visibility gating, session enter/exit/handover rules, stale-entry cancellation).
- E2E: all specs passing (9 new — selection state-table with real clipboard content, caret paste landing inside the long-pressed paragraph, Muya's progressive select-all from a caret (block → document), empty-document select all, ordinary-tap/typing negatives, subsequent-tap dismissal, and the read-only rows driven through the Android mock's new native-signal channel — the same entry path real devices use). Existing selection specs pass without behavioral edits.
- Lint, typecheck, build.
- API 35 emulator smoke with REAL long-presses via adb (10/10): ordinary tap opens nothing; long-press selects a word with visible native drag handles and no native menu while the floating toolbar shows Cut/Copy/Paste/Select all; copy dismisses; a caret long-press at a paragraph end offers exactly Paste/Select all with a confirmed collapsed caret; paste inserts at the caret and dismisses; the bottom formatting toolbar is untouched throughout (screenshot-verified).