### PR TITLE
Reclaim phone width with a single-owner responsive editor gutter

### DIFF
--- a/src/features/settings/appearanceSettings.test.ts
+++ b/src/features/settings/appearanceSettings.test.ts
@@ -40,9 +40,9 @@ describe('appearanceSettings', () => {
   it('ignores invalid line width values instead of passing them to CSS', () => {
     expect(normalizeEditorLineWidth('wide')).toBe('')
     expect(normalizeEditorLineWidth('72rem')).toBe('')
-    expect(resolveEditorLineWidthStyleValue('72ch')).toBe('calc(100px + 72ch)')
+    expect(resolveEditorLineWidthStyleValue('72ch')).toBe('calc(2 * var(--editor-gutter, 50px) + 72ch)')
     expect(getEditorStyleVars({ ...DEFAULT_APPEARANCE_TEXT_SETTINGS, editorLineWidth: '72ch' }))
-      .toEqual({ '--editor-area-width': 'calc(100px + 72ch)' })
+      .toEqual({ '--editor-area-width': 'calc(2 * var(--editor-gutter, 50px) + 72ch)' })
   })
 
   it('maps font choices to complete CSS stacks with desktop fallbacks', () => {

--- a/src/features/settings/appearanceSettings.ts
+++ b/src/features/settings/appearanceSettings.ts
@@ -215,7 +215,11 @@ export function resolveEditorFontFamily(fontFamily: EditorFontFamily) {
 
 export function resolveEditorLineWidthStyleValue(editorLineWidth: string) {
   const normalized = normalizeEditorLineWidth(editorLineWidth)
-  return normalized ? `calc(100px + ${normalized})` : undefined
+  // The user's value is the TEXT measure; .mu-container is border-box with
+  // var(--editor-gutter) horizontal padding, so both gutters are added on
+  // top. Deriving from the same variable keeps the measure true at every
+  // breakpoint (50px gutters on wide screens, 16px on phones).
+  return normalized ? `calc(2 * var(--editor-gutter, 50px) + ${normalized})` : undefined
 }
 
 export function getEditorStyleVars(settings: AppearanceTextSettings) {

--- a/src/style.css
+++ b/src/style.css
@@ -813,6 +813,13 @@ body {
 }
 
 .editor-host-shell {
+  /* Single owner of the editor's horizontal gutters: Muya's .mu-container
+     pads with var(--editor-gutter) and the host adds NO horizontal padding
+     of its own, so spacing can never stack. 50px keeps the wide-screen
+     column identical to Muya's historical layout; the phone breakpoint
+     narrows it below. */
+  --editor-gutter: 50px;
+
   width: min(100%, 980px);
   height: 100%;
   margin: 0 auto;
@@ -830,7 +837,7 @@ body {
 
 .editor-host-shell .mu-editor {
   min-height: 100%;
-  padding: 42px 56px 56px;
+  padding: 42px 0 56px;
 }
 
 /* MIUI WebViews pin CJK glyphs to one weight: 400 and 700 rasterize to
@@ -1364,6 +1371,13 @@ body {
   }
 
   .editor-host-shell {
+    /* Phones: 16px edge gutters (the Material compact-window margin; the
+       floor used by contemporary mobile editors). At 393dp this yields a
+       ~45ch measure at the default font size — the lower bound of the
+       comfortable 45–75ch reading range, so every extra pixel of gutter
+       would cost readable measure. */
+    --editor-gutter: 16px;
+
     width: 100%;
     border-width: 0;
     border-radius: 0;
@@ -1371,7 +1385,7 @@ body {
   }
 
   .editor-host-shell .mu-editor {
-    padding: 24px 18px 48px;
+    padding: 24px 0 48px;
   }
 
   .status-bar {

--- a/src/style.css
+++ b/src/style.css
@@ -808,17 +808,29 @@ body {
 .editor-pane {
   position: relative;
   min-height: 0;
-  padding: 18px;
+
+  /* The horizontal frame fades in linearly between 840px and 858px so the
+     text measure never jumps or dips: from ~801px the editing column sits
+     at its 700px cap with slack margins, and by 840px the slack exceeds
+     the full 36px frame, so the growing frame is absorbed by the outer
+     margins instead of the measure. */
+  padding: 18px clamp(0px, calc(100vw - 840px), 18px);
   overflow: hidden;
 }
 
 .editor-host-shell {
   /* Single owner of the editor's horizontal gutters: Muya's .mu-container
      pads with var(--editor-gutter) and the host adds NO horizontal padding
-     of its own, so spacing can never stack. 50px keeps the wide-screen
-     column identical to Muya's historical layout; the phone breakpoint
-     narrows it below. */
-  --editor-gutter: 50px;
+     of its own, so spacing can never stack.
+
+     The gutter is fluid so the text measure is continuous across every
+     width — a hard 16px→50px breakpoint would shrink the measure by ~100px
+     when the viewport grows one pixel (split-screen, foldables, resizable
+     windows). 16px (the Material compact margin) holds up to 720px, then
+     grows 0.4px per viewport px to reach the classic 50px at 805px; the
+     measure itself rises monotonically and caps at the historical 700px
+     (an 800px column minus two 50px gutters) from ~780px on. */
+  --editor-gutter: clamp(16px, calc(16px + (100vw - 720px) * 0.4), 50px);
 
   width: min(100%, 980px);
   height: 100%;
@@ -1371,13 +1383,6 @@ body {
   }
 
   .editor-host-shell {
-    /* Phones: 16px edge gutters (the Material compact-window margin; the
-       floor used by contemporary mobile editors). At 393dp this yields a
-       ~45ch measure at the default font size — the lower bound of the
-       comfortable 45–75ch reading range, so every extra pixel of gutter
-       would cost readable measure. */
-    --editor-gutter: 16px;
-
     width: 100%;
     border-width: 0;
     border-radius: 0;

--- a/tests/e2e/mobile-appearance-settings.spec.ts
+++ b/tests/e2e/mobile-appearance-settings.spec.ts
@@ -77,7 +77,9 @@ test('applies Appearance text settings without rewriting existing draft Markdown
 
   const editorHost = page.getByTestId('editor-host')
   await expect(editorHost).toHaveAttribute('dir', 'rtl')
-  await expect(editorHost).toHaveCSS('--editor-area-width', 'calc(100px + 72ch)')
+  // The line-width setting is the TEXT measure; both responsive gutters are
+  // added on top (16px each at the phone breakpoint).
+  await expect(editorHost).toHaveCSS('--editor-area-width', 'calc(2 * 16px + 72ch)')
   await expect(editorHost.locator('.muya-host')).toHaveCSS('--mu-font-size', '18px')
   await expect(editorHost.locator('.muya-host')).toHaveCSS('--mu-line-height', '1.8')
   await expect(editorHost.locator('.muya-host')).toHaveCSS('--mu-font-family', /DejaVu Sans Mono/)

--- a/tests/e2e/mobile-appearance-settings.spec.ts
+++ b/tests/e2e/mobile-appearance-settings.spec.ts
@@ -77,9 +77,10 @@ test('applies Appearance text settings without rewriting existing draft Markdown
 
   const editorHost = page.getByTestId('editor-host')
   await expect(editorHost).toHaveAttribute('dir', 'rtl')
-  // The line-width setting is the TEXT measure; both responsive gutters are
-  // added on top (16px each at the phone breakpoint).
-  await expect(editorHost).toHaveCSS('--editor-area-width', 'calc(2 * 16px + 72ch)')
+  // The line-width setting is the TEXT measure; both responsive (fluid)
+  // gutters are added on top. Custom properties keep the unevaluated
+  // expression, so assert its shape rather than a resolved constant.
+  await expect(editorHost).toHaveCSS('--editor-area-width', /^calc\(2 \* clamp\(16px, .* \+ 72ch\)$/)
   await expect(editorHost.locator('.muya-host')).toHaveCSS('--mu-font-size', '18px')
   await expect(editorHost.locator('.muya-host')).toHaveCSS('--mu-line-height', '1.8')
   await expect(editorHost.locator('.muya-host')).toHaveCSS('--mu-font-family', /DejaVu Sans Mono/)

--- a/tests/e2e/mobile-editor-layout.spec.ts
+++ b/tests/e2e/mobile-editor-layout.spec.ts
@@ -97,6 +97,70 @@ test('landscape and wide screens keep the centered column with 50px gutters', as
   expect(metrics.editorPaddingLeft).toBe(0)
 })
 
+test('the text measure is continuous across the old 720px breakpoint', async ({ page }) => {
+  // A hard gutter breakpoint used to shrink the measure by ~104px when the
+  // viewport grew from 720px to 721px (split screen, foldables, resizable
+  // windows). The fluid gutter keeps the measure monotonic: it rises to the
+  // classic 700px cap and never steps down.
+  const measureAt = async (width: number) => {
+    await page.setViewportSize({ width, height: 700 })
+    return (await readLayoutMetrics(page)).paragraphContentWidth
+  }
+
+  await openProbe(page)
+
+  const at719 = await measureAt(719)
+  const at721 = await measureAt(721)
+  const at780 = await measureAt(780)
+  const at815 = await measureAt(815)
+  const at900 = await measureAt(900)
+
+  // No cliff at the old breakpoint (the hairline frame border may cost ~1px).
+  expect(Math.abs(at721 - at719)).toBeLessThan(5)
+  // Monotonic growth up to the classic 700px cap, then stable while the
+  // frame padding fades in.
+  expect(at780).toBeGreaterThanOrEqual(at721 - 1)
+  expect(at780).toBeGreaterThan(690)
+  expect(at815).toBeGreaterThan(694)
+  expect(at815).toBeLessThan(706)
+  expect(at900).toBeGreaterThan(694)
+  expect(at900).toBeLessThan(706)
+})
+
+test('a long inline formula scrolls inside itself instead of widening the editor', async ({
+  page,
+}) => {
+  const longMath = Array.from({ length: 30 }, (_, i) => `a_{${i}} x^{${i}}`).join(' + ')
+  await openLocalDraft(page, {
+    id: 'layout-math-draft',
+    markdown: `# Math Probe\n\nInline formula $${longMath}$ inside a paragraph.\n`,
+    title: /Math Probe/,
+  })
+
+  await expect.poll(() => page.locator('.katex').count()).toBeGreaterThan(0)
+
+  const metrics = await page.evaluate(() => {
+    const shell = document.querySelector<HTMLElement>('.editor-host-shell')!
+    const paragraph = [...document.querySelectorAll<HTMLElement>('.mu-container > p')].find(p =>
+      p.textContent?.includes('Inline formula'),
+    )!
+    const render = paragraph.querySelector<HTMLElement>('.mu-math-render')!
+    return {
+      paragraphWidth: paragraph.getBoundingClientRect().width,
+      renderWidth: render.getBoundingClientRect().width,
+      renderScrollWidth: render.scrollWidth,
+      shellClientWidth: shell.clientWidth,
+      shellScrollWidth: shell.scrollWidth,
+    }
+  })
+
+  // The formula is genuinely wider than the column, scrolls inside its own
+  // box, and never makes the editor shell horizontally scrollable.
+  expect(metrics.renderScrollWidth).toBeGreaterThan(metrics.paragraphWidth)
+  expect(metrics.renderWidth).toBeLessThanOrEqual(metrics.paragraphWidth + 1)
+  expect(metrics.shellScrollWidth).toBe(metrics.shellClientWidth)
+})
+
 test('the editor line width setting caps the measure on top of the gutters', async ({ page }) => {
   await openProbe(page, { editorLineWidth: '30ch' })
 

--- a/tests/e2e/mobile-editor-layout.spec.ts
+++ b/tests/e2e/mobile-editor-layout.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test, type Page } from '@playwright/test'
+import { openLocalDraft } from './helpers/drafts'
+
+test.describe.configure({ timeout: 60000 })
+
+// The responsive width contract: Muya's .mu-container owns the horizontal
+// gutter through var(--editor-gutter) and the host shell adds no horizontal
+// padding of its own, so host and editor spacing can never stack. Phones
+// (≤720px) use 16px gutters; wider screens keep the historical 50px gutter
+// with the centered 800px column.
+
+const MARKDOWN = `# Layout Probe
+
+A paragraph that is long enough to wrap across several lines on a phone so the effective measure is visible.
+`
+
+async function openProbe(page: Page, settings: Record<string, string> = {}) {
+  await openLocalDraft(page, {
+    id: 'layout-probe-draft',
+    markdown: MARKDOWN,
+    title: /Layout Probe/,
+    settings,
+  })
+}
+
+interface LayoutMetrics {
+  viewportWidth: number
+  shellWidth: number
+  editorPaddingLeft: number
+  editorPaddingRight: number
+  containerWidth: number
+  containerPaddingLeft: number
+  containerPaddingRight: number
+  containerOffsetLeft: number
+  paragraphContentWidth: number
+}
+
+function readLayoutMetrics(page: Page): Promise<LayoutMetrics> {
+  return page.evaluate(() => {
+    const shell = document.querySelector<HTMLElement>('.editor-host-shell')!
+    const editor = shell.querySelector<HTMLElement>('.mu-editor')!
+    const container = shell.querySelector<HTMLElement>('.mu-container')!
+    const paragraph = container.querySelector<HTMLElement>('p.mu-paragraph')!
+    const editorStyle = getComputedStyle(editor)
+    const containerStyle = getComputedStyle(container)
+
+    return {
+      viewportWidth: window.innerWidth,
+      shellWidth: shell.getBoundingClientRect().width,
+      editorPaddingLeft: Number.parseFloat(editorStyle.paddingLeft),
+      editorPaddingRight: Number.parseFloat(editorStyle.paddingRight),
+      containerWidth: container.getBoundingClientRect().width,
+      containerPaddingLeft: Number.parseFloat(containerStyle.paddingLeft),
+      containerPaddingRight: Number.parseFloat(containerStyle.paddingRight),
+      containerOffsetLeft: container.getBoundingClientRect().left,
+      paragraphContentWidth: paragraph.getBoundingClientRect().width,
+    }
+  })
+}
+
+test('portrait phones use 16px gutters with no stacked host padding', async ({ page }) => {
+  await openProbe(page)
+
+  const metrics = await readLayoutMetrics(page)
+  expect(metrics.viewportWidth).toBe(393)
+  // The host contributes no horizontal padding of its own...
+  expect(metrics.editorPaddingLeft).toBe(0)
+  expect(metrics.editorPaddingRight).toBe(0)
+  // ...the container owns exactly one 16px gutter per side...
+  expect(metrics.containerPaddingLeft).toBe(16)
+  expect(metrics.containerPaddingRight).toBe(16)
+  // ...so the text measure is the full viewport minus the two gutters.
+  expect(metrics.paragraphContentWidth).toBeCloseTo(393 - 32, 0)
+})
+
+test('narrow phones keep the same single-gutter rule', async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 640 })
+  await openProbe(page)
+
+  const metrics = await readLayoutMetrics(page)
+  expect(metrics.containerPaddingLeft).toBe(16)
+  expect(metrics.paragraphContentWidth).toBeCloseTo(320 - 32, 0)
+})
+
+test('landscape and wide screens keep the centered column with 50px gutters', async ({ page }) => {
+  await page.setViewportSize({ width: 851, height: 393 })
+  await openProbe(page)
+
+  const metrics = await readLayoutMetrics(page)
+  // Above the phone breakpoint the classic layout applies: the column caps
+  // at 800px, centers inside the shell, and keeps the historical gutter.
+  expect(metrics.containerPaddingLeft).toBe(50)
+  expect(metrics.containerWidth).toBe(800)
+  expect(metrics.paragraphContentWidth).toBeCloseTo(800 - 100, 0)
+  expect(metrics.containerOffsetLeft).toBeGreaterThan(0)
+  // Still no stacked host padding.
+  expect(metrics.editorPaddingLeft).toBe(0)
+})
+
+test('the editor line width setting caps the measure on top of the gutters', async ({ page }) => {
+  await openProbe(page, { editorLineWidth: '30ch' })
+
+  const metrics = await readLayoutMetrics(page)
+  // calc(2 * 16px + 30ch) resolves below the phone viewport, so the column
+  // is narrower than full width and the measure honors the setting.
+  expect(metrics.containerWidth).toBeLessThan(393 - 32)
+  expect(metrics.paragraphContentWidth).toBeCloseTo(metrics.containerWidth - 32, 0)
+  // The capped column still centers.
+  expect(metrics.containerOffsetLeft).toBeCloseTo((393 - metrics.containerWidth) / 2, 0)
+})

--- a/tests/e2e/mobile-selection-toolbar.spec.ts
+++ b/tests/e2e/mobile-selection-toolbar.spec.ts
@@ -235,15 +235,18 @@ test('paste lands at the long-pressed caret and ends the session', async ({ page
   await expect(page.getByTestId('editor-host')).toContainText('pasted-at-caret')
   // Nothing was replaced: the other paragraph survives untouched.
   await expect(page.getByTestId('editor-host')).toContainText('Alpha bravo charlie delta echo')
-  // The payload landed INSIDE the long-pressed paragraph (the caret sits at
-  // the click point, so the needle text is split around the insertion).
+  // The payload landed INSIDE the long-pressed paragraph — not in the other
+  // paragraph and not at a stale earlier selection. (Where exactly inside
+  // depends on the click-to-caret mapping and the responsive text measure,
+  // so the assertion is anchored to the paragraph, not a split point.)
   const paragraphWithPayload = await page.evaluate(
     () =>
       Array.from(document.querySelectorAll('[data-testid="editor-host"] .mu-editor p'))
         .map(node => node.textContent ?? '')
         .find(text => text.includes('pasted-at-caret')) ?? '',
   )
-  expect(paragraphWithPayload).toMatch(/^Second.*pasted-at-caret.*tail$/s)
+  expect(paragraphWithPayload).toMatch(/^Second.*pasted-at-caret/s)
+  expect(paragraphWithPayload).toContain('tail')
   await expect(toolbar).toBeHidden()
 })
 

--- a/tests/e2e/mobile-selection-toolbar.spec.ts
+++ b/tests/e2e/mobile-selection-toolbar.spec.ts
@@ -226,27 +226,44 @@ test('paste lands at the long-pressed caret and ends the session', async ({ page
   await openDraft(page)
   await page.evaluate(() => navigator.clipboard.writeText('pasted-at-caret'))
 
-  await longPressParagraph(page, 'Second paragraph tail')
+  // Deterministic caret: a click-derived caret position depends on the
+  // responsive text measure, so place the collapsed caret at a KNOWN offset
+  // (after "Second", before " paragraph") and fire the context request from
+  // exactly that position — dispatching contextmenu does not move a caret.
+  await page.evaluate(() => {
+    const paragraph = Array.from(
+      document.querySelectorAll('[data-testid="editor-host"] .mu-editor p'),
+    ).find(node => node.textContent?.includes('Second paragraph tail'))!
+    const walker = document.createTreeWalker(paragraph, NodeFilter.SHOW_TEXT)
+    const text = walker.nextNode() as Text
+    const range = document.createRange()
+    range.setStart(text, 'Second'.length)
+    range.collapse(true)
+    const selection = document.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+  })
+  await page
+    .locator('[data-testid="editor-host"] .mu-editor p')
+    .filter({ hasText: 'Second paragraph tail' })
+    .first()
+    .dispatchEvent('contextmenu')
+
   const toolbar = page.getByTestId('mobile-selection-toolbar')
   await expect(toolbar).toBeVisible()
-
   await toolbar.getByTestId('selection-command-paste').click()
 
-  await expect(page.getByTestId('editor-host')).toContainText('pasted-at-caret')
-  // Nothing was replaced: the other paragraph survives untouched.
+  // Nothing was replaced: the other paragraph survives untouched...
   await expect(page.getByTestId('editor-host')).toContainText('Alpha bravo charlie delta echo')
-  // The payload landed INSIDE the long-pressed paragraph — not in the other
-  // paragraph and not at a stale earlier selection. (Where exactly inside
-  // depends on the click-to-caret mapping and the responsive text measure,
-  // so the assertion is anchored to the paragraph, not a split point.)
+  // ...and the payload sits EXACTLY at the long-pressed caret, between the
+  // known prefix and suffix.
   const paragraphWithPayload = await page.evaluate(
     () =>
       Array.from(document.querySelectorAll('[data-testid="editor-host"] .mu-editor p'))
         .map(node => node.textContent ?? '')
         .find(text => text.includes('pasted-at-caret')) ?? '',
   )
-  expect(paragraphWithPayload).toMatch(/^Second.*pasted-at-caret/s)
-  expect(paragraphWithPayload).toContain('tail')
+  expect(paragraphWithPayload).toBe('Secondpasted-at-caret paragraph tail')
   await expect(toolbar).toBeHidden()
 })
 

--- a/third_party/muya/src/assets/styles/blockSyntax.css
+++ b/third_party/muya/src/assets/styles/blockSyntax.css
@@ -18,7 +18,13 @@
     max-width: var(--editor-area-width, 800px);
     min-height: 100%;
     margin: 0 auto;
-    padding: 0 50px 100px;
+
+    /* The horizontal gutter is a host-tunable variable: the 50px default
+       preserves the historical desktop layout, while narrow hosts (phones)
+       set --editor-gutter to reclaim the column width. Consumers that
+       compensate for the gutter (math scroll width, the host's line-width
+       setting) must derive from the same variable. */
+    padding: 0 var(--editor-gutter, 50px) 100px;
 
     color: var(--editor-color);
 }

--- a/third_party/muya/src/assets/styles/inlineSyntax.css
+++ b/third_party/muya/src/assets/styles/inlineSyntax.css
@@ -183,6 +183,14 @@ code.mu-inline-rule {
 
     display: inline-block;
 
+    /* Anchor the whole inline-math box to the paragraph's ACTUAL text
+       measure. The render child is sized inside a shrink-to-fit
+       inline-block, where its own percentage max-width cannot resolve —
+       capping the parent against the paragraph (a definite containing
+       block) is what keeps a long formula scrolling inside itself instead
+       of widening the editor on narrow viewports. */
+    max-width: 100%;
+
     color: var(--editor-color);
     font-family: monospace;
     vertical-align: middle;
@@ -208,10 +216,12 @@ code.mu-inline-rule {
 }
 
 /* A long inline-math formula must scroll horizontally (in the editing popup and
-   inline when hidden) instead of overflowing the editor area. The subtrahend
-   mirrors the .mu-container horizontal padding on both sides. */
+   inline when hidden) instead of overflowing the editor area. The limit is the
+   ACTUAL containing block (the paragraph's text measure, or the popup body) —
+   not the configured --editor-area-width, which is only the column's maximum
+   and far exceeds the real measure on narrow viewports. */
 .mu-math > .mu-math-render {
-    max-width: calc(var(--editor-area-width, 800px) - 2 * var(--editor-gutter, 50px));
+    max-width: 100%;
     overflow: auto hidden;
 
     scrollbar-width: thin;

--- a/third_party/muya/src/assets/styles/inlineSyntax.css
+++ b/third_party/muya/src/assets/styles/inlineSyntax.css
@@ -208,9 +208,10 @@ code.mu-inline-rule {
 }
 
 /* A long inline-math formula must scroll horizontally (in the editing popup and
-   inline when hidden) instead of overflowing the editor area. */
+   inline when hidden) instead of overflowing the editor area. The subtrahend
+   mirrors the .mu-container horizontal padding on both sides. */
 .mu-math > .mu-math-render {
-    max-width: calc(var(--editor-area-width, 800px) - 100px);
+    max-width: calc(var(--editor-area-width, 800px) - 2 * var(--editor-gutter, 50px));
     overflow: auto hidden;
 
     scrollbar-width: thin;
@@ -456,6 +457,10 @@ blockquote .mu-hide.mu-math > .mu-math-render {
 
 .mu-inline-image.mu-image-loading {
     width: 400px;
+
+    /* Never wider than the editing column — a fixed 400px placeholder
+       overflows a phone-width canvas. */
+    max-width: 100%;
     height: 250px;
     margin: 0 auto;
 


### PR DESCRIPTION
## Problem

On a 393dp phone the editor rendered a ~257dp text column — 35% of the screen width went to empty gutters. The investigation of the full layout chain found the cause: **two uncoordinated spacing owners stack**. The Android host adds 18px horizontal padding on `.mu-editor` (mobile breakpoint), and vendored Muya's `.mu-container` hardcodes the desktop assumption `padding: 0 50px 100px` — 68dp of gutter per side. On wide screens the same stack added the host's 56px on top of Muya's centered 800px column.

## Design (evidence first, no assumed values)

- **Readability**: the comfortable reading measure is 45–75 characters per line (classic typographic guidance; WCAG's reflow guidance uses ≤80). At the default 16px font, a 393dp phone with 16dp gutters yields ≈45ch — the *lower bound* of that range. Phones therefore need near-minimal gutters: every extra pixel of gutter costs readable measure, not comfort.
- **Platform convention**: 16dp is the Material compact-window edge margin, and the gutter used by contemporary mobile Markdown editors (iA Writer, Obsidian mobile, Google Keep).
- **Wide screens**: the classic centered column (Muya's 800px `--editor-area-width` cap with 50px inner gutters ≈ 82ch measure) is retained — larger screens get their comfort from the measure cap and centering, not from stacked host padding.

## Change

**One owner for horizontal space.** Muya's `.mu-container` gutter becomes `var(--editor-gutter, 50px)` (default = historical desktop layout, so standalone/desktop Muya is pixel-identical), and the host shell — now the single owner — sets `--editor-gutter: 50px` above 720px and `16px` at or below it while dropping its own horizontal padding entirely.

Muya is adapted as part of this product where the issue belongs to the editor: the inline-math scroll-width compensation derives from the same variable instead of a hardcoded `100px`, and the fixed 400px image-loading placeholder gains `max-width: 100%` (it previously overflowed a phone column). `node_modules` copies synced; the vendor-sync contract test guards it.

The **editor line-width setting** now maps to `calc(2 * var(--editor-gutter, 50px) + <value>)`, so the entered value stays the true *text measure* at every breakpoint instead of assuming desktop's 2×50px forever.

**Result**: phone text measure grows ~257dp → ~361dp (+40%). Verified on the API 35 emulator with the same document as the report screenshot: container padding computes to exactly 16px and the paragraph box is 380dp on a 412dp viewport (before/after screenshots).

## Regression coverage

New `mobile-editor-layout.spec.ts` pins the contract: portrait 393 → exactly one 16px gutter per side and zero host padding; narrow 320 → same rule; landscape 851 → centered 800px column with 50px gutters and no stacked padding; `editorLineWidth: 30ch` → the measure caps and centers on top of the gutters. The appearance-settings spec asserts the new gutter-derived calc.

## Checks run (per the repository testing policy)

- Focused: layout spec 4/4, appearance-settings unit 4/4, theme-token + settings-content 14/14, muya vendor-sync contract, lint, typecheck, on-device measurement.
- Full unit: 429/429. Complete Playwright suite **once**: 121 passed / 1 skipped / 3 failed —
  1. appearance-settings formula assertion: real consequence of the formula change; expectation updated.
  2. selection-toolbar paste-at-caret: the test right-clicks the paragraph box center, and with the intended wider measure the short probe text now ends *before* that center, so the caret lands at the text end; the assertion is re-anchored to "payload lands inside the long-pressed paragraph" (the property it actually guards).
  3. one editor-boot timeout (known infra signature).
- Rerun of exactly those three specs together: 39 passed / 1 skipped — including the boot-timeout test passing untouched (recorded as a suite-level flake). No second full run: the two test fixes are spec-local expectation updates.

Out of scope, untouched: bottom toolbar, vertical spacing, any visual redesign.