### PR TITLE
Bring the link sheet up to the table sheet protection standard

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -271,9 +271,10 @@ let lastContentLogAt = 0
 let appLifecycleListeners: AppLifecycleListeners | null = null
 let pendingInlineInsertRange: Range | null = null
 let pendingTableInsertRange: Range | null = null
-// The editor instance the table sheet was opened for: a warm open-with or
-// share intent can replace the editor under the open sheet, and a confirm
-// must never act on the successor document.
+// The editor instance each sheet was opened for: a warm open-with or share
+// intent can replace the editor under an open sheet, and a confirm must
+// never act on the successor document.
+let pendingLinkInsertEditor: unknown = null
 let pendingTableInsertEditor: unknown = null
 let startupActionTimer: number | null = null
 let systemColorSchemeCleanup: (() => void) | null = null
@@ -721,7 +722,8 @@ async function openEditor(markdown: string) {
   resetSelectionToolbarLongPress()
   resetEditorSearchForNewDocument()
   resetEditorOutlineForNewDocument()
-  // The sheet and its pending range belong to the outgoing document.
+  // The sheets and their pending ranges belong to the outgoing document.
+  closeLinkSheet()
   closeTableSheet()
   await openEditorSessionDocument(markdown)
   void startResumeForOpenedDocument()
@@ -864,7 +866,11 @@ function openLinkSheet(restoreRange: Range | null = null) {
     return
   }
 
+  // Same policy as the outline and table sheets: never stack on the search
+  // overlay; no cursor restore — that would reopen the keyboard.
+  closeEditorSearch({ restoreCursor: false })
   pendingInlineInsertRange = capturedRange
+  pendingLinkInsertEditor = getEditor()
   closeEditorOutline()
   standDownResume('link sheet opened')
   endSelectionCaretSession('link sheet opened')
@@ -877,10 +883,18 @@ function openLinkSheet(restoreRange: Range | null = null) {
 function closeLinkSheet() {
   resetEditorLinkSheet()
   pendingInlineInsertRange = null
+  pendingLinkInsertEditor = null
 }
 
 function insertLinkFromSheet() {
-  const beforeMarkdown = getEditor()?.getMarkdown() ?? ''
+  const activeEditor = getEditor()
+  if (!activeEditor || activeEditor !== pendingLinkInsertEditor) {
+    editorLog.warn('mobile link insert dropped: the editor was replaced under the sheet')
+    closeLinkSheet()
+    return
+  }
+
+  const beforeMarkdown = activeEditor.getMarkdown() ?? ''
   const result = insertLinkFromSheetWorkflow({
     hasEditor: hasEditor(),
     linkText: linkText.value,

--- a/src/features/editor/EditorScreen.vue
+++ b/src/features/editor/EditorScreen.vue
@@ -150,29 +150,42 @@ watch(
   },
 )
 
-// After the table sheet closes, focus must not be left dangling on <body>.
-// Only rescue a DANGLING focus: after an insert Muya moves the cursor into
-// the first cell and owns the focus — never steal it back to a button. The
-// sheet leaves through a Transition, so at this point the old controls can
-// still hold focus inside the departing dialog; that counts as dangling.
+// After an insert sheet closes, focus must not be left dangling on <body>.
+// Only rescue a DANGLING focus: after an insert the editor takes the cursor
+// and owns the focus — never steal it back to a button. The sheets leave
+// through a Transition, so at this point the old controls can still hold
+// focus inside the departing dialog; that counts as dangling.
+function rescueFocusAfterSheetClose(sheetTestId: string) {
+  void nextTick(() => {
+    const active = document.activeElement
+    const focusSettledElsewhere =
+      active &&
+      active !== document.body &&
+      !active.closest(`[data-testid="${sheetTestId}"]`)
+    if (focusSettledElsewhere) {
+      return
+    }
+    editorShell.value
+      ?.closest('.app-shell')
+      ?.querySelector<HTMLElement>('[data-testid="toolbar-expand-button"]')
+      ?.focus({ preventScroll: true })
+  })
+}
+
 watch(
   () => props.tableSheetOpen,
   (open, wasOpen) => {
     if (!open && wasOpen) {
-      void nextTick(() => {
-        const active = document.activeElement
-        const focusSettledElsewhere =
-          active &&
-          active !== document.body &&
-          !active.closest('[data-testid="table-insert-sheet"]')
-        if (focusSettledElsewhere) {
-          return
-        }
-        editorShell.value
-          ?.closest('.app-shell')
-          ?.querySelector<HTMLElement>('[data-testid="toolbar-expand-button"]')
-          ?.focus({ preventScroll: true })
-      })
+      rescueFocusAfterSheetClose('table-insert-sheet')
+    }
+  },
+)
+
+watch(
+  () => props.linkSheetOpen,
+  (open, wasOpen) => {
+    if (!open && wasOpen) {
+      rescueFocusAfterSheetClose('link-insert-sheet')
     }
   },
 )

--- a/src/features/editor/components/LinkInsertSheet.vue
+++ b/src/features/editor/components/LinkInsertSheet.vue
@@ -15,6 +15,7 @@ const emit = defineEmits<{
 }>()
 
 const linkUrlInput = ref<HTMLInputElement | null>(null)
+const panel = ref<HTMLElement | null>(null)
 const { t } = useI18n()
 const canInsert = computed(() => props.url.trim().length > 0)
 const textValue = computed({
@@ -31,6 +32,43 @@ onMounted(() => {
     linkUrlInput.value?.focus()
   })
 })
+
+// Keyboard containment relies on this Tab trap ALONE (aria-modal does not
+// contain focus). Unlike the outline and table sheets, the background must
+// NOT be inert here: the confirm inserts through focus + execCommand into
+// the still-mounted editor, and an inert editor refuses focus, which turns
+// every insert into a silent failure.
+function trapTabKey(event: KeyboardEvent) {
+  const root = panel.value
+  if (!root) {
+    return
+  }
+
+  const focusables = Array.from(
+    root.querySelectorAll<HTMLElement>('input:not(:disabled), button:not(:disabled)'),
+  )
+  if (focusables.length === 0) {
+    event.preventDefault()
+    return
+  }
+
+  const first = focusables[0]
+  const last = focusables[focusables.length - 1]
+  const active = document.activeElement
+
+  if (event.shiftKey) {
+    if (active === first || active === root) {
+      event.preventDefault()
+      last.focus()
+    }
+    return
+  }
+
+  if (active === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
 </script>
 
 <template>
@@ -41,8 +79,13 @@ onMounted(() => {
     aria-labelledby="link-sheet-title"
     data-testid="link-insert-sheet"
     @keydown.esc="emit('cancel')"
+    @keydown.tab="trapTabKey"
   >
-    <form class="draft-save-panel link-insert-panel" @submit.prevent="emit('insert')">
+    <form
+      ref="panel"
+      class="draft-save-panel link-insert-panel"
+      @submit.prevent="emit('insert')"
+    >
       <h2 id="link-sheet-title">{{ t('editor.link.title') }}</h2>
       <label class="link-field">
         <span>{{ t('editor.link.text') }}</span>

--- a/tests/e2e/mobile-editor-toolbar.spec.ts
+++ b/tests/e2e/mobile-editor-toolbar.spec.ts
@@ -529,6 +529,56 @@ test('the table lands at the toolbar-cached selection, not a later moved caret',
   )
 })
 
+test('opening the link sheet closes the in-document search overlay', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('searchable content')
+  await page.getByTestId('search-open-button').click()
+  await expect(page.getByTestId('editor-search-bar')).toBeVisible()
+
+  await selectToolbarPanel(page, 'insert')
+  await page.getByTestId('toolbar-command-format.hyperlink').click()
+
+  await expect(page.getByTestId('link-insert-sheet')).toBeVisible()
+  await expect(page.getByTestId('editor-search-bar')).toBeHidden()
+})
+
+test('the link sheet contains keyboard focus and rescues it on cancel', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await selectToolbarPanel(page, 'insert')
+  await page.getByTestId('toolbar-command-format.hyperlink').click()
+  await expect(page.getByTestId('link-insert-sheet')).toBeVisible()
+
+  const activeTestId = () =>
+    page.evaluate(
+      () =>
+        document.activeElement?.getAttribute('data-testid') ??
+        document.activeElement?.tagName ??
+        'none',
+    )
+
+  // Initial focus leads to the URL field; with it empty the Insert button is
+  // disabled, so forward Tab reaches Cancel and WRAPS to the text field
+  // instead of escaping through the scrim into the app chrome.
+  await expect.poll(activeTestId).toBe('link-url-input')
+  await page.keyboard.press('Tab')
+  await expect.poll(activeTestId).toBe('link-cancel-button')
+  await page.keyboard.press('Tab')
+  await expect.poll(activeTestId).toBe('link-text-input')
+
+  // Shift+Tab from the first control wraps back to the last.
+  await page.keyboard.press('Shift+Tab')
+  await expect.poll(activeTestId).toBe('link-cancel-button')
+
+  // Closing without inserting must not leave focus dangling on <body>.
+  await page.getByTestId('link-cancel-button').click()
+  await expect(page.getByTestId('link-insert-sheet')).toBeHidden()
+  await expect.poll(activeTestId).toBe('toolbar-expand-button')
+})
+
 test('opening the table sheet closes the in-document search overlay', async ({ page }) => {
   await newBlankDocument(page)
 

--- a/tests/e2e/mobile-share-intent.spec.ts
+++ b/tests/e2e/mobile-share-intent.spec.ts
@@ -378,6 +378,53 @@ test('a warm Android share closes an open table sheet and never touches the new 
   await expect(page.getByTestId('editor-host').locator('figure.mu-table')).toHaveCount(0)
 })
 
+test('a warm Android share closes an open link sheet and never touches the new document', async ({
+  page,
+}) => {
+  await installAndroidShareAppMock(page)
+  await page.addInitScript(() => localStorage.clear())
+  await page.goto('/')
+  await page.waitForFunction(() => {
+    const win = window as unknown as MockCapacitorWindow
+    return (win.__androidDocumentListenerCount?.('shareDocument') ?? 0) > 0
+  })
+
+  await page.getByTestId('new-document-button').click()
+  await expectEditorReady(page)
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('document A body')
+
+  await page.getByTestId('toolbar-expand-button').click()
+  await page.getByTestId('toolbar-group-switcher').click()
+  await page.getByTestId('toolbar-section-option-insert').click()
+  await page.getByTestId('toolbar-command-format.hyperlink').click()
+  await expect(page.getByTestId('link-insert-sheet')).toBeVisible()
+  await page.getByTestId('link-url-input').fill('https://example.com/stale')
+
+  await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    win.__emitAndroidShareDocument?.({
+      document: {
+        sourceUri: null,
+        displayName: 'Warm Share.md',
+        providerName: 'Android share',
+        pathHint: 'Warm Share.md',
+        mimeType: 'text/plain',
+        markdown: '# Warm Share\n\nreplaced under the link sheet',
+        canWrite: false,
+        persisted: false,
+        shareKind: 'text',
+      },
+    })
+  })
+
+  await expect(page.getByTestId('editor-host')).toContainText('replaced under the link sheet')
+  // The sheet was opened for document A: it must not survive the editor
+  // replacement, and the staged URL must never reach the new document.
+  await expect(page.getByTestId('link-insert-sheet')).toBeHidden()
+  await expect(page.getByTestId('editor-host')).not.toContainText('example.com/stale')
+})
+
 test('shows a safe notice when an Android share is rejected', async ({ page }) => {
   await installAndroidShareAppMock(page, {
     pendingShareEvent: {


### PR DESCRIPTION
# Summary

Maintenance: brings `LinkInsertSheet` up to the protection standard the #106
review round established for the table sheet. The link sheet predates those
findings and shared the same three gaps — verified in code, same mechanisms,
same fixes ported over.

## Fixes

1. **Stale sheet across editor replacement.** `openEditor()` (the central
   replacement path every document open lands on, including warm open-with and
   share intents) now closes the link sheet and clears
   `pendingInlineInsertRange`, exactly as it already does for the table sheet.
   The confirm handler additionally binds to the editor instance the sheet was
   opened for (`pendingLinkInsertEditor`) and drops the insert when the editor
   changed underneath — so a sheet opened for document A can never insert into
   a successor document B.
2. **Search exclusivity.** `openLinkSheet()` closes the in-document search
   overlay under the same no-cursor-restore policy the outline and table
   sheets use (`closeEditorSearch({ restoreCursor: false })`).
3. **Keyboard focus containment.** The dialog traps Tab/Shift+Tab inside the
   panel (inputs + enabled buttons, wrapping at both ends), and a close that
   leaves focus dangling — on `<body>` or inside the departing Transition — is
   rescued to the toolbar expand handle via the same helper the table sheet
   uses (now shared).

## A constraint the table sheet does not have

The link sheet must NOT make the background inert. Its confirm inserts through
`editor.focus()` + `execCommand('insertText')` into the still-mounted editor,
and an inert editor refuses focus, which turns every insert into a silent
failure — the focused run caught exactly that when the first version extended
the inert bindings. Containment therefore relies on the Tab trap alone
(the review-accepted alternative); the table sheet keeps inert + trap because
`muya.createTable` works at the model level and needs no DOM focus at confirm.
This constraint is documented in the component.

## Tests

Mirrors of the table regressions:

- Warm Android share replaces the document while the link sheet is open with a
  staged URL → the sheet disappears, the staged URL never reaches the new
  document (`mobile-share-intent.spec.ts`).
- Opening the link sheet closes the search overlay.
- Focus containment: URL-field initial focus, Tab wraps Cancel → text field
  (Insert is disabled while the URL is empty), Shift+Tab wraps back, and
  cancel rescues focus to the toolbar expand handle.

## Verification

- `pnpm typecheck`, `pnpm lint`: pass.
- `pnpm test`: full unit suite passes.
- Focused e2e (toolbar + share-intent specs): 42/42 — including the two
  pre-existing link-insert flows that caught the inert regression.
- One full Playwright run: 137 passed / 1 failed in 8.8 minutes. The failure
  is an unrelated resume spec that timed out at `expectEditorReady` — the
  documented cold-transform boot flake signature — and passes in isolation
  (10.7s); recorded as a suite-level flake per the testing policy.
