### PR TITLE
Stop the empty-paragraph hint advertising the unregistered slash menu

### DIFF
--- a/src/features/editor/editorRuntime.test.ts
+++ b/src/features/editor/editorRuntime.test.ts
@@ -1,6 +1,42 @@
 import { describe, expect, it, vi } from 'vitest'
 import { DEFAULT_EDITING_SETTINGS, type EditingSettings } from '../settings/editingSettings'
-import { applyMuyaEditingSettings, type MuyaEditor } from './editorRuntime'
+import { applyMuyaEditingSettings, resolveMuyaLocale, type MuyaEditor } from './editorRuntime'
+
+const fakeCore = {
+  en: {
+    name: 'en',
+    resource: { 'Type / to insert...': 'Type / to insert...', 'Untouched': 'Untouched' },
+  },
+  zhCN: {
+    name: 'zh-CN',
+    resource: { 'Type / to insert...': '输入 / 插入段落', 'Untouched': '未动' },
+  },
+} as unknown as Parameters<typeof resolveMuyaLocale>[0]
+
+describe('editorRuntime locale', () => {
+  it('replaces the hint that advertises the unregistered quick-insert menu', () => {
+    const en = resolveMuyaLocale(fakeCore, 'en')
+    expect(en.resource['Type / to insert...']).toBe('Start writing...')
+    expect(en.resource['Untouched']).toBe('Untouched')
+
+    const zh = resolveMuyaLocale(fakeCore, 'zh-CN')
+    expect(zh.resource['Type / to insert...']).toBe('开始书写…')
+    expect(zh.resource['Type / to insert...']).not.toContain('/')
+
+    // Unknown app locales fall back to the English base and English hint.
+    const fallback = resolveMuyaLocale(fakeCore, 'fr')
+    expect(fallback.name).toBe('en')
+    expect(fallback.resource['Type / to insert...']).toBe('Start writing...')
+  })
+
+  it('never mutates the shared vendored locale objects', () => {
+    resolveMuyaLocale(fakeCore, 'en')
+    resolveMuyaLocale(fakeCore, 'zh-CN')
+
+    expect(fakeCore.en.resource['Type / to insert...']).toBe('Type / to insert...')
+    expect(fakeCore.zhCN.resource['Type / to insert...']).toBe('输入 / 插入段落')
+  })
+})
 
 describe('editorRuntime editing settings', () => {
   it('applies Editing updates through Muya options without reading or saving markdown', () => {

--- a/src/features/editor/editorRuntime.ts
+++ b/src/features/editor/editorRuntime.ts
@@ -65,8 +65,25 @@ async function registerMuyaPlugins(logger?: EditorRuntimeLogger) {
   return core
 }
 
-function resolveMuyaLocale(core: MuyaCoreModule, appLocale = 'en') {
-  return appLocale === 'zh-CN' ? core.zhCN : core.en
+// The stock Muya empty-paragraph hint advertises the "/" quick-insert menu,
+// whose plugin is deliberately not registered on Android: the toolbar is the
+// insert surface, and "/" sits behind the symbols layer on touch keyboards.
+// Never promise an interaction that does not exist — swap the hint at the
+// locale boundary so vendored Muya stays untouched. Revisit only if a
+// curated, touch-adapted quick-insert menu ships (see todolist).
+const EMPTY_PARAGRAPH_HINTS: Record<string, string> = {
+  'en': 'Start writing...',
+  'zh-CN': '开始书写…',
+}
+
+export function resolveMuyaLocale(core: MuyaCoreModule, appLocale = 'en') {
+  const base = appLocale === 'zh-CN' ? core.zhCN : core.en
+  const resource: Record<string, string> = {
+    ...base.resource,
+    'Type / to insert...': EMPTY_PARAGRAPH_HINTS[appLocale] ?? EMPTY_PARAGRAPH_HINTS['en'],
+  }
+
+  return { ...base, resource }
 }
 
 function getMuyaAppearanceOptions(settings?: AppearanceTextSettings) {

--- a/tests/e2e/mobile-markdown-editing.spec.ts
+++ b/tests/e2e/mobile-markdown-editing.spec.ts
@@ -7,6 +7,17 @@ import {
 
 test.describe.configure({ timeout: 60000 })
 
+// The "/" quick-insert menu is deliberately not registered on Android (the
+// toolbar is the insert surface), so the empty-paragraph hint must not
+// advertise it.
+test('the empty-paragraph hint does not promise the unregistered "/" menu', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await expect(
+    page.locator('[data-testid="editor-host"] [empty-hint]').first(),
+  ).toHaveAttribute('empty-hint', 'Start writing...')
+})
+
 test('toggles a task list checkbox and persists the checked markdown state', async ({ page }) => {
   await openLocalDraft(
     page,


### PR DESCRIPTION
# Summary

The empty-paragraph ghost text advertised "Type / to insert..." — but the `/`
quick-insert menu (`ParagraphQuickInsertMenu`) is deliberately not registered
on Android, so typing `/` just types a slash. The hint is core Muya behavior
(`paragraphContent` sets it unconditionally through i18n), which is why the
promise survived the plugin decision. The hint now reads "Start writing..." /
"开始书写…" instead.

## Why remove the promise instead of keeping it

Investigated before changing (details in the local todolist entry):

- **Touch keyboards tax the trigger.** `/` sits behind the `?123` symbols
  layer on Gboard — reaching the menu costs more taps than the always-visible
  toolbar's Insert panel, which already covers every insertable block
  (audited in #102). On touch, slash insert is a slower duplicate path.
- **Industry practice matches.** Obsidian ships its customizable mobile
  toolbar by default and keeps slash commands an opt-in plugin; Notion mobile
  leads with the `+` button and mobile slash friction is a recurring user
  complaint. The toolbar-first pattern is the mobile convention.
- **Registering the stock menu would reintroduce known dead ends.** Its
  `table` item routes into `muya-table-picker` (the exact Android no-op #106
  just fixed at the toolbar) and it carries five diagram items whose Android
  rendering has never been validated. An honest menu means a curated item
  set — real scope, near-zero value today. Deferred with an explicit
  revisit condition (hardware-keyboard/tablet evidence).

## Mechanics

The swap happens at the locale boundary: `resolveMuyaLocale` clones the
vendored locale and overrides the single resource key, so vendored Muya is
untouched, both the editor-creation and locale-switch paths get the new hint
(Muya re-resolves hints on locale change, pinned by its `localeRefresh`
spec), and the shared vendored locale objects are never mutated (unit-pinned).

## Tests

- Unit: en/zh/fallback hint resolution, untouched sibling keys, and
  no mutation of the shared vendored locale objects.
- E2E: a blank document's `empty-hint` attribute reads "Start writing..."
  (and therefore no longer mentions `/`).

## Verification

- `pnpm typecheck`, `pnpm lint`: pass.
- `pnpm test`: full unit suite passes (3 new).
- Focused e2e: `mobile-markdown-editing.spec.ts` 5/5.
- One full Playwright run: in progress at PR time; the result will be posted
  before merge.
