### PR TITLE
Hide the redundant code-fence markers that overlap under textZoom

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -869,6 +869,25 @@ body {
   -webkit-text-stroke: 0.035em currentColor;
 }
 
+/* An active fenced code block draws literal ``` fence markers above and below
+   it (Muya's `pre.mu-active.mu-fenced-code::before/::after`). Their positions
+   are fixed px, but Android WebView applies the user's system font scale as
+   textZoom — it enlarges the marker GLYPHS without scaling the px offsets, so
+   at any non-default font scale the top ``` collides with the language-label
+   field and the bottom ``` laps the box border (device-measured: markers at
+   1.25x width over unscaled 20px/-23px offsets). Pure-CSS alignment is
+   impossible because the glyph width tracks textZoom while the offsets do not.
+   The markers are desktop editing chrome and are redundant on mobile: the box,
+   the editable language label, and the corner "fenced" tag already identify the
+   block, so hide just the two ``` pseudo-markers. Android-scoped on purpose —
+   the vendored Muya CSS still shows them for the desktop build. The higher
+   specificity (extra `.mu-editor`) wins over Muya's own rule, which loads later
+   via the dynamic editor import. */
+.mu-editor pre.mu-active.mu-fenced-code::before,
+.mu-editor pre.mu-active.mu-fenced-code::after {
+  content: none;
+}
+
 .status-bar {
   display: flex;
   justify-content: center;

--- a/tests/e2e/mobile-editor-toolbar.spec.ts
+++ b/tests/e2e/mobile-editor-toolbar.spec.ts
@@ -430,6 +430,38 @@ test('inserts a fenced code block from the paragraph panel', async ({ page }) =>
   await expect.poll(() => getDraftStorage(page)).toContain('```js\\nconst fenced = true\\n```')
 })
 
+// Android WebView scales marker GLYPHS by the user's system font size
+// (textZoom) but not the fence markers' fixed px offsets, so Muya's literal
+// ``` fence pseudo-markers collided with the language label above and the box
+// border below. They are desktop editing chrome, redundant with the box, the
+// language field, and the corner "fenced" tag, so the Android build hides
+// them; the box and tag stay.
+test('hides the literal fence pseudo-markers on an active code block', async ({ page }) => {
+  await newBlankDocument(page)
+
+  await page.getByTestId('editor-host').click()
+  await selectToolbarPanel(page, 'paragraph')
+  await page.getByTestId('toolbar-command-paragraph.code-fence').scrollIntoViewIfNeeded()
+  await page.getByTestId('toolbar-command-paragraph.code-fence').click()
+
+  const fence = page.getByTestId('editor-host').locator('pre.mu-code-block.mu-fenced-code')
+  await expect(fence).toHaveCount(1)
+  // The block is active (just inserted, cursor inside): the app override must
+  // win the cascade over Muya's own marker rule.
+  await expect(fence).toHaveClass(/mu-active/)
+
+  const markerContent = await fence.evaluate(node => [
+    getComputedStyle(node, '::before').content,
+    getComputedStyle(node, '::after').content,
+  ])
+  expect(markerContent).toEqual(['none', 'none'])
+
+  // The "fenced" tag (a different pseudo-element on .mu-code) is untouched.
+  await expect(
+    page.getByTestId('editor-host').locator('.mu-fenced-code.mu-active .mu-code'),
+  ).toHaveCount(1)
+})
+
 // The Table command opens the size sheet (steppers, default 3×3) and inserts
 // through `muya.createTable`. It must not route to `updateParagraph('table')`:
 // that Muya path emits `muya-table-picker`, whose only subscriber is the


### PR DESCRIPTION
# Summary

Fixes the code block's overlapping fence markers reported on-device: an active
fenced code block drew literal ``` markers that collided with the language
label above and the box border below. The Android build now hides those
decorative markers; the box, the editable language label, and the corner
"fenced" tag remain.

## Root cause (device-measured)

Muya draws the ``` fence markers as `pre.mu-active.mu-fenced-code::before` /
`::after`, positioned with fixed px offsets (`top: -20px`, `bottom: -23px`,
language label `left: 20px`). Android WebView applies the user's system font
size as **textZoom**, which enlarges the marker GLYPHS (measured 1.25× — the
``` rendered 39.5px wide) but does **not** scale the px offsets. So the wider
scaled ``` overran the 20px language offset (top collision) and the taller
scaled marker line lapped back over the box border (bottom collision).

- Confirmed it is textZoom (the user's font-size preference), not Chromium
  text-autosizing: injecting `text-size-adjust: 100%` on-device left the 1.25×
  intact, so it must be respected, not disabled.
- Pure-CSS alignment is impossible: the glyph width tracks textZoom while the
  CSS offsets do not, and the scale factor is not exposed to CSS. Any px/em
  value drifts at some font scale.

## Fix

The ``` markers are desktop editing chrome and are redundant on mobile — the
box outline, the editable language label, and the corner "fenced" tag already
identify the block. So the Android layer hides just the two ``` pseudo-markers
for an active fenced code block (`src/style.css`):

```css
.mu-editor pre.mu-active.mu-fenced-code::before,
.mu-editor pre.mu-active.mu-fenced-code::after {
  content: none;
}
```

- **Android-scoped on purpose**: vendored Muya is untouched, so the desktop
  build still shows the markers. No vendor sync, no `test:muya` impact.
- The extra `.mu-editor` raises specificity above Muya's own rule so it wins the
  cascade even though the app CSS loads before the dynamically-imported editor
  CSS (verified by the e2e assertion, not just reasoning).
- The `.mu-code`'s separate "fenced"/"indented" tag is a different pseudo-element
  and is unaffected. Math/HTML/front-matter blocks keep their delimiters (their
  markers are the primary indicator, not redundant) and are out of scope here.

## Tests

- E2E (`mobile-editor-toolbar.spec.ts`): a new test inserts a fenced code block,
  asserts it is active, and checks both `::before` and `::after` computed
  `content` are `none` while the "fenced" tag element remains — this pins that
  the override wins the cascade.

## Verification

- `pnpm typecheck`, `pnpm lint`, full unit suite: pass.
- Focused e2e: the fenced-code insertion test and the new marker-hidden test
  both pass.
- One full Playwright run: 149 passed / 0 failed / 0 skipped in 7.8 minutes.
- Device (Xiaomi 14, Android 14, system font scale 1.25×): rebuilt APK renders a
  clean code block — `python` language label above, clean box borders,
  syntax-highlighted body, corner "fenced" tag, and no ``` overlap. Measured
  `::before`/`::after` content = `none` on the active block.
