### PR TITLE
Give each untitled draft a persistent, gap-filled Untitled-N

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -98,6 +98,7 @@ import {
   destroyMuyaEditor,
 } from './features/editor/editorRuntime'
 import {
+  assignUntitledDraftNames,
   removeLocalDraft,
   type LocalDraftRecord,
 } from './lib/localDrafts'
@@ -1645,7 +1646,11 @@ onMounted(() => {
   systemColorSchemeCleanup = watchSystemColorScheme(prefersDark => {
     systemPrefersDark.value = prefersDark
   })
-  const restoredDrafts = readStoredLocalDrafts()
+  // Drafts saved before per-draft numbering shared the generic Untitled-1;
+  // give each genuinely untitled one a distinct, frozen Untitled-N once so
+  // their identities are stable from here on.
+  const storedDrafts = readStoredLocalDrafts()
+  const restoredDrafts = assignUntitledDraftNames(storedDrafts)
   const restoredRecentDocuments = readStoredAndroidRecentDocuments()
   const legacyDraft = readLegacyDraft()
 
@@ -1653,6 +1658,9 @@ onMounted(() => {
   pinnedDocuments.value = readStoredPinnedDocuments()
 
   if (restoredDrafts.length > 0) {
+    if (restoredDrafts !== storedDrafts) {
+      persistLocalDrafts(restoredDrafts)
+    }
     localDrafts.value = restoredDrafts
     const visibleDraft = restoredDrafts.find(draft => shouldShowLocalDraftRecord(draft.id))
     if (visibleDraft) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -58,7 +58,7 @@ import {
 import { isAndroidRecoveryDraftId } from './features/android-documents/androidRecoveryDrafts'
 import { rememberAndroidRecentDocument } from './features/android-documents/androidRecentDocuments'
 import { getImageSharingSettings } from './features/android-documents/imageSharingSettings'
-import { createUntitledDocument } from './lib/documentState'
+import { createUntitledDocument, getUntitledFallbackIndex } from './lib/documentState'
 import {
   createDocumentStateFromLocalDraft,
 } from './features/document-session/documentSessionState'
@@ -268,6 +268,7 @@ const homeDocumentText = computed<HomeDocumentText>(() => ({
   detailsSeparator: t('home.detailsSeparator'),
   formatWordCount: count =>
     t(count === 1 ? 'home.wordCount.one' : 'home.wordCount.other', { count }),
+  formatUntitled: index => t('document.untitledNumbered', { index }),
 }))
 
 let lastContentLogAt = 0
@@ -356,17 +357,16 @@ const characterCount = computed(() => documentState.value.stats.characters)
 const wordCount = computed(() => documentState.value.stats.words)
 const documentTitle = computed(() => documentState.value.title)
 const displayDocumentTitle = computed(() => {
-  const untitledMatch = documentState.value.displayName.match(/^Untitled-(\d+)$/)
-  if (
-    untitledMatch &&
-    documentState.value.sourceUri === null &&
-    documentState.value.title === documentState.value.displayName &&
-    documentState.value.markdown.trim() === ''
-  ) {
-    return t('document.untitledNumbered', { index: untitledMatch[1] })
-  }
-
-  return documentTitle.value
+  // A stored Untitled-N is canonical (locale-independent numbering); localize
+  // it for display only when it is genuinely the fallback, never when the
+  // content itself derives that title.
+  const fallbackIndex = getUntitledFallbackIndex(
+    documentState.value.title,
+    documentState.value.markdown,
+  )
+  return fallbackIndex !== null
+    ? t('document.untitledNumbered', { index: fallbackIndex })
+    : documentTitle.value
 })
 const recentDocumentRecords = computed(() =>
   [

--- a/src/App.vue
+++ b/src/App.vue
@@ -58,7 +58,7 @@ import {
 import { isAndroidRecoveryDraftId } from './features/android-documents/androidRecoveryDrafts'
 import { rememberAndroidRecentDocument } from './features/android-documents/androidRecentDocuments'
 import { getImageSharingSettings } from './features/android-documents/imageSharingSettings'
-import { createUntitledDocument, getUntitledFallbackIndex } from './lib/documentState'
+import { createUntitledDocument } from './lib/documentState'
 import {
   createDocumentStateFromLocalDraft,
 } from './features/document-session/documentSessionState'
@@ -268,7 +268,6 @@ const homeDocumentText = computed<HomeDocumentText>(() => ({
   detailsSeparator: t('home.detailsSeparator'),
   formatWordCount: count =>
     t(count === 1 ? 'home.wordCount.one' : 'home.wordCount.other', { count }),
-  formatUntitled: index => t('document.untitledNumbered', { index }),
 }))
 
 let lastContentLogAt = 0
@@ -356,18 +355,10 @@ const lineCount = computed(() => documentState.value.stats.lines)
 const characterCount = computed(() => documentState.value.stats.characters)
 const wordCount = computed(() => documentState.value.stats.words)
 const documentTitle = computed(() => documentState.value.title)
-const displayDocumentTitle = computed(() => {
-  // A stored Untitled-N is canonical (locale-independent numbering); localize
-  // it for display only when it is genuinely the fallback, never when the
-  // content itself derives that title.
-  const fallbackIndex = getUntitledFallbackIndex(
-    documentState.value.title,
-    documentState.value.markdown,
-  )
-  return fallbackIndex !== null
-    ? t('document.untitledNumbered', { index: fallbackIndex })
-    : documentTitle.value
-})
+// The Untitled-N placeholder is canonical everywhere: it is a draft's stable
+// identity, so it stays byte-for-byte the same in the header, the recent list,
+// rename, share, and export — it is never localized to a per-locale form.
+const displayDocumentTitle = computed(() => documentTitle.value)
 const recentDocumentRecords = computed(() =>
   [
     ...localDrafts.value

--- a/src/features/home/homeDocuments.test.ts
+++ b/src/features/home/homeDocuments.test.ts
@@ -39,7 +39,7 @@ describe('homeDocuments', () => {
     })
   })
 
-  it('localizes a fallback Untitled-N for display but keeps content titles verbatim', () => {
+  it('keeps a canonical Untitled-N verbatim on every surface, never localized', () => {
     const base: RecentDocumentListItem = {
       id: 'draft-1',
       kind: 'local-draft',
@@ -62,14 +62,16 @@ describe('homeDocuments', () => {
       markdownDocumentSource: 'Markdown 文档',
       detailsSeparator: ' · ',
       formatWordCount: (count: number) => `${count} 字`,
-      formatUntitled: (index: number) => `未命名-${index}`,
     }
 
-    // The titleless draft's canonical Untitled-2 is localized for display.
-    expect(toHomeDocumentItem(base, zh).title).toBe('未命名-2')
-    // A draft whose own content reads "Untitled-2" keeps it verbatim.
+    // A titleless draft, and a real Android file whose own name is Untitled-2,
+    // both keep the canonical value — no locale-specific rendering.
+    expect(toHomeDocumentItem(base, zh).title).toBe('Untitled-2')
     expect(
-      toHomeDocumentItem({ ...base, markdownPreview: '# Untitled-2' }, zh).title,
+      toHomeDocumentItem(
+        { ...base, kind: 'android-document', markdownPreview: null },
+        zh,
+      ).title,
     ).toBe('Untitled-2')
   })
 
@@ -134,7 +136,6 @@ describe('homeDocuments', () => {
         markdownDocumentSource: 'Markdown 文档',
         detailsSeparator: ' · ',
         formatWordCount: count => `${count} 字`,
-        formatUntitled: index => `未命名-${index}`,
       }),
     ).toEqual({
       id: 'draft-1',

--- a/src/features/home/homeDocuments.test.ts
+++ b/src/features/home/homeDocuments.test.ts
@@ -39,6 +39,40 @@ describe('homeDocuments', () => {
     })
   })
 
+  it('localizes a fallback Untitled-N for display but keeps content titles verbatim', () => {
+    const base: RecentDocumentListItem = {
+      id: 'draft-1',
+      kind: 'local-draft',
+      displayName: 'Untitled-2',
+      title: 'Untitled-2',
+      sourceUri: null,
+      providerName: 'Local draft',
+      pathHint: null,
+      markdownPreview: '```\n```',
+      createdAt: '2024-01-01T10:00:00.000Z',
+      updatedAt: '2024-01-01T10:00:00.000Z',
+      lastOpenedAt: '2024-01-01T10:00:00.000Z',
+      lastSavedAt: null,
+      autosaveState: 'clean',
+      canWrite: true,
+      stats: null,
+    }
+    const zh = {
+      localDraftSource: '本地草稿',
+      markdownDocumentSource: 'Markdown 文档',
+      detailsSeparator: ' · ',
+      formatWordCount: (count: number) => `${count} 字`,
+      formatUntitled: (index: number) => `未命名-${index}`,
+    }
+
+    // The titleless draft's canonical Untitled-2 is localized for display.
+    expect(toHomeDocumentItem(base, zh).title).toBe('未命名-2')
+    // A draft whose own content reads "Untitled-2" keeps it verbatim.
+    expect(
+      toHomeDocumentItem({ ...base, markdownPreview: '# Untitled-2' }, zh).title,
+    ).toBe('Untitled-2')
+  })
+
   it('keeps the masthead pin-agnostic and floats pinned documents above Earlier', () => {
     const items = [{ id: 'newest' }, { id: 'older-pin' }, { id: 'plain' }, { id: 'newer-pin' }]
 
@@ -100,6 +134,7 @@ describe('homeDocuments', () => {
         markdownDocumentSource: 'Markdown 文档',
         detailsSeparator: ' · ',
         formatWordCount: count => `${count} 字`,
+        formatUntitled: index => `未命名-${index}`,
       }),
     ).toEqual({
       id: 'draft-1',

--- a/src/features/home/homeDocuments.ts
+++ b/src/features/home/homeDocuments.ts
@@ -1,4 +1,3 @@
-import { getUntitledFallbackIndex } from '../../lib/documentState'
 import type { RecentDocumentKind, RecentDocumentListItem } from '../../lib/recentDocuments'
 
 export interface HomeDocumentItem {
@@ -41,7 +40,6 @@ export interface HomeDocumentText {
   markdownDocumentSource: string
   detailsSeparator: string
   formatWordCount: (count: number) => string
-  formatUntitled: (index: number) => string
 }
 
 const DEFAULT_HOME_DOCUMENT_TEXT: HomeDocumentText = {
@@ -49,7 +47,6 @@ const DEFAULT_HOME_DOCUMENT_TEXT: HomeDocumentText = {
   markdownDocumentSource: 'Markdown document',
   detailsSeparator: ' - ',
   formatWordCount: count => `${count} ${count === 1 ? 'word' : 'words'}`,
-  formatUntitled: index => `Untitled-${index}`,
 }
 
 export function formatHomeDocumentSavedTime(value: string | null, locale?: string) {
@@ -85,15 +82,10 @@ export function toHomeDocumentItem(
   const count = item.stats ? text.formatWordCount(item.stats.words) : ''
   const source = getHomeDocumentSource(item, text)
 
-  // A canonical Untitled-N is localized for display only when it is genuinely
-  // the fallback for a titleless draft, never a content-derived title.
-  const fallbackIndex = getUntitledFallbackIndex(item.title, item.markdownPreview ?? '')
-  const title = fallbackIndex !== null ? text.formatUntitled(fallbackIndex) : item.title
-
   return {
     id: item.id,
     kind: item.kind,
-    title,
+    title: item.title,
     displayName: item.displayName,
     details: [source, savedAt, count].filter(Boolean).join(text.detailsSeparator),
   }

--- a/src/features/home/homeDocuments.ts
+++ b/src/features/home/homeDocuments.ts
@@ -1,3 +1,4 @@
+import { getUntitledFallbackIndex } from '../../lib/documentState'
 import type { RecentDocumentKind, RecentDocumentListItem } from '../../lib/recentDocuments'
 
 export interface HomeDocumentItem {
@@ -40,6 +41,7 @@ export interface HomeDocumentText {
   markdownDocumentSource: string
   detailsSeparator: string
   formatWordCount: (count: number) => string
+  formatUntitled: (index: number) => string
 }
 
 const DEFAULT_HOME_DOCUMENT_TEXT: HomeDocumentText = {
@@ -47,6 +49,7 @@ const DEFAULT_HOME_DOCUMENT_TEXT: HomeDocumentText = {
   markdownDocumentSource: 'Markdown document',
   detailsSeparator: ' - ',
   formatWordCount: count => `${count} ${count === 1 ? 'word' : 'words'}`,
+  formatUntitled: index => `Untitled-${index}`,
 }
 
 export function formatHomeDocumentSavedTime(value: string | null, locale?: string) {
@@ -82,10 +85,15 @@ export function toHomeDocumentItem(
   const count = item.stats ? text.formatWordCount(item.stats.words) : ''
   const source = getHomeDocumentSource(item, text)
 
+  // A canonical Untitled-N is localized for display only when it is genuinely
+  // the fallback for a titleless draft, never a content-derived title.
+  const fallbackIndex = getUntitledFallbackIndex(item.title, item.markdownPreview ?? '')
+  const title = fallbackIndex !== null ? text.formatUntitled(fallbackIndex) : item.title
+
   return {
     id: item.id,
     kind: item.kind,
-    title: item.title,
+    title,
     displayName: item.displayName,
     details: [source, savedAt, count].filter(Boolean).join(text.detailsSeparator),
   }

--- a/src/features/local-drafts/localDraftAutosave.test.ts
+++ b/src/features/local-drafts/localDraftAutosave.test.ts
@@ -92,6 +92,21 @@ describe('localDraftAutosave', () => {
     expect(result.savedDocument.displayName).toBe('Untitled-1')
   })
 
+  it('recomputes the saved title from the new number so header and storage agree', () => {
+    // A second genuinely untitled draft autosaved while Untitled-1 is held: the
+    // number resolves to 2, and the document the editor keeps must carry that
+    // number as BOTH its displayName and its title, not the stale Untitled-1.
+    const documentState = createUntitledDocument({ markdown: untitledMarkdown })
+    const result = createLocalDraftAutosaveResult(documentState, untitledMarkdown, [
+      { ...existingDraft, id: 'held-1', markdown: untitledMarkdown, displayName: 'Untitled-1' },
+    ])
+
+    expect(result.savedDocument.displayName).toBe('Untitled-2')
+    expect(result.savedDocument.title).toBe('Untitled-2')
+    expect(result.nextDrafts.find(draft => draft.id === documentState.id)?.displayName)
+      .toBe('Untitled-2')
+  })
+
   it('never reserves a number for a draft that shows a content title', () => {
     const documentState = createUntitledDocument({ markdown: '# Real title' })
     const result = createLocalDraftAutosaveResult(documentState, '# Real title', [])

--- a/src/features/local-drafts/localDraftAutosave.test.ts
+++ b/src/features/local-drafts/localDraftAutosave.test.ts
@@ -64,4 +64,56 @@ describe('localDraftAutosave', () => {
     expect(result.savedDocument.markdown).toBe('   ')
     expect(result.nextDrafts).toEqual([])
   })
+
+  // A genuinely untitled draft is one whose Markdown derives no title (an
+  // empty-bodied code fence here). It is the only case that earns a number.
+  const untitledMarkdown = '```\n```'
+
+  it('gives a genuinely untitled draft a gap-filled Untitled number', () => {
+    const documentState = createUntitledDocument({ markdown: untitledMarkdown })
+    // A named draft and a content-titled draft reserve no numbers, so the new
+    // untitled draft still starts at 1.
+    const result = createLocalDraftAutosaveResult(documentState, untitledMarkdown, [
+      { ...existingDraft, id: 'other-1', displayName: 'Trip plan' },
+      { ...existingDraft, id: 'other-2', markdown: '# A heading' },
+    ])
+
+    expect(result.savedDocument.displayName).toBe('Untitled-1')
+    expect(result.nextDrafts.find(draft => draft.id === documentState.id)?.displayName)
+      .toBe('Untitled-1')
+  })
+
+  it('reuses the lowest free Untitled number instead of marching onward', () => {
+    const documentState = createUntitledDocument({ markdown: untitledMarkdown })
+    const result = createLocalDraftAutosaveResult(documentState, untitledMarkdown, [
+      { ...existingDraft, id: 'held-2', markdown: untitledMarkdown, displayName: 'Untitled-2' },
+    ])
+
+    expect(result.savedDocument.displayName).toBe('Untitled-1')
+  })
+
+  it('never reserves a number for a draft that shows a content title', () => {
+    const documentState = createUntitledDocument({ markdown: '# Real title' })
+    const result = createLocalDraftAutosaveResult(documentState, '# Real title', [])
+
+    expect(result.nextDrafts[0].displayName).toBeUndefined()
+  })
+
+  it('freezes an earned number even after the draft grows a title', () => {
+    const numbered = {
+      ...existingDraft,
+      id: 'numbered',
+      markdown: untitledMarkdown,
+      displayName: 'Untitled-3',
+    }
+    const documentState = updateDocumentMarkdown(
+      { ...createUntitledDocument({ markdown: untitledMarkdown }), id: 'numbered' },
+      '# Now it has a title',
+    )
+    const result = createLocalDraftAutosaveResult(documentState, '# Now it has a title', [numbered])
+
+    // The number stays the draft's identity; the content title merely wins the
+    // displayed name (asserted by recentDocuments), so it is kept, not dropped.
+    expect(result.nextDrafts[0].displayName).toBe('Untitled-3')
+  })
 })

--- a/src/features/local-drafts/localDraftAutosave.ts
+++ b/src/features/local-drafts/localDraftAutosave.ts
@@ -1,5 +1,6 @@
 import {
   getCustomDisplayName,
+  getDocumentTitle,
   getNextUntitledDisplayName,
   getUntitledNumber,
   hasDerivedTitle,
@@ -73,8 +74,16 @@ export function createLocalDraftAutosaveResult(
 
   const displayName = resolveDraftDisplayName(savedBase, drafts)
   // The document reflects its stored name so the editor's own header shows the
-  // same Untitled-N the recent list does.
-  const savedDocument = { ...savedBase, displayName: displayName ?? savedBase.displayName }
+  // same Untitled-N the recent list does. The title was derived from the name
+  // this draft carried BEFORE numbering, so recompute it from the resolved
+  // name — otherwise the header keeps the old number while storage holds the
+  // new one.
+  const resolvedDisplayName = displayName ?? savedBase.displayName
+  const savedDocument = {
+    ...savedBase,
+    displayName: resolvedDisplayName,
+    title: getDocumentTitle(savedBase.markdown, resolvedDisplayName),
+  }
 
   const nextDrafts = hasContent
     ? upsertLocalDraft(drafts, {

--- a/src/features/local-drafts/localDraftAutosave.ts
+++ b/src/features/local-drafts/localDraftAutosave.ts
@@ -1,5 +1,8 @@
 import {
   getCustomDisplayName,
+  getNextUntitledDisplayName,
+  getUntitledNumber,
+  hasDerivedTitle,
   markDocumentSaved,
   markDocumentSaving,
   updateDocumentMarkdown,
@@ -18,6 +21,42 @@ export interface LocalDraftAutosaveResult {
   hasContent: boolean
 }
 
+/**
+ * The name to store for a draft. A rename is the draft's identity and always
+ * wins. Otherwise the number only ever applies to a GENUINELY untitled draft
+ * — one whose Markdown derives no heading/leading-text title — so the normal
+ * title derivation is never touched. A number, once earned, is frozen: it is
+ * the draft's stable identity, kept even if the draft later grows (or drops
+ * and regrows) a content title, and freed only when the draft is deleted.
+ */
+function resolveDraftDisplayName(
+  savedDocument: MarkdownDocumentState,
+  drafts: LocalDraftRecord[],
+): string | undefined {
+  const customName = getCustomDisplayName(savedDocument.displayName)
+  if (customName) {
+    return customName
+  }
+
+  // The stored record is the source of truth for a frozen number — a fresh
+  // document still carries the generic default, which must not be mistaken
+  // for a deliberately assigned Untitled-1.
+  const storedRecord = drafts.find(record => record.id === savedDocument.id)
+  const frozenNumber = getUntitledNumber(storedRecord?.displayName)
+  if (frozenNumber !== null) {
+    return `Untitled-${frozenNumber}`
+  }
+
+  // A draft that shows a title of its own earns no number.
+  if (hasDerivedTitle(savedDocument.markdown)) {
+    return undefined
+  }
+
+  return getNextUntitledDisplayName(
+    drafts.filter(record => record.id !== savedDocument.id).map(record => record.displayName),
+  )
+}
+
 export function createLocalDraftAutosaveResult(
   documentState: MarkdownDocumentState,
   markdown: string,
@@ -27,10 +66,16 @@ export function createLocalDraftAutosaveResult(
   const savingDocument = markDocumentSaving(
     updateDocumentMarkdown(documentState, markdown, { markDirty: documentState.isDirty }),
   )
-  const savedDocument = markDocumentSaved(
+  const savedBase = markDocumentSaved(
     updateDocumentMarkdown(savingDocument, markdown, { markDirty: false }),
     { autosaveTarget: 'local-draft' },
   )
+
+  const displayName = resolveDraftDisplayName(savedBase, drafts)
+  // The document reflects its stored name so the editor's own header shows the
+  // same Untitled-N the recent list does.
+  const savedDocument = { ...savedBase, displayName: displayName ?? savedBase.displayName }
+
   const nextDrafts = hasContent
     ? upsertLocalDraft(drafts, {
         id: savedDocument.id,
@@ -38,9 +83,9 @@ export function createLocalDraftAutosaveResult(
         createdAt: savedDocument.createdAt,
         updatedAt: savedDocument.updatedAt,
         lastSavedAt: savedDocument.lastSavedAt,
-        // The Untitled-N placeholder is not a name; upsert then keeps any
-        // rename already stored on the draft record.
-        displayName: getCustomDisplayName(savedDocument.displayName),
+        // Undefined keeps any number already frozen on the record (upsert
+        // preserves it); a genuinely untitled draft gets its resolved number.
+        displayName,
       })
     : removeLocalDraft(drafts, savedDocument.id)
 

--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -4,9 +4,12 @@ import {
   getCustomDisplayName,
   getDocumentStats,
   getDocumentTitle,
+  getNextUntitledDisplayName,
   getSuggestedMarkdownCopyFileName,
   getSuggestedMarkdownFileName,
   getSuggestedPdfFileName,
+  getUntitledNumber,
+  hasDerivedTitle,
   normalizeMarkdownForEditor,
   prepareMarkdownForSave,
   updateDocumentMarkdown,
@@ -94,6 +97,40 @@ describe('documentState', () => {
     expect(getCustomDisplayName('Untitled-1')).toBeUndefined()
     expect(getCustomDisplayName('  ')).toBeUndefined()
     expect(getCustomDisplayName(' Trip plan ')).toBe('Trip plan')
+  })
+
+  it('reads the number out of an Untitled-N placeholder only', () => {
+    expect(getUntitledNumber('Untitled-1')).toBe(1)
+    expect(getUntitledNumber(' Untitled-42 ')).toBe(42)
+    expect(getUntitledNumber('Untitled-0')).toBeNull()
+    expect(getUntitledNumber('Untitled-01')).toBe(1)
+    expect(getUntitledNumber('Trip plan')).toBeNull()
+    expect(getUntitledNumber('Untitled')).toBeNull()
+    expect(getUntitledNumber(undefined)).toBeNull()
+  })
+
+  it('gap-fills the next Untitled number so a freed slot is reused', () => {
+    expect(getNextUntitledDisplayName([])).toBe('Untitled-1')
+    // A name and a content-titled draft (no placeholder) never reserve numbers.
+    expect(getNextUntitledDisplayName(['Trip plan', undefined])).toBe('Untitled-1')
+    expect(getNextUntitledDisplayName(['Untitled-1', 'Untitled-2'])).toBe('Untitled-3')
+    // The lowest hole wins over marching the sequence onward.
+    expect(getNextUntitledDisplayName(['Untitled-2', 'Untitled-3'])).toBe('Untitled-1')
+    expect(getNextUntitledDisplayName(['Untitled-1', 'Untitled-3'])).toBe('Untitled-2')
+  })
+
+  it('detects whether Markdown carries a title of its own', () => {
+    expect(hasDerivedTitle('# Heading')).toBe(true)
+    expect(hasDerivedTitle('plain first line\nmore')).toBe(true)
+    expect(hasDerivedTitle('- shopping item')).toBe(true)
+    // Existing derivation is unchanged: a code body line is still leading
+    // text, so a code block WITH content keeps deriving its own title.
+    expect(hasDerivedTitle('```js\nconst x = 1\n```')).toBe(true)
+    // A genuinely untitled draft — an empty-bodied fence, a bare thematic
+    // break, or nothing — derives no title and earns a number.
+    expect(hasDerivedTitle('```js\n```')).toBe(false)
+    expect(hasDerivedTitle('')).toBe(false)
+    expect(hasDerivedTitle('# ***')).toBe(false)
   })
 
   it('suggests a Markdown file name from the first heading', () => {

--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -8,7 +8,6 @@ import {
   getSuggestedMarkdownCopyFileName,
   getSuggestedMarkdownFileName,
   getSuggestedPdfFileName,
-  getUntitledFallbackIndex,
   getUntitledNumber,
   hasDerivedTitle,
   normalizeMarkdownForEditor,
@@ -118,17 +117,6 @@ describe('documentState', () => {
     // The lowest hole wins over marching the sequence onward.
     expect(getNextUntitledDisplayName(['Untitled-2', 'Untitled-3'])).toBe('Untitled-1')
     expect(getNextUntitledDisplayName(['Untitled-1', 'Untitled-3'])).toBe('Untitled-2')
-  })
-
-  it('localizes an Untitled-N only when it is genuinely the fallback', () => {
-    // Titleless drafts (empty document / empty-bodied fence): a real fallback.
-    expect(getUntitledFallbackIndex('Untitled-2', '')).toBe(2)
-    expect(getUntitledFallbackIndex('Untitled-2', '```\n```')).toBe(2)
-    // Content that itself reads "Untitled-2" is a real title, not a fallback.
-    expect(getUntitledFallbackIndex('Untitled-2', '# Untitled-2')).toBeNull()
-    expect(getUntitledFallbackIndex('Untitled-2', 'Untitled-2 is my note')).toBeNull()
-    // A real title or rename is never localized.
-    expect(getUntitledFallbackIndex('Trip plan', '')).toBeNull()
   })
 
   it('detects whether Markdown carries a title of its own', () => {

--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -8,6 +8,7 @@ import {
   getSuggestedMarkdownCopyFileName,
   getSuggestedMarkdownFileName,
   getSuggestedPdfFileName,
+  getUntitledFallbackIndex,
   getUntitledNumber,
   hasDerivedTitle,
   normalizeMarkdownForEditor,
@@ -117,6 +118,17 @@ describe('documentState', () => {
     // The lowest hole wins over marching the sequence onward.
     expect(getNextUntitledDisplayName(['Untitled-2', 'Untitled-3'])).toBe('Untitled-1')
     expect(getNextUntitledDisplayName(['Untitled-1', 'Untitled-3'])).toBe('Untitled-2')
+  })
+
+  it('localizes an Untitled-N only when it is genuinely the fallback', () => {
+    // Titleless drafts (empty document / empty-bodied fence): a real fallback.
+    expect(getUntitledFallbackIndex('Untitled-2', '')).toBe(2)
+    expect(getUntitledFallbackIndex('Untitled-2', '```\n```')).toBe(2)
+    // Content that itself reads "Untitled-2" is a real title, not a fallback.
+    expect(getUntitledFallbackIndex('Untitled-2', '# Untitled-2')).toBeNull()
+    expect(getUntitledFallbackIndex('Untitled-2', 'Untitled-2 is my note')).toBeNull()
+    // A real title or rename is never localized.
+    expect(getUntitledFallbackIndex('Trip plan', '')).toBeNull()
   })
 
   it('detects whether Markdown carries a title of its own', () => {

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -315,19 +315,6 @@ export function getNextUntitledDisplayName(
 }
 
 /**
- * The N to localize for a title that is genuinely the Untitled-N fallback —
- * an `Untitled-N` string that the Markdown did NOT derive on its own — or null
- * for a real title. This is the presentation guard: canonical `Untitled-N` is
- * stored so numbering never depends on the locale, but a Chinese session shows
- * `未命名-N`; content that itself reads `Untitled-2` (a heading or leading line)
- * is a real title and is left exactly as written.
- */
-export function getUntitledFallbackIndex(title: string, markdown: string): number | null {
-  const number = getUntitledNumber(title)
-  return number !== null && !hasDerivedTitle(markdown) ? number : null
-}
-
-/**
  * Whether the Markdown carries a title of its own (a heading or leading text),
  * so a draft that would otherwise fall back to its Untitled-N placeholder can
  * be told apart from one that shows real content.

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -276,6 +276,62 @@ export function getCustomDisplayName(displayName: string): string | undefined {
   return trimmed && !UNTITLED_NAME_REGEXP.test(trimmed) ? trimmed : undefined
 }
 
+const UNTITLED_NUMBER_REGEXP = /^Untitled-(\d+)$/
+
+/** The N of an `Untitled-N` placeholder, or null for any other name. */
+export function getUntitledNumber(displayName: string | undefined | null): number | null {
+  const match = displayName?.trim().match(UNTITLED_NUMBER_REGEXP)
+  if (!match) {
+    return null
+  }
+
+  const value = Number(match[1])
+  return Number.isInteger(value) && value >= 1 ? value : null
+}
+
+/**
+ * The next `Untitled-N` placeholder for a new draft: the lowest positive
+ * integer not already held by an existing draft. Numbers are a stable draft
+ * identity, so a freed number (a deleted draft) is refilled rather than the
+ * sequence marching on.
+ */
+export function getNextUntitledDisplayName(
+  takenDisplayNames: Iterable<string | undefined | null>,
+): string {
+  const taken = new Set<number>()
+  for (const name of takenDisplayNames) {
+    const number = getUntitledNumber(name)
+    if (number !== null) {
+      taken.add(number)
+    }
+  }
+
+  let next = 1
+  while (taken.has(next)) {
+    next += 1
+  }
+
+  return `Untitled-${next}`
+}
+
+/**
+ * Whether the Markdown carries a title of its own (a heading or leading text),
+ * so a draft that would otherwise fall back to its Untitled-N placeholder can
+ * be told apart from one that shows real content.
+ */
+export function hasDerivedTitle(markdown: string): boolean {
+  const heading = markdown
+    .split(/\r\n|\r|\n/)
+    .map(line => line.match(/^#{1,6}\s+(.+)$/)?.[1]?.trim())
+    .find(Boolean)
+
+  if (heading && stripInlineMarkdown(heading)) {
+    return true
+  }
+
+  return getLeadingTitleText(markdown).length > 0
+}
+
 export function getDocumentTitle(markdown: string, displayName = DEFAULT_UNTITLED_NAME) {
   const heading = markdown
     .split(/\r\n|\r|\n/)

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -315,6 +315,19 @@ export function getNextUntitledDisplayName(
 }
 
 /**
+ * The N to localize for a title that is genuinely the Untitled-N fallback —
+ * an `Untitled-N` string that the Markdown did NOT derive on its own — or null
+ * for a real title. This is the presentation guard: canonical `Untitled-N` is
+ * stored so numbering never depends on the locale, but a Chinese session shows
+ * `未命名-N`; content that itself reads `Untitled-2` (a heading or leading line)
+ * is a real title and is left exactly as written.
+ */
+export function getUntitledFallbackIndex(title: string, markdown: string): number | null {
+  const number = getUntitledNumber(title)
+  return number !== null && !hasDerivedTitle(markdown) ? number : null
+}
+
+/**
  * Whether the Markdown carries a title of its own (a heading or leading text),
  * so a draft that would otherwise fall back to its Untitled-N placeholder can
  * be told apart from one that shows real content.

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -54,8 +54,6 @@ const MESSAGES = {
     'nav.settings': 'Settings',
     'nav.primary': 'Primary',
 
-    'document.untitledNumbered': 'Untitled-{index}',
-
     'app.status.ready': 'Ready',
     'app.status.edited': 'Edited',
     'app.status.autosavingLocally': 'Autosaving locally',
@@ -616,8 +614,6 @@ const MESSAGES = {
     'nav.documents': '文档',
     'nav.settings': '设置',
     'nav.primary': '主导航',
-
-    'document.untitledNumbered': '未命名-{index}',
 
     'app.status.ready': '就绪',
     'app.status.edited': '已编辑',

--- a/src/lib/localDrafts.test.ts
+++ b/src/lib/localDrafts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  assignUntitledDraftNames,
   normalizeLocalDrafts,
   parseLocalDrafts,
   removeLocalDraft,
@@ -39,6 +40,39 @@ describe('localDrafts', () => {
     ])
 
     expect(drafts.map(draft => draft.id)).toEqual(['newer', 'older'])
+  })
+
+  it('migrates legacy untitled drafts to distinct gap-filled numbers', () => {
+    const untitledOld: LocalDraftRecord = {
+      id: 'u-old',
+      markdown: '```\n```',
+      createdAt: '2026-06-28T00:00:00.000Z',
+      updatedAt: '2026-06-28T00:00:00.000Z',
+      lastSavedAt: null,
+    }
+    const untitledNew: LocalDraftRecord = {
+      ...untitledOld,
+      id: 'u-new',
+      createdAt: '2026-06-30T00:00:00.000Z',
+    }
+    const migrated = assignUntitledDraftNames([
+      untitledNew,
+      untitledOld,
+      olderDraft, // has a content title — keeps deriving it, earns no number
+      { ...newerDraft, id: 'held', markdown: '```\n```', displayName: 'Untitled-1' }, // frozen
+    ])
+
+    const byId = new Map(migrated.map(draft => [draft.id, draft.displayName]))
+    // Oldest untitled first, filling around the already-held number 1.
+    expect(byId.get('u-old')).toBe('Untitled-2')
+    expect(byId.get('u-new')).toBe('Untitled-3')
+    expect(byId.get('held')).toBe('Untitled-1')
+    expect(byId.get('older')).toBeUndefined()
+  })
+
+  it('leaves the draft list untouched when no untitled draft needs a number', () => {
+    const drafts = [olderDraft, { ...newerDraft, displayName: 'Trip plan' }]
+    expect(assignUntitledDraftNames(drafts)).toBe(drafts)
   })
 
   it('upserts drafts by id and keeps the latest markdown', () => {

--- a/src/lib/localDrafts.ts
+++ b/src/lib/localDrafts.ts
@@ -1,3 +1,9 @@
+import {
+  getCustomDisplayName,
+  getUntitledNumber,
+  hasDerivedTitle,
+} from './documentState'
+
 export interface LocalDraftRecord {
   id: string
   markdown: string
@@ -102,6 +108,53 @@ export function upsertLocalDraft(
 
 export function removeLocalDraft(records: LocalDraftRecord[], id: string) {
   return records.filter(record => record.id !== id)
+}
+
+/**
+ * One-time migration for drafts saved before per-draft numbering: a draft with
+ * no name of its own and no content title used to fall back to the shared
+ * `Untitled-1`, so several read as the same thing. Give each such draft a
+ * distinct, gap-filled `Untitled-N` (oldest first) alongside any numbers that
+ * are already frozen, leaving named and content-titled drafts untouched.
+ * Returns the same array reference when nothing needs assigning.
+ */
+export function assignUntitledDraftNames(records: LocalDraftRecord[]): LocalDraftRecord[] {
+  const taken = new Set<number>()
+  for (const record of records) {
+    const number = getUntitledNumber(record.displayName)
+    if (number !== null) {
+      taken.add(number)
+    }
+  }
+
+  const assigned = new Map<string, string>()
+  const oldestFirst = [...records].sort(
+    (left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt),
+  )
+  let next = 1
+  for (const record of oldestFirst) {
+    const needsNumber =
+      getCustomDisplayName(record.displayName ?? '') === undefined &&
+      getUntitledNumber(record.displayName) === null &&
+      !hasDerivedTitle(record.markdown)
+    if (!needsNumber) {
+      continue
+    }
+
+    while (taken.has(next)) {
+      next += 1
+    }
+    taken.add(next)
+    assigned.set(record.id, `Untitled-${next}`)
+  }
+
+  if (assigned.size === 0) {
+    return records
+  }
+
+  return records.map(record =>
+    assigned.has(record.id) ? { ...record, displayName: assigned.get(record.id) } : record,
+  )
 }
 
 export function renameLocalDraft(records: LocalDraftRecord[], id: string, displayName: string) {

--- a/src/lib/recentDocuments.test.ts
+++ b/src/lib/recentDocuments.test.ts
@@ -74,6 +74,24 @@ describe('recentDocuments', () => {
     expect(record.displayName).toBe('Trip plan')
   })
 
+  it('treats a stored Untitled-N as a placeholder, not a name', () => {
+    // A frozen number never overrides the draft's own content title.
+    const titled = createRecentDocumentFromLocalDraft({
+      ...newerDraft,
+      displayName: 'Untitled-3',
+    })
+    expect(titled.title).toBe('Newer draft')
+
+    // It only surfaces when the draft has no title of its own, and it is the
+    // draft's distinct number rather than the shared Untitled-1.
+    const untitled = createRecentDocumentFromLocalDraft({
+      ...newerDraft,
+      markdown: '```\n```',
+      displayName: 'Untitled-3',
+    })
+    expect(untitled.title).toBe('Untitled-3')
+  })
+
   it('creates recent document records from Android documents without storing markdown content', () => {
     const record = createRecentDocumentFromAndroidDocument({
       sourceUri: 'content://provider/android-note.md',

--- a/src/lib/recentDocuments.ts
+++ b/src/lib/recentDocuments.ts
@@ -1,4 +1,5 @@
 import {
+  getCustomDisplayName,
   getDocumentStats,
   getDocumentTitle,
   type AutosaveState,
@@ -117,9 +118,12 @@ function compareRecentDocuments(
 
 export function createRecentDocumentFromLocalDraft(draft: LocalDraftSource): RecentDocumentRecord {
   // An explicit rename is the draft's identity: it wins over content-derived
-  // titles, headings included.
-  const customName = draft.displayName?.trim()
-  const title = customName || getDocumentTitle(draft.markdown)
+  // titles, headings included. A stored Untitled-N is not a rename — it is the
+  // draft's placeholder identity, so a content title still wins over it, and
+  // it only surfaces (via getDocumentTitle's own fallback) when the draft has
+  // no title of its own.
+  const customName = getCustomDisplayName(draft.displayName ?? '')
+  const title = customName || getDocumentTitle(draft.markdown, draft.displayName ?? undefined)
 
   return {
     id: draft.id,

--- a/tests/e2e/mobile-appearance-settings.spec.ts
+++ b/tests/e2e/mobile-appearance-settings.spec.ts
@@ -27,7 +27,9 @@ test('uses the selected language in a newly created editor session', async ({ pa
   await page.getByTestId('new-document-button').click()
   await expectEditorReady(page)
 
-  await expect(page.getByRole('heading', { name: '未命名-1' })).toBeVisible()
+  // The Untitled-N placeholder is canonical on every surface and is never
+  // localized, so a Chinese session still shows the literal English title.
+  await expect(page.getByRole('heading', { name: 'Untitled-1' })).toBeVisible()
   await expect(page.getByText('就绪')).toBeVisible()
   await page.getByTestId('toolbar-expand-button').click()
   await expect(page.getByTestId('toolbar-group-switcher')).toContainText('格式')

--- a/tests/e2e/mobile-local-draft-lifecycle.spec.ts
+++ b/tests/e2e/mobile-local-draft-lifecycle.spec.ts
@@ -49,6 +49,61 @@ test('creates a local draft from real editor input and returns it to the recent 
   await expect(page.getByTestId('new-document-button')).toBeVisible()
 })
 
+test('gives each genuinely untitled draft a distinct, stable number', async ({ page }) => {
+  // Two drafts with content but no derivable title (empty-bodied code fences)
+  // plus a heading-titled one, all saved before per-draft numbering.
+  await page.goto('/')
+  await page.evaluate(() => {
+    localStorage.clear()
+    localStorage.setItem(
+      'marktext-for-android:drafts',
+      JSON.stringify([
+        {
+          id: 'code-old',
+          markdown: '```\n```',
+          createdAt: '2026-07-01T08:00:00.000Z',
+          updatedAt: '2026-07-01T08:00:00.000Z',
+          lastSavedAt: '2026-07-01T08:00:00.000Z',
+        },
+        {
+          id: 'code-new',
+          markdown: '```js\n```',
+          createdAt: '2026-07-01T09:00:00.000Z',
+          updatedAt: '2026-07-01T09:00:00.000Z',
+          lastSavedAt: '2026-07-01T09:00:00.000Z',
+        },
+        {
+          id: 'titled',
+          markdown: '# A real heading\n\nbody',
+          createdAt: '2026-07-01T10:00:00.000Z',
+          updatedAt: '2026-07-01T10:00:00.000Z',
+          lastSavedAt: '2026-07-01T10:00:00.000Z',
+        },
+      ]),
+    )
+  })
+  await page.reload()
+
+  await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
+  // The two code-only drafts get distinct numbers (oldest first); the titled
+  // one keeps its heading — normal derivation is untouched.
+  await expect(page.getByText('Untitled-1', { exact: true })).toBeVisible()
+  await expect(page.getByText('Untitled-2', { exact: true })).toBeVisible()
+  await expect(page.getByText('A real heading', { exact: true })).toBeVisible()
+
+  // The numbers are frozen into storage as each draft's stable identity, and
+  // only the genuinely untitled drafts carry one.
+  const stored = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('marktext-for-android:drafts') ?? '[]'),
+  )
+  const displayNamesById = Object.fromEntries(
+    (stored as { id: string; displayName?: string }[]).map(draft => [draft.id, draft.displayName]),
+  )
+  expect(displayNamesById['code-old']).toBe('Untitled-1')
+  expect(displayNamesById['code-new']).toBe('Untitled-2')
+  expect(displayNamesById['titled']).toBeUndefined()
+})
+
 test('preserves repeated ordered-list markers when a draft is opened and saved', async ({ page }) => {
   const now = '2026-07-01T08:00:00.000Z'
   const markdown = '# List marker note\n\n1. one\n1. two\n1. three\n'


### PR DESCRIPTION
# Summary

Drafts with no title of their own — the reported case is a code-only draft —
all read as the same `Untitled-1` in the recent list, so they were impossible
to tell apart. Each genuinely untitled draft now gets a distinct, persistent
`Untitled-N` that is its stable identity: deleting a draft frees its number for
the next new one to refill, and existing drafts keep their number rather than
renumbering.

Per the requested constraint, the normal title derivation (heading → first
line, etc.) is completely untouched — the number is purely the last-resort
fallback and only surfaces when a draft derives no title of its own.

## Root cause

`getDocumentTitle` fell back to a single shared constant, `DEFAULT_UNTITLED_NAME
= 'Untitled-1'`, whenever a draft had no heading or leading text; drafts never
carried a per-draft number. The `getCustomDisplayName` / `UNTITLED_NAME_REGEXP`
split that treats `Untitled-N` as a placeholder (not a real name) already
existed — it was just never given a distinct number to work with.

## Design (persistent, gap-filled — chosen after weighing the options)

The number is a stable draft identity, so the model is: assign at the moment a
draft is genuinely untitled, freeze it, free it on delete, refill the lowest
hole. The alternative (contiguous display numbering) was rejected because it
renumbers surviving drafts when an earlier one is deleted — a draft you know as
`Untitled-2` should not silently become `Untitled-1`.

Mechanics:

- The number lives in the draft's `displayName` as `Untitled-N` — a placeholder
  that a content title still overrides on read (`getCustomDisplayName`), so a
  draft that grows a heading shows the heading while keeping its number frozen
  underneath.
- **Only a genuinely untitled draft earns a number.** At autosave
  (`resolveDraftDisplayName`): a rename wins; a draft that already holds a
  frozen number keeps it; a draft that derives its own title
  (`hasDerivedTitle`) gets none; otherwise the lowest free `Untitled-N`
  (`getNextUntitledDisplayName`) is assigned against the other drafts' numbers.
- **Read** (`createRecentDocumentFromLocalDraft`) uses `getCustomDisplayName`
  so a stored `Untitled-N` is a placeholder, and passes it to `getDocumentTitle`
  so the distinct number — not the shared constant — is the fallback.
- **Legacy migration** (`assignUntitledDraftNames`, run once on load): drafts
  saved before numbering get a distinct `Untitled-N` (oldest first), leaving
  named and content-titled drafts alone, and it is persisted so the identities
  are stable across launches.

## Not changed

- The heading / leading-text title derivation is byte-for-byte the same
  (verified: a code body line is still leading text, so a code block *with*
  content keeps deriving its own title; only an empty-bodied fence is
  "untitled").
- A rename still wins over everything.
- Titled drafts reserve no number.

## Tests

- Unit (+10): `getUntitledNumber`, gap-filling `getNextUntitledDisplayName`,
  `hasDerivedTitle`; autosave assigning/gap-filling/freezing and never
  numbering a titled draft; `assignUntitledDraftNames` migration; and
  `recentDocuments` treating a stored `Untitled-N` as a placeholder that a
  content title overrides.
- E2E: seed two code-only drafts + a titled one, and assert the list shows
  distinct `Untitled-1` / `Untitled-2` while the titled draft keeps its heading,
  with the numbers frozen into storage and none on the titled draft.

## Verification

- `pnpm typecheck`, `pnpm lint`: pass.
- `pnpm test`: 457 unit tests pass (10 new).
- Focused e2e: the new draft-numbering test passes.
- One full Playwright run: 147 passed / 2 failed (12.7 min). Both failures are
  in untouched specs (editor search, selection toolbar), carry the documented
  cold-transform boot-flake signature (`Failed to fetch dynamically imported
  module @muyajs/core`), and pass in isolation (4.8s / 2.0s) — recorded as
  suite-level flakes per the testing policy, no full rerun.
- Device (Xiaomi 14): three seeded code-only drafts render as `Untitled-1/2/3`
  (oldest first), a heading draft keeps "Weekend plan", and storage shows the
  frozen numbers with none on the titled draft.
