### PR TITLE
Complete Playwright coverage for exposed Android editor commands

### DIFF
--- a/tests/e2e/mobile-editor-toolbar.spec.ts
+++ b/tests/e2e/mobile-editor-toolbar.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test, type Page } from '@playwright/test'
-import { getDraftStorage, newBlankDocument } from './helpers/drafts'
+import {
+  getDraftStorage,
+  getStoredDraftMarkdown,
+  newBlankDocument,
+  openLocalDraft,
+} from './helpers/drafts'
 import { expectEditorReady } from './helpers/editor'
 
 test.describe.configure({ timeout: 60000 })
@@ -182,7 +187,11 @@ test('applies quick toolbar inline formatting to selected editor text', async ({
   await page.keyboard.press('Control+A')
   await page.getByTestId('toolbar-command-format.strong').click()
 
+  // Markdown result AND the rendered inline structure.
   await expect.poll(() => getDraftStorage(page)).toContain('**bold from mobile toolbar**')
+  await expect(
+    page.getByTestId('editor-host').locator('strong.mu-inline-rule'),
+  ).toContainText('bold from mobile toolbar')
 })
 
 test('keeps selected text active while chaining quick inline formatting', async ({ page }) => {
@@ -203,11 +212,20 @@ test('keeps selected text active while chaining quick inline formatting', async 
   await page.getByTestId('toolbar-command-format.emphasis').tap()
 
   await expect.poll(() => getDraftStorage(page)).toContain('***abc***')
+  // The chained result renders as nested strong + em inline structures.
+  await expect(page.getByTestId('editor-host').locator('strong.mu-inline-rule')).toContainText('abc')
+  await expect(page.getByTestId('editor-host').locator('em.mu-inline-rule')).toContainText('abc')
   await expect.poll(() => page.evaluate(() => document.getSelection()?.toString() ?? '')).toBe('abc')
 })
 
-test('applies expanded desktop format commands to selected editor text', async ({ page }) => {
+test('applies inline format commands from their panels to selected editor text', async ({ page }) => {
   const cases = [
+    {
+      commandId: 'format.inline-code',
+      text: 'inline code from mobile toolbar',
+      expected: '`inline code from mobile toolbar`',
+      panelId: 'markdown',
+    },
     {
       commandId: 'format.underline',
       text: 'underlined from mobile toolbar',
@@ -264,6 +282,235 @@ test('applies expanded desktop format commands to selected editor text', async (
       await expect.poll(() => getDraftStorage(page)).toContain(expected)
     })
   }
+})
+
+test('clears inline formatting back to plain text', async ({ page }) => {
+  await newBlankDocument(page)
+
+  const editor = page.getByTestId('editor-host')
+  await editor.click()
+  await page.keyboard.type('formatted away')
+  await page.keyboard.press('Control+A')
+  await page.getByTestId('toolbar-command-format.strong').click()
+  await expect.poll(() => getDraftStorage(page)).toContain('**formatted away**')
+  await expect(editor.locator('strong.mu-inline-rule')).toContainText('formatted away')
+
+  await selectToolbarPanel(page, 'format')
+  await page.getByTestId('toolbar-command-format.clear-format').scrollIntoViewIfNeeded()
+  await page.getByTestId('toolbar-command-format.clear-format').click()
+
+  // The parsed Markdown is exactly the plain text again, and the rendered
+  // strong structure is gone.
+  await expect.poll(() => getStoredDraftMarkdown(page)).toBe('formatted away\n')
+  await expect(editor.locator('strong.mu-inline-rule')).toHaveCount(0)
+})
+
+test('undo and redo from the toolbar walk the edit history', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('history probe')
+  await expect.poll(() => getDraftStorage(page)).toContain('history probe')
+
+  await page.getByTestId('toolbar-command-edit.undo').click()
+  await expect.poll(() => getDraftStorage(page)).not.toContain('history probe')
+
+  // Redo lives in the expanded toolbar header next to undo.
+  await page.getByTestId('toolbar-expand-button').click()
+  await page.getByTestId('toolbar-command-edit.redo').click()
+  await expect.poll(() => getDraftStorage(page)).toContain('history probe')
+})
+
+test('converts the current paragraph through every heading level and back', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('Heading matrix probe')
+  await selectToolbarPanel(page, 'paragraph')
+
+  const editor = page.getByTestId('editor-host')
+  for (let level = 1; level <= 6; level += 1) {
+    await page.getByTestId(`toolbar-command-paragraph.heading-${level}`).scrollIntoViewIfNeeded()
+    await page.getByTestId(`toolbar-command-paragraph.heading-${level}`).click()
+
+    // Markdown result AND the rendered Muya block structure.
+    await expect
+      .poll(() => getDraftStorage(page))
+      .toContain(`${'#'.repeat(level)} Heading matrix probe`)
+    await expect(editor.locator(`h${level}.mu-atx-heading`)).toContainText('Heading matrix probe')
+  }
+
+  // The explicit Paragraph command converts the heading leaf back.
+  await page.getByTestId('toolbar-command-paragraph.paragraph').scrollIntoViewIfNeeded()
+  await page.getByTestId('toolbar-command-paragraph.paragraph').click()
+  await expect.poll(() => getDraftStorage(page)).not.toContain('# Heading matrix probe')
+  await expect.poll(() => getDraftStorage(page)).toContain('Heading matrix probe')
+  await expect(editor.locator('p.mu-paragraph')).toContainText('Heading matrix probe')
+})
+
+test('promotes and demotes the current heading level', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('### Level three')
+  await expect.poll(() => getDraftStorage(page)).toContain('### Level three')
+
+  await selectToolbarPanel(page, 'paragraph')
+  await page.getByTestId('toolbar-command-paragraph.upgrade-heading').scrollIntoViewIfNeeded()
+  await page.getByTestId('toolbar-command-paragraph.upgrade-heading').click()
+  await expect.poll(() => getDraftStorage(page)).toContain('## Level three')
+  await expect.poll(() => getDraftStorage(page)).not.toContain('### Level three')
+
+  await page.getByTestId('toolbar-command-paragraph.degrade-heading').click()
+  await expect.poll(() => getDraftStorage(page)).toContain('### Level three')
+  await page.getByTestId('toolbar-command-paragraph.degrade-heading').click()
+  await expect.poll(() => getDraftStorage(page)).toContain('#### Level three')
+})
+
+test('toggles bullet and ordered lists from the quick strip', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('first entry')
+  await page.getByTestId('toolbar-command-paragraph.bullet-list').click()
+  await expect.poll(() => getDraftStorage(page)).toContain('- first entry')
+  await expect(
+    page.getByTestId('editor-host').locator('ul.mu-bullet-list').filter({ hasText: 'first entry' }),
+  ).toHaveCount(1)
+
+  // Converting the same list to an ordered list swaps the kind in place.
+  await page.getByTestId('toolbar-command-paragraph.order-list').click()
+  await expect.poll(() => getDraftStorage(page)).toContain('1. first entry')
+  await expect.poll(() => getDraftStorage(page)).not.toContain('- first entry')
+  await expect(
+    page.getByTestId('editor-host').locator('ol.mu-order-list').filter({ hasText: 'first entry' }),
+  ).toHaveCount(1)
+})
+
+test('toggles list looseness from the paragraph panel', async ({ page }) => {
+  // A tight list loaded from Markdown parses as loose: false, so the first
+  // toggle makes it loose and the second returns it to tight.
+  await openLocalDraft(page, {
+    id: 'loose-list-draft',
+    markdown: '- alpha\n- beta\n',
+    title: /alpha/,
+  })
+
+  await page
+    .locator('[data-testid="editor-host"] .mu-list-item')
+    .filter({ hasText: 'alpha' })
+    .click()
+  await selectToolbarPanel(page, 'paragraph')
+  await page.getByTestId('toolbar-command-paragraph.loose-list-item').scrollIntoViewIfNeeded()
+  await page.getByTestId('toolbar-command-paragraph.loose-list-item').click()
+
+  await expect.poll(() => getStoredDraftMarkdown(page)).toBe('- alpha\n\n- beta\n')
+
+  await page.getByTestId('toolbar-command-paragraph.loose-list-item').click()
+  await expect.poll(() => getStoredDraftMarkdown(page)).toBe('- alpha\n- beta\n')
+})
+
+test('inserts a fenced code block from the paragraph panel', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('above the fence')
+  await selectToolbarPanel(page, 'paragraph')
+  await page.getByTestId('toolbar-command-paragraph.code-fence').scrollIntoViewIfNeeded()
+  await page.getByTestId('toolbar-command-paragraph.code-fence').click()
+
+  await expect(page.getByTestId('editor-host').locator('.mu-code-block')).toHaveCount(1)
+  await expect.poll(() => getDraftStorage(page)).toContain('above the fence')
+
+  // The cursor lands in the new fence's language field; Enter moves it into
+  // the code body.
+  await page.keyboard.type('js')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('const fenced = true')
+  await expect.poll(() => getDraftStorage(page)).toContain('```js\\nconst fenced = true\\n```')
+})
+
+// PRODUCT GAP, documented during the coverage audit and tracked separately:
+// the Table command routes to Muya's `muya-table-picker` event, whose only
+// subscriber is the TableChessboard hover-grid UI plugin — deliberately not
+// registered on Android (editorRuntime.ts). The toolbar button is therefore
+// a silent no-op today: no table block is created on an empty or non-empty
+// paragraph and the Markdown is unchanged (verified against the live DOM).
+// This fixme pins the INTENDED behavior so it activates once an
+// Android-appropriate table insertion path exists.
+test.fixme('inserts a table from the insert panel', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('above the table')
+  await selectToolbarPanel(page, 'insert')
+  await page.getByTestId('toolbar-command-paragraph.table').scrollIntoViewIfNeeded()
+  await page.getByTestId('toolbar-command-paragraph.table').click()
+
+  await expect(page.getByTestId('editor-host').locator('figure.mu-table')).toHaveCount(1)
+  await expect.poll(() => getStoredDraftMarkdown(page)).toMatch(/\|.*\|\n\| ?-+/)
+})
+
+test('inserts a horizontal rule from the insert panel', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('above the rule')
+  await selectToolbarPanel(page, 'insert')
+  await page.getByTestId('toolbar-command-paragraph.horizontal-line').scrollIntoViewIfNeeded()
+  await page.getByTestId('toolbar-command-paragraph.horizontal-line').click()
+
+  await expect(page.getByTestId('editor-host').locator('.mu-thematic-break')).toHaveCount(1)
+  await expect.poll(() => getDraftStorage(page)).toContain('above the rule\\n\\n---')
+})
+
+test('inserts a math block from the markdown panel', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('lead paragraph')
+  await selectToolbarPanel(page, 'markdown')
+
+  await page.getByTestId('toolbar-command-paragraph.math-formula').scrollIntoViewIfNeeded()
+  await page.getByTestId('toolbar-command-paragraph.math-formula').click()
+
+  await expect(page.getByTestId('editor-host').locator('.mu-math-block')).toHaveCount(1)
+  await expect.poll(() => getDraftStorage(page)).toContain('$$\\n\\n$$')
+})
+
+test('inserts an HTML block from the markdown panel', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('lead paragraph')
+  await selectToolbarPanel(page, 'markdown')
+
+  await page.getByTestId('toolbar-command-paragraph.html-block').scrollIntoViewIfNeeded()
+  await page.getByTestId('toolbar-command-paragraph.html-block').click()
+
+  await expect(page.getByTestId('editor-host').locator('.mu-html-block')).toHaveCount(1)
+  await expect.poll(() => getDraftStorage(page)).toContain('<div>\\n\\n</div>')
+})
+
+test('prepends a single front matter block from the markdown panel', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('lead paragraph')
+  await selectToolbarPanel(page, 'markdown')
+
+  const editor = page.getByTestId('editor-host')
+  await page.getByTestId('toolbar-command-paragraph.front-matter').scrollIntoViewIfNeeded()
+  await page.getByTestId('toolbar-command-paragraph.front-matter').click()
+
+  // Front matter always prepends at the document start...
+  await expect(editor.locator('pre.mu-frontmatter')).toHaveCount(1)
+  await expect.poll(() => getStoredDraftMarkdown(page)).toMatch(/^---\n/)
+  await expect.poll(() => getStoredDraftMarkdown(page)).toContain('lead paragraph')
+
+  // ...and stays a single block when invoked again (idempotent).
+  await page.getByTestId('toolbar-command-paragraph.front-matter').click()
+  await expect(editor.locator('pre.mu-frontmatter')).toHaveCount(1)
 })
 
 test('exposes mobile syntax sections without collapsing everything into paragraph', async ({

--- a/tests/e2e/mobile-markdown-editing.spec.ts
+++ b/tests/e2e/mobile-markdown-editing.spec.ts
@@ -80,52 +80,7 @@ test('converts typed dollar fences into a persisted math block', async ({ page }
   await expect.poll(() => getDraftStorage(page)).toContain('a^2 + b^2 = c^2')
 })
 
-test('shows the MarkText selection toolbar only while editor text is selected', async ({
-  page,
-}) => {
-  await openLocalDraft(
-    page,
-    {
-      id: 'markdown-editing-draft',
-      markdown: `# Selection Probe
-
-Select this paragraph to reveal the toolbar
-`,
-      title: /Selection Probe/,
-    },
-  )
-
-  const toolbar = page.getByTestId('mobile-selection-toolbar')
-  await expect(toolbar).toBeHidden()
-
-  await page.evaluate(() => {
-    const paragraph = Array.from(
-      document.querySelectorAll('[data-testid="editor-host"] .mu-editor p'),
-    ).find(node => node.textContent?.includes('Select this paragraph'))
-    if (!paragraph) {
-      throw new Error('selection probe paragraph not found')
-    }
-
-    const range = document.createRange()
-    range.selectNodeContents(paragraph)
-    const selection = document.getSelection()
-    selection?.removeAllRanges()
-    selection?.addRange(range)
-  })
-
-  await expect(toolbar).toBeVisible()
-  await expect(toolbar.getByTestId('selection-command-copy')).toBeVisible()
-  await expect(toolbar.getByTestId('selection-command-cut')).toBeVisible()
-  await expect(toolbar.getByTestId('selection-command-selectAll')).toBeVisible()
-
-  // tap() exercises the touch dispatch path real Android devices use:
-  // touchstart is suppressed by the toolbar and the command fires on touchend.
-  await toolbar.getByTestId('selection-command-selectAll').tap()
-  await expect(toolbar).toBeVisible()
-  await expect
-    .poll(() => page.evaluate(() => document.getSelection()?.toString() ?? ''))
-    .toContain('Selection Probe')
-
-  await page.evaluate(() => document.getSelection()?.removeAllRanges())
-  await expect(toolbar).toBeHidden()
-})
+// The floating selection toolbar's visibility, action set, select-all
+// retention, and dismissal behavior are owned by
+// mobile-selection-toolbar.spec.ts; this file covers Markdown editing
+// semantics only.

--- a/tests/e2e/mobile-markdown-rendering.spec.ts
+++ b/tests/e2e/mobile-markdown-rendering.spec.ts
@@ -35,6 +35,9 @@ test('renders loaded CommonMark and GFM blocks as Muya editor structures', async
   const editor = page.getByTestId('editor-host')
   await expect(editor.locator('h1.mu-atx-heading')).toContainText('Rendering Matrix')
   await expect(editor.locator('.mu-block-quote')).toContainText('Quoted')
+  // The inline marks render as their own Muya structures inside the quote.
+  await expect(editor.locator('.mu-block-quote strong.mu-inline-rule')).toContainText('strong')
+  await expect(editor.locator('.mu-block-quote em.mu-inline-rule')).toContainText('emphasized')
   await expect(editor.locator('.mu-thematic-break')).toHaveCount(1)
   await expect(editor.locator('ul').filter({ hasText: 'Bullet item' })).toHaveCount(1)
   await expect(editor.locator('ol').filter({ hasText: 'Second item' })).toHaveCount(1)


### PR DESCRIPTION
## What

Test-only PR. Audits the Android editor's actually-exposed command surface (quick strip, Format/Paragraph/Insert/Markdown panels, toolbar undo/redo — inventoried from `mobileToolbarConfig.ts`/`mobileCommands.ts`) against the existing Playwright specs, with the vendored Muya suites and the desktop MarkText tests (`E:\marktext-contrib-latest`) as evidence, and closes every gap. Each command now verifies the user action, the resulting Markdown, and the rendered Muya structure where that adds distinct value.

## Coverage added (`mobile-editor-toolbar.spec.ts`, 12 new tests)

- **Headings H1–H6 matrix**: sequential conversion with both the `#{n}` Markdown and the rendered `h{n}.mu-atx-heading` block asserted at every level, then the explicit **Paragraph** command converting the heading leaf back (`p.mu-paragraph`).
- **Promote/demote heading**: H3 → H2 → H3 → H4.
- **Bullet / ordered lists from the quick strip**, including Muya's in-place list-kind conversion (bullet → ordered swaps the same list), with rendered `ul.mu-bullet-list` / `ol.mu-order-list`.
- **Loose list toggle**: a tight list loaded from Markdown gains the blank line between items and loses it again on the second toggle. (Audit finding worth knowing: editor-created lists start internally loose, so the deterministic fixture loads `- alpha\n- beta` instead of typing it.)
- **Fenced code block**: audit found the cursor lands in the new fence's language field — the test types `js`, Enter, then the body, and round-trips ` ```js `.
- **Horizontal rule**, **math block**, **HTML block** (Markdown + rendered `.mu-thematic-break` / `.mu-math-block` / `.mu-html-block`), and **front matter** — prepends at the document start and stays a single block on a second invocation (idempotence per Muya's contract).
- **Inline code** joined the inline-format cases; **clear format** now proves the parsed stored Markdown is exactly the plain text again AND the rendered `strong.mu-inline-rule` is gone.
- **Undo/redo** from the toolbar walking the edit history.
- **Bold/italic** additionally assert the rendered `strong.mu-inline-rule` / `em.mu-inline-rule` structures (review finding 3), and the rendering matrix asserts the inline marks inside the loaded block quote.

## Product gap found by the audit (documented, deliberately not fixed here)

The Insert panel's **Table** command is a silent no-op on Android: `updateParagraph('table')` routes to Muya's `muya-table-picker` event, whose only subscriber is the **TableChessboard** hover-grid plugin — deliberately not registered on Android (`editorRuntime.ts`). Verified against the live DOM: no table block is created from an empty or non-empty paragraph and the Markdown is unchanged. A `test.fixme` pins the intended behavior (rendered `figure.mu-table` + `|`-row Markdown) so the coverage activates the moment an Android-appropriate insertion path ships. Typed pipe-row conversion and loaded-table rendering remain covered elsewhere.

## Consolidation

- Removed the floating-selection-toolbar visibility test from `mobile-markdown-editing.spec.ts` — every behavior it asserted (visibility gating, select-all retention, collapse dismissal) is owned by `mobile-selection-toolbar.spec.ts`.
- Renamed the stale "expanded desktop format commands" title to "inline format commands from their panels".
- Desktop-only Electron/menu/hover/mouse interactions were not ported; Muya-engine semantics (already covered by the vendored suites) are asserted only at the Android toolbar boundary.

## Checks run (per the repository testing policy)

- Focused: `mobile-editor-toolbar` + `mobile-markdown-editing` + `mobile-markdown-rendering` — 28 passed, 1 fixme-skipped.
- Lint, typecheck.
- Complete Playwright suite, once: **119 passed, 1 skipped (the table fixme), 1 failed** — `mobile-selection-toolbar.spec.ts › copy places the selected text on the real clipboard`, timed out waiting for the home screen at app boot. That spec is untouched by this PR; rerun in isolation it passes **14/14**. Recorded as a suite-level flake; no further full run was performed.