### PR TITLE
Synchronize the caret-paste e2e assertion with the async clipboard read

### DIFF
--- a/tests/e2e/mobile-selection-toolbar.spec.ts
+++ b/tests/e2e/mobile-selection-toolbar.spec.ts
@@ -256,14 +256,19 @@ test('paste lands at the long-pressed caret and ends the session', async ({ page
   // Nothing was replaced: the other paragraph survives untouched...
   await expect(page.getByTestId('editor-host')).toContainText('Alpha bravo charlie delta echo')
   // ...and the payload sits EXACTLY at the long-pressed caret, between the
-  // known prefix and suffix.
-  const paragraphWithPayload = await page.evaluate(
-    () =>
-      Array.from(document.querySelectorAll('[data-testid="editor-host"] .mu-editor p'))
-        .map(node => node.textContent ?? '')
-        .find(text => text.includes('pasted-at-caret')) ?? '',
-  )
-  expect(paragraphWithPayload).toBe('Secondpasted-at-caret paragraph tail')
+  // known prefix and suffix. Polled: the paste command re-reads the clipboard
+  // asynchronously after the click, so a one-shot snapshot races it on slow
+  // runners.
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          Array.from(document.querySelectorAll('[data-testid="editor-host"] .mu-editor p'))
+            .map(node => node.textContent ?? '')
+            .find(text => text.includes('pasted-at-caret')) ?? '',
+      ),
+    )
+    .toBe('Secondpasted-at-caret paragraph tail')
   await expect(toolbar).toBeHidden()
 })
 


### PR DESCRIPTION
# Summary

Fixes the `Mobile WebView E2E` failure on main after #103:
`mobile-selection-toolbar.spec.ts › paste lands at the long-pressed caret and
ends the session` failed on CI with `Received: ""`.

## Root cause

A missing synchronization in the test, not a product bug. After the toolbar's
Paste button is clicked, the paste command **re-reads the clipboard
asynchronously** (`navigator.clipboard.readText`) before adopting the caret and
applying the insert. The test then:

1. asserts `toContainText('Alpha bravo…')` — content that exists **before** the
   paste, so it passes immediately and provides no synchronization, and
2. takes a **one-shot** `page.evaluate` snapshot scanning for the payload.

On a fast local machine the paste chain wins that race; on the slower CI runner
the snapshot lands first, no paragraph contains the payload yet, and the
`?? ''` fallback produces exactly the observed `Received: ""`.

The empty-payload hypothesis is ruled out by the test's own preconditions: the
Paste row only renders when the clipboard query returns content (pinned by the
empty-clipboard tests in the same file), and that click succeeded.

## Reproduction

Delaying `navigator.clipboard.readText` by 600 ms in a throwaway local spec
reproduces the CI failure byte-for-byte with the one-shot assertion, while the
polled form passes **with the expected string unchanged** — confirming the
paste position was always correct and only the observation raced.

## Fix

The payload scan now uses `expect.poll`, the same idiom the cut and select-all
tests in this file already use. The expected string is untouched: the exact
prefix/payload/suffix placement contract from the #103 review round stays
fully in force.

## Verification

- `tests/e2e/mobile-selection-toolbar.spec.ts`: 14/14 pass.
- Repro spec (deleted, never committed): unfixed assertion fails with the CI
  signature under 600 ms clipboard latency; fixed assertion passes.
- `pnpm lint`: pass.
