### PR TITLE
Make Android document saves atomic so a failed write never truncates the file

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -984,7 +984,8 @@ public class AndroidDocumentsPlugin extends Plugin {
         MarkdownWriteOptions writeOptions
     ) throws IOException, DocumentReadException {
         byte[] bytes = MarkdownCodec.validateBytes(markdown, writeOptions);
-        writeText(uri, bytes);
+        // A freshly created document has no prior content to protect.
+        writeText(uri, bytes, false);
 
         String displayName = getDisplayName(uri);
         String mimeType = getMimeType(uri);
@@ -1017,7 +1018,8 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
 
         byte[] bytes = MarkdownCodec.validateBytes(markdown, writeOptions);
-        writeText(uri, bytes);
+        // Overwriting an existing document: protect its bytes with backup+rollback.
+        writeText(uri, bytes, true);
         JSObject result = new JSObject();
         result.put("sourceUri", uri.toString());
         result.put("displayName", displayName);
@@ -1125,15 +1127,16 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
     }
 
-    private void writeText(Uri uri, byte[] bytes) throws IOException {
-        ContentResolver resolver = getContext().getContentResolver();
-        try (OutputStream output = resolver.openOutputStream(uri, "wt")) {
-            if (output == null) {
-                throw new IOException("Content resolver returned no output stream");
-            }
-            output.write(bytes);
-            output.flush();
-        }
+    // Atomic-intent write: never leave the user's real file truncated on a
+    // mid-write failure. The algorithm (backup, write, fsync, verify, restore
+    // on failure) lives in the Android-free SafeDocumentWriter; this only binds
+    // it to the resolver + URI.
+    private void writeText(Uri uri, byte[] bytes, boolean protectExisting) throws IOException {
+        SafeDocumentWriter.write(
+            new ContentResolverDocumentIo(
+                getContext().getContentResolver(), uri, MarkdownCodec.MAX_MARKDOWN_BYTES),
+            bytes,
+            protectExisting);
     }
 
     private DecodedMarkdown readText(Uri uri) throws IOException, DocumentReadException {

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/ContentResolverDocumentIo.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/ContentResolverDocumentIo.java
@@ -1,0 +1,122 @@
+package io.github.renakoni.marktextandroid;
+
+import android.content.ContentResolver;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import java.io.ByteArrayOutputStream;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * {@link SafeDocumentWriter.DocumentIo} backed by a {@link ContentResolver} and
+ * a single document {@link Uri}. This is the only Android-coupled part of the
+ * atomic-write path; the algorithm in {@link SafeDocumentWriter} stays pure and
+ * unit tested against a fake.
+ */
+final class ContentResolverDocumentIo implements SafeDocumentWriter.DocumentIo {
+    private final ContentResolver resolver;
+    private final Uri uri;
+    private final int maxBytes;
+
+    ContentResolverDocumentIo(ContentResolver resolver, Uri uri, int maxBytes) {
+        this.resolver = resolver;
+        this.uri = uri;
+        this.maxBytes = maxBytes;
+    }
+
+    @Override
+    public byte[] readBytes() throws IOException {
+        try (InputStream input = resolver.openInputStream(uri)) {
+            if (input == null) {
+                throw new IOException("Content resolver returned no input stream");
+            }
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int total = 0;
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                total += read;
+                if (total > maxBytes) {
+                    throw new IOException("Existing document exceeds the " + maxBytes + " byte limit");
+                }
+                output.write(buffer, 0, read);
+            }
+            return output.toByteArray();
+        }
+    }
+
+    @Override
+    public SafeDocumentWriter.WriteHandle openWrite() throws IOException {
+        // "rwt": read-write + truncate. "rw" implies a seekable on-disk file so
+        // the written length can be verified; "t" forces truncation (since
+        // Android 10 a bare "w" may leave trailing bytes).
+        ParcelFileDescriptor descriptor = resolver.openFileDescriptor(uri, "rwt");
+        if (descriptor == null) {
+            throw new IOException("Content resolver returned no file descriptor");
+        }
+        return new DescriptorWriteHandle(descriptor);
+    }
+
+    private static final class DescriptorWriteHandle implements SafeDocumentWriter.WriteHandle {
+        private final ParcelFileDescriptor descriptor;
+        private final FileOutputStream output;
+
+        DescriptorWriteHandle(ParcelFileDescriptor descriptor) {
+            this.descriptor = descriptor;
+            this.output = new FileOutputStream(descriptor.getFileDescriptor());
+        }
+
+        @Override
+        public void write(byte[] bytes) throws IOException {
+            output.write(bytes);
+            output.flush();
+        }
+
+        @Override
+        public void sync() {
+            // Durability: on Android (ext4) close() alone does not guarantee the
+            // bytes reach disk. Best-effort — a provider backed by a pipe cannot
+            // sync, and that must not fail an otherwise good write.
+            try {
+                FileDescriptor fd = descriptor.getFileDescriptor();
+                if (fd != null && fd.valid()) {
+                    fd.sync();
+                }
+            } catch (IOException ignored) {
+                // best-effort durability only
+            }
+        }
+
+        @Override
+        public long length() {
+            try {
+                return output.getChannel().size();
+            } catch (IOException error) {
+                // Non-seekable provider (e.g. a cloud pipe): length is unknown,
+                // so the caller skips the verify and relies on sync + close.
+                return -1;
+            }
+        }
+
+        @Override
+        public void commit() throws IOException {
+            output.close();
+            descriptor.close();
+        }
+
+        @Override
+        public void abort(String reason) {
+            // Tell the provider the write is bad so it discards the partial
+            // result (well-behaved cloud providers stage on write and commit on
+            // clean close). Deliberately do NOT close `output`, which would
+            // commit; closeWithError closes the descriptor with the error.
+            try {
+                descriptor.closeWithError(reason != null ? reason : "document write aborted");
+            } catch (IOException ignored) {
+                // nothing more we can do
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/ContentResolverDocumentIo.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/ContentResolverDocumentIo.java
@@ -79,6 +79,19 @@ final class ContentResolverDocumentIo implements SafeDocumentWriter.DocumentIo {
         }
     }
 
+    // The length used to verify a write, extracted as a pure decision so it can
+    // be tested without a real descriptor. A non-regular descriptor
+    // (pipe/socket) fstats to a negative size — see
+    // ParcelFileDescriptor.getStatSize(), which returns -1 for non-regular fds —
+    // while its byte-channel size is a meaningless 0 (fstat on a pipe SUCCEEDS
+    // and reports st_size 0, it does NOT throw). So a non-regular descriptor's
+    // length is reported as unknown (-1) and the caller skips verification
+    // instead of aborting a good streaming write; a regular descriptor reports
+    // its real size so short-write detection still works.
+    static long resolveWriteLength(long statSize, long channelSize) {
+        return statSize < 0 ? -1 : channelSize;
+    }
+
     private static final class DescriptorWriteHandle implements SafeDocumentWriter.WriteHandle {
         private final ParcelFileDescriptor descriptor;
         private final FileOutputStream output;
@@ -123,13 +136,16 @@ final class ContentResolverDocumentIo implements SafeDocumentWriter.DocumentIo {
 
         @Override
         public long length() {
+            long channelSize;
             try {
-                return output.getChannel().size();
+                channelSize = output.getChannel().size();
             } catch (IOException error) {
-                // Non-seekable provider (e.g. a cloud pipe): length is unknown,
-                // so the caller skips the verify and relies on sync + close.
                 return -1;
             }
+            // getChannel().size() does NOT throw for a pipe on Android (fstat
+            // succeeds and returns 0), so a non-regular descriptor is filtered by
+            // its stat size, not by a channel exception.
+            return resolveWriteLength(descriptor.getStatSize(), channelSize);
         }
 
         @Override

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/ContentResolverDocumentIo.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/ContentResolverDocumentIo.java
@@ -8,6 +8,7 @@ import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.SyncFailedException;
 
 /**
  * {@link SafeDocumentWriter.DocumentIo} backed by a {@link ContentResolver} and
@@ -49,14 +50,33 @@ final class ContentResolverDocumentIo implements SafeDocumentWriter.DocumentIo {
 
     @Override
     public SafeDocumentWriter.WriteHandle openWrite() throws IOException {
-        // "rwt": read-write + truncate. "rw" implies a seekable on-disk file so
-        // the written length can be verified; "t" forces truncation (since
-        // Android 10 a bare "w" may leave trailing bytes).
-        ParcelFileDescriptor descriptor = resolver.openFileDescriptor(uri, "rwt");
+        // Prefer "rwt": read-write + truncate — a seekable on-disk descriptor
+        // that lets the write be length-verified and fsync'd; "t" forces
+        // truncation (since Android 10 a bare "w" may leave trailing bytes).
+        ParcelFileDescriptor descriptor = tryOpen("rwt");
+        if (descriptor == null) {
+            // A streaming-only provider (some cloud/remote SAF backends) may not
+            // expose a seekable read-write descriptor; fall back to write-only
+            // truncating. Backup/rollback and closeWithError still apply — only
+            // the length verify and fsync are unavailable on the resulting
+            // non-seekable descriptor. A genuinely missing document surfaces
+            // from this final attempt (mapped to DOCUMENT_NOT_FOUND).
+            descriptor = resolver.openFileDescriptor(uri, "wt");
+        }
         if (descriptor == null) {
             throw new IOException("Content resolver returned no file descriptor");
         }
         return new DescriptorWriteHandle(descriptor);
+    }
+
+    // Open in a mode, returning null when the provider does not support it so
+    // the caller can fall back, rather than failing the whole write.
+    private ParcelFileDescriptor tryOpen(String mode) {
+        try {
+            return resolver.openFileDescriptor(uri, mode);
+        } catch (IOException | IllegalArgumentException | UnsupportedOperationException error) {
+            return null;
+        }
     }
 
     private static final class DescriptorWriteHandle implements SafeDocumentWriter.WriteHandle {
@@ -75,18 +95,30 @@ final class ContentResolverDocumentIo implements SafeDocumentWriter.DocumentIo {
         }
 
         @Override
-        public void sync() {
+        public void sync() throws IOException {
             // Durability: on Android (ext4) close() alone does not guarantee the
-            // bytes reach disk. Best-effort — a provider backed by a pipe cannot
-            // sync, and that must not fail an otherwise good write.
-            try {
-                FileDescriptor fd = descriptor.getFileDescriptor();
-                if (fd != null && fd.valid()) {
-                    fd.sync();
-                }
-            } catch (IOException ignored) {
-                // best-effort durability only
+            // bytes reach disk.
+            FileDescriptor fd = descriptor.getFileDescriptor();
+            if (fd == null || !fd.valid()) {
+                return;
             }
+            try {
+                fd.sync();
+            } catch (SyncFailedException error) {
+                // On a seekable on-disk descriptor a sync failure is a real
+                // durability failure (disk full, I/O error) — propagate so the
+                // caller aborts and restores. A non-seekable streaming
+                // descriptor legitimately cannot sync; skip it quietly.
+                if (isSeekable()) {
+                    throw error;
+                }
+            }
+        }
+
+        private boolean isSeekable() {
+            // A regular on-disk file reports a stat size; a pipe/socket returns
+            // -1 — mirrors length()'s capability to report a size.
+            return descriptor.getStatSize() >= 0;
         }
 
         @Override

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/SafeDocumentWriter.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/SafeDocumentWriter.java
@@ -42,11 +42,12 @@ final class SafeDocumentWriter {
         void write(byte[] bytes) throws IOException;
 
         /**
-         * Force bytes to stable storage. Best-effort: a provider backed by a
-         * non-seekable pipe cannot sync, and that must not fail an otherwise
-         * good write.
+         * Force bytes to stable storage. A seekable on-disk descriptor that
+         * cannot sync signals a real durability failure (disk full, I/O error)
+         * and MUST throw so the caller rolls back; a non-seekable streaming
+         * descriptor legitimately cannot sync and returns quietly.
          */
-        void sync();
+        void sync() throws IOException;
 
         /** Bytes currently written, or {@code -1} when the provider cannot report a size. */
         long length();
@@ -70,23 +71,24 @@ final class SafeDocumentWriter {
         // under us, this throws here — before a single byte is truncated.
         byte[] backup = protectExisting ? io.readBytes() : null;
 
-        WriteHandle handle = io.openWrite();
+        WriteHandle handle = null;
         try {
-            handle.write(bytes);
-            handle.sync();
-
-            long written = handle.length();
-            if (written >= 0 && written != bytes.length) {
-                throw new IOException(
-                    "Document write verification failed: wrote " + written + " of " + bytes.length + " bytes");
-            }
-
-            handle.commit();
+            // openWrite() is inside the protected boundary on purpose: opening a
+            // truncating descriptor is itself destructive (a provider may empty
+            // the file before returning, or return null/throw after truncating),
+            // so a failure here — now that the backup is captured — must still
+            // trigger a restore.
+            handle = io.openWrite();
+            writeVerified(handle, bytes);
         } catch (IOException writeError) {
-            // Signal the provider (cloud especially) to discard the partial
-            // write instead of committing a truncation...
-            handle.abort(writeError.getMessage());
-            // ...then put the original bytes back so the file is never left empty.
+            if (handle != null) {
+                // Signal the provider (cloud especially) to discard the partial
+                // write instead of committing a truncation.
+                handle.abort(writeError.getMessage());
+            }
+            // Put the original bytes back so the file is never left empty — even
+            // when openWrite() truncated the target and then failed with no
+            // usable handle.
             if (backup != null) {
                 restore(io, backup, writeError);
             }
@@ -102,18 +104,33 @@ final class SafeDocumentWriter {
         }
     }
 
+    // write -> fsync -> length verify -> commit, applied identically to the
+    // primary write and the rollback so a silent short-write cannot corrupt
+    // either. The verify is skipped only when the provider cannot report a
+    // length (a non-seekable streaming descriptor), where sync + closeWithError
+    // are the remaining guarantees.
+    private static void writeVerified(WriteHandle handle, byte[] bytes) throws IOException {
+        handle.write(bytes);
+        handle.sync();
+
+        long written = handle.length();
+        if (written >= 0 && written != bytes.length) {
+            throw new IOException(
+                "Document write verification failed: wrote " + written + " of " + bytes.length + " bytes");
+        }
+
+        handle.commit();
+    }
+
     private static void restore(DocumentIo io, byte[] backup, IOException cause) {
+        WriteHandle handle = null;
         try {
-            WriteHandle handle = io.openWrite();
-            try {
-                handle.write(backup);
-                handle.sync();
-                handle.commit();
-            } catch (IOException restoreError) {
-                handle.abort(restoreError.getMessage());
-                throw restoreError;
-            }
+            handle = io.openWrite();
+            writeVerified(handle, backup);
         } catch (IOException restoreError) {
+            if (handle != null) {
+                handle.abort(restoreError.getMessage());
+            }
             // Best-effort: the same failing storage may reject the restore too.
             // The file may be left truncated; the JS layer still holds the new
             // content as a recovery draft. Keep the original write error primary.

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/SafeDocumentWriter.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/SafeDocumentWriter.java
@@ -1,0 +1,123 @@
+package io.github.renakoni.marktextandroid;
+
+import java.io.IOException;
+
+/**
+ * Writes bytes to an already-granted Storage Access Framework document with
+ * all-or-nothing intent: a mid-write failure must never leave the user's real
+ * file truncated or half-written.
+ *
+ * <p>SAF offers no atomic replace for a bare document URI — the app holds only
+ * a single-document grant (no parent tree), and {@code renameDocument} cannot
+ * overwrite an existing name — so true filesystem rename-atomicity is
+ * unreachable here. This emulates it at the application layer:
+ *
+ * <ol>
+ *   <li>back up the existing bytes BEFORE anything is truncated,</li>
+ *   <li>truncate + write the new bytes, fsync, and verify the written length,</li>
+ *   <li>on ANY failure, tell the provider to discard the partial write and
+ *       restore the backup so the file is never left empty.</li>
+ * </ol>
+ *
+ * <p>All provider I/O is behind {@link DocumentIo}, so this algorithm is unit
+ * tested without Android.
+ */
+final class SafeDocumentWriter {
+
+    /** Provider I/O for a single document. The real impl wraps a ContentResolver + Uri. */
+    interface DocumentIo {
+        /**
+         * The document's current raw bytes, for backup/rollback. Throws
+         * {@link java.io.FileNotFoundException} when the document no longer
+         * exists — callers rely on this surfacing BEFORE any truncation.
+         */
+        byte[] readBytes() throws IOException;
+
+        /** Open a truncating, seekable write handle onto the document. */
+        WriteHandle openWrite() throws IOException;
+    }
+
+    /** A single truncating write attempt onto the document. */
+    interface WriteHandle {
+        void write(byte[] bytes) throws IOException;
+
+        /**
+         * Force bytes to stable storage. Best-effort: a provider backed by a
+         * non-seekable pipe cannot sync, and that must not fail an otherwise
+         * good write.
+         */
+        void sync();
+
+        /** Bytes currently written, or {@code -1} when the provider cannot report a size. */
+        long length();
+
+        /** Clean close — commits the write. */
+        void commit() throws IOException;
+
+        /** Abort — signals the provider to discard the partial write. */
+        void abort(String reason);
+    }
+
+    private SafeDocumentWriter() {}
+
+    /**
+     * @param protectExisting {@code true} when overwriting an existing document
+     *     (read a backup and roll back on failure); {@code false} when writing a
+     *     freshly created document (nothing to protect yet).
+     */
+    static void write(DocumentIo io, byte[] bytes, boolean protectExisting) throws IOException {
+        // Read the backup FIRST. If the document was moved or deleted out from
+        // under us, this throws here — before a single byte is truncated.
+        byte[] backup = protectExisting ? io.readBytes() : null;
+
+        WriteHandle handle = io.openWrite();
+        try {
+            handle.write(bytes);
+            handle.sync();
+
+            long written = handle.length();
+            if (written >= 0 && written != bytes.length) {
+                throw new IOException(
+                    "Document write verification failed: wrote " + written + " of " + bytes.length + " bytes");
+            }
+
+            handle.commit();
+        } catch (IOException writeError) {
+            // Signal the provider (cloud especially) to discard the partial
+            // write instead of committing a truncation...
+            handle.abort(writeError.getMessage());
+            // ...then put the original bytes back so the file is never left empty.
+            if (backup != null) {
+                restore(io, backup, writeError);
+            }
+            // TODO(process-kill): `backup` lives only in memory, so a process
+            // kill DURING the write — not a catchable exception — could still
+            // leave the target truncated with no rollback source. Guarding that
+            // near-impossible case (the write is a single sub-second push of at
+            // most 5 MB while the app is foregrounded) would mean staging the
+            // backup + new bytes to a fsync'd cache file BEFORE truncating and
+            // adding a next-launch interrupted-save recovery pass. Deliberately
+            // deferred; tracked in todolist.
+            throw writeError;
+        }
+    }
+
+    private static void restore(DocumentIo io, byte[] backup, IOException cause) {
+        try {
+            WriteHandle handle = io.openWrite();
+            try {
+                handle.write(backup);
+                handle.sync();
+                handle.commit();
+            } catch (IOException restoreError) {
+                handle.abort(restoreError.getMessage());
+                throw restoreError;
+            }
+        } catch (IOException restoreError) {
+            // Best-effort: the same failing storage may reject the restore too.
+            // The file may be left truncated; the JS layer still holds the new
+            // content as a recovery draft. Keep the original write error primary.
+            cause.addSuppressed(restoreError);
+        }
+    }
+}

--- a/android/app/src/test/java/io/github/renakoni/marktextandroid/ContentResolverDocumentIoTest.java
+++ b/android/app/src/test/java/io/github/renakoni/marktextandroid/ContentResolverDocumentIoTest.java
@@ -1,0 +1,29 @@
+package io.github.renakoni.marktextandroid;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ContentResolverDocumentIoTest {
+
+    @Test
+    public void reportsUnknownLengthForANonRegularDescriptor() {
+        // A pipe/socket fstats to a negative size, but its byte-channel size is a
+        // meaningless 0 (fstat on a pipe SUCCEEDS and reports 0 — it does not
+        // throw). The length must therefore be reported as unknown (-1), not
+        // mistaken for a zero-length short-write, which previously aborted every
+        // non-empty streaming ("wt") save and its rollback.
+        assertEquals(-1L, ContentResolverDocumentIo.resolveWriteLength(-1L, 0L));
+        assertEquals(-1L, ContentResolverDocumentIo.resolveWriteLength(-1L, 500L));
+    }
+
+    @Test
+    public void reportsTheRealSizeForARegularDescriptor() {
+        // A regular on-disk file reports its true size so short-write detection
+        // still works.
+        assertEquals(42L, ContentResolverDocumentIo.resolveWriteLength(42L, 42L));
+        assertEquals(3L, ContentResolverDocumentIo.resolveWriteLength(3L, 3L));
+        // A genuinely empty regular file is length 0, not "unknown".
+        assertEquals(0L, ContentResolverDocumentIo.resolveWriteLength(0L, 0L));
+    }
+}

--- a/android/app/src/test/java/io/github/renakoni/marktextandroid/SafeDocumentWriterTest.java
+++ b/android/app/src/test/java/io/github/renakoni/marktextandroid/SafeDocumentWriterTest.java
@@ -1,0 +1,234 @@
+package io.github.renakoni.marktextandroid;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import org.junit.Test;
+
+public class SafeDocumentWriterTest {
+
+    /** A programmable single write attempt. */
+    private static final class FakeHandle implements SafeDocumentWriter.WriteHandle {
+        IOException writeError;
+        Long lengthOverride; // null = report exactly what was written
+
+        byte[] written;
+        boolean synced;
+        boolean committed;
+        boolean aborted;
+
+        @Override
+        public void write(byte[] bytes) throws IOException {
+            if (writeError != null) {
+                throw writeError;
+            }
+            written = bytes;
+        }
+
+        @Override
+        public void sync() {
+            synced = true;
+        }
+
+        @Override
+        public long length() {
+            if (lengthOverride != null) {
+                return lengthOverride;
+            }
+            return written == null ? 0 : written.length;
+        }
+
+        @Override
+        public void commit() {
+            committed = true;
+        }
+
+        @Override
+        public void abort(String reason) {
+            aborted = true;
+        }
+    }
+
+    private static final class FakeIo implements SafeDocumentWriter.DocumentIo {
+        byte[] existing;
+        IOException readError;
+        final Deque<FakeHandle> handles = new ArrayDeque<>();
+        final List<FakeHandle> opened = new ArrayList<>();
+        int readCount;
+
+        @Override
+        public byte[] readBytes() throws IOException {
+            readCount++;
+            if (readError != null) {
+                throw readError;
+            }
+            return existing;
+        }
+
+        @Override
+        public SafeDocumentWriter.WriteHandle openWrite() {
+            FakeHandle handle = handles.poll();
+            if (handle == null) {
+                fail("openWrite() called more times than configured");
+            }
+            opened.add(handle);
+            return handle;
+        }
+    }
+
+    @Test
+    public void writesAndCommitsOnTheHappyPath() throws IOException {
+        FakeIo io = new FakeIo();
+        io.existing = new byte[] { 1, 2, 3 };
+        FakeHandle handle = new FakeHandle();
+        io.handles.add(handle);
+
+        byte[] bytes = new byte[] { 9, 8, 7, 6 };
+        SafeDocumentWriter.write(io, bytes, true);
+
+        assertEquals(1, io.readCount);
+        assertEquals(1, io.opened.size());
+        assertArrayEquals(bytes, handle.written);
+        assertTrue(handle.synced);
+        assertTrue(handle.committed);
+        assertFalse(handle.aborted);
+    }
+
+    @Test
+    public void skipsTheBackupReadWhenNotProtectingExisting() throws IOException {
+        FakeIo io = new FakeIo();
+        FakeHandle handle = new FakeHandle();
+        io.handles.add(handle);
+
+        SafeDocumentWriter.write(io, new byte[] { 1 }, false);
+
+        assertEquals(0, io.readCount); // a fresh document has nothing to back up
+        assertTrue(handle.committed);
+    }
+
+    @Test
+    public void restoresTheBackupWhenTheWriteFails() {
+        FakeIo io = new FakeIo();
+        io.existing = new byte[] { 4, 5, 6 };
+        FakeHandle failing = new FakeHandle();
+        IOException boom = new IOException("disk full");
+        failing.writeError = boom;
+        FakeHandle restore = new FakeHandle();
+        io.handles.add(failing);
+        io.handles.add(restore);
+
+        try {
+            SafeDocumentWriter.write(io, new byte[] { 7, 7 }, true);
+            fail("expected the write error to propagate");
+        } catch (IOException error) {
+            assertSame(boom, error);
+        }
+
+        assertTrue(failing.aborted); // provider told to discard the partial write
+        assertEquals(2, io.opened.size()); // failing write + restore write
+        assertArrayEquals(io.existing, restore.written); // original bytes rewritten
+        assertTrue(restore.committed);
+    }
+
+    @Test
+    public void restoresWhenTheLengthVerificationFails() {
+        FakeIo io = new FakeIo();
+        io.existing = new byte[] { 1 };
+        FakeHandle shortWrite = new FakeHandle();
+        shortWrite.lengthOverride = 2L; // provider silently wrote fewer than 4 bytes
+        FakeHandle restore = new FakeHandle();
+        io.handles.add(shortWrite);
+        io.handles.add(restore);
+
+        try {
+            SafeDocumentWriter.write(io, new byte[] { 1, 2, 3, 4 }, true);
+            fail("expected a verification failure");
+        } catch (IOException error) {
+            assertTrue(error.getMessage().contains("verification failed"));
+        }
+
+        assertTrue(shortWrite.aborted);
+        assertArrayEquals(io.existing, restore.written);
+        assertTrue(restore.committed);
+    }
+
+    @Test
+    public void skipsVerificationWhenLengthIsUnavailable() throws IOException {
+        FakeIo io = new FakeIo();
+        io.existing = new byte[] { 1 };
+        FakeHandle handle = new FakeHandle();
+        handle.lengthOverride = -1L; // non-seekable pipe: length unknown
+        io.handles.add(handle);
+
+        SafeDocumentWriter.write(io, new byte[] { 1, 2, 3 }, true);
+
+        assertTrue(handle.committed); // committed despite an unknown length
+        assertFalse(handle.aborted);
+    }
+
+    @Test
+    public void abortsWithoutRestoringWhenThereIsNoBackup() {
+        FakeIo io = new FakeIo();
+        FakeHandle failing = new FakeHandle();
+        failing.writeError = new IOException("provider gone");
+        io.handles.add(failing);
+
+        try {
+            SafeDocumentWriter.write(io, new byte[] { 1 }, false);
+            fail("expected the write error to propagate");
+        } catch (IOException error) {
+            assertEquals("provider gone", error.getMessage());
+        }
+
+        assertTrue(failing.aborted);
+        assertEquals(1, io.opened.size()); // no restore attempt for a fresh document
+    }
+
+    @Test
+    public void surfacesDeletionBeforeTruncatingAnything() {
+        FakeIo io = new FakeIo();
+        io.readError = new FileNotFoundException("document deleted");
+
+        try {
+            SafeDocumentWriter.write(io, new byte[] { 1, 2 }, true);
+            fail("expected the not-found error to propagate");
+        } catch (IOException error) {
+            assertTrue(error instanceof FileNotFoundException);
+        }
+
+        assertEquals(0, io.opened.size()); // nothing opened for writing → nothing truncated
+    }
+
+    @Test
+    public void keepsTheOriginalErrorWhenTheRestoreAlsoFails() {
+        FakeIo io = new FakeIo();
+        io.existing = new byte[] { 9 };
+        FakeHandle failing = new FakeHandle();
+        IOException boom = new IOException("primary failure");
+        failing.writeError = boom;
+        FakeHandle restore = new FakeHandle();
+        restore.writeError = new IOException("restore failure too");
+        io.handles.add(failing);
+        io.handles.add(restore);
+
+        try {
+            SafeDocumentWriter.write(io, new byte[] { 1 }, true);
+            fail("expected the primary write error");
+        } catch (IOException error) {
+            assertSame(boom, error); // the original error stays primary
+            assertEquals(1, error.getSuppressed().length); // restore failure attached
+        }
+
+        assertTrue(restore.aborted);
+    }
+}

--- a/android/app/src/test/java/io/github/renakoni/marktextandroid/SafeDocumentWriterTest.java
+++ b/android/app/src/test/java/io/github/renakoni/marktextandroid/SafeDocumentWriterTest.java
@@ -20,6 +20,7 @@ public class SafeDocumentWriterTest {
     /** A programmable single write attempt. */
     private static final class FakeHandle implements SafeDocumentWriter.WriteHandle {
         IOException writeError;
+        IOException syncError;
         Long lengthOverride; // null = report exactly what was written
 
         byte[] written;
@@ -36,8 +37,11 @@ public class SafeDocumentWriterTest {
         }
 
         @Override
-        public void sync() {
+        public void sync() throws IOException {
             synced = true;
+            if (syncError != null) {
+                throw syncError;
+            }
         }
 
         @Override
@@ -62,9 +66,12 @@ public class SafeDocumentWriterTest {
     private static final class FakeIo implements SafeDocumentWriter.DocumentIo {
         byte[] existing;
         IOException readError;
-        final Deque<FakeHandle> handles = new ArrayDeque<>();
+        // Each entry is either a FakeHandle to return or an IOException to throw
+        // (modelling a destructive openWrite that truncates then fails).
+        final Deque<Object> handles = new ArrayDeque<>();
         final List<FakeHandle> opened = new ArrayList<>();
         int readCount;
+        int openCallCount;
 
         @Override
         public byte[] readBytes() throws IOException {
@@ -76,11 +83,16 @@ public class SafeDocumentWriterTest {
         }
 
         @Override
-        public SafeDocumentWriter.WriteHandle openWrite() {
-            FakeHandle handle = handles.poll();
-            if (handle == null) {
+        public SafeDocumentWriter.WriteHandle openWrite() throws IOException {
+            openCallCount++;
+            Object action = handles.poll();
+            if (action == null) {
                 fail("openWrite() called more times than configured");
             }
+            if (action instanceof IOException) {
+                throw (IOException) action;
+            }
+            FakeHandle handle = (FakeHandle) action;
             opened.add(handle);
             return handle;
         }
@@ -230,5 +242,83 @@ public class SafeDocumentWriterTest {
         }
 
         assertTrue(restore.aborted);
+    }
+
+    @Test
+    public void restoresWhenOpeningTheWriteTruncatesThenFails() {
+        // openWrite() ("rwt"/"wt") is itself destructive: it can empty the file
+        // and then fail while returning the descriptor. That failure must still
+        // trigger a restore even though no usable handle was produced.
+        FakeIo io = new FakeIo();
+        io.existing = new byte[] { 4, 5, 6 };
+        IOException openBoom = new IOException("descriptor lost after truncation");
+        FakeHandle restore = new FakeHandle();
+        io.handles.add(openBoom); // first openWrite truncates then throws
+        io.handles.add(restore); // restore openWrite succeeds
+
+        try {
+            SafeDocumentWriter.write(io, new byte[] { 7, 7 }, true);
+            fail("expected the open error to propagate");
+        } catch (IOException error) {
+            assertSame(openBoom, error);
+        }
+
+        assertEquals(2, io.openCallCount); // failed open + restore open
+        assertArrayEquals(io.existing, restore.written); // original bytes rewritten
+        assertTrue(restore.committed);
+    }
+
+    @Test
+    public void restoresWhenFsyncFails() {
+        // A durability (fsync) failure on a seekable descriptor surfaces even
+        // when write() and the length looked fine — it must abort and restore.
+        FakeIo io = new FakeIo();
+        io.existing = new byte[] { 1, 2 };
+        FakeHandle failing = new FakeHandle();
+        IOException syncBoom = new IOException("fsync failed: disk full");
+        failing.syncError = syncBoom;
+        FakeHandle restore = new FakeHandle();
+        io.handles.add(failing);
+        io.handles.add(restore);
+
+        try {
+            SafeDocumentWriter.write(io, new byte[] { 8, 9 }, true);
+            fail("expected the fsync failure to propagate");
+        } catch (IOException error) {
+            assertSame(syncBoom, error);
+        }
+
+        assertTrue(failing.aborted); // the un-synced partial write is discarded
+        assertFalse(failing.committed);
+        assertArrayEquals(io.existing, restore.written);
+        assertTrue(restore.committed);
+    }
+
+    @Test
+    public void verifiesTheRollbackWriteAndAttachesItsShortWriteToTheOriginalError() {
+        // The rollback runs the SAME length verify as the forward write, so a
+        // silent short-write during restore is caught and attached, not
+        // mistaken for a completed rollback.
+        FakeIo io = new FakeIo();
+        io.existing = new byte[] { 5, 5, 5 };
+        FakeHandle failing = new FakeHandle();
+        IOException boom = new IOException("primary write failed");
+        failing.writeError = boom;
+        FakeHandle restore = new FakeHandle();
+        restore.lengthOverride = 1L; // restore silently writes fewer than 3 bytes
+        io.handles.add(failing);
+        io.handles.add(restore);
+
+        try {
+            SafeDocumentWriter.write(io, new byte[] { 7 }, true);
+            fail("expected the primary write error");
+        } catch (IOException error) {
+            assertSame(boom, error);
+            assertEquals(1, error.getSuppressed().length);
+            assertTrue(error.getSuppressed()[0].getMessage().contains("verification failed"));
+        }
+
+        assertTrue(restore.aborted); // the short rollback write is aborted, not committed
+        assertFalse(restore.committed);
     }
 }


### PR DESCRIPTION
## Summary

`writeText` truncated the user's real file (`openOutputStream(uri, "wt")`) before writing a byte and only `flush()`ed — never `fsync`ed. A mid-write failure (storage full, provider drop, encode error) left the file empty or partial with **no backup and no rollback**. This makes the save all-or-nothing.

## Why not a plain temp-file + rename

SAF has no atomic replace for a bare document URI: the app holds only a single-document grant (files open via `ACTION_OPEN_DOCUMENT`, no parent tree), and `DocumentsContract.renameDocument` cannot overwrite an existing name. A sibling-temp swap is therefore impossible here — atomicity is emulated at the application layer.

## Approach — `SafeDocumentWriter`

1. Read a **raw backup** of the existing bytes FIRST (a document deleted out from under us therefore fails here, before anything is truncated).
2. `openFileDescriptor(uri, "rwt")` → write → **fsync** → **lightweight length verify** (catches a provider that silently short-writes; skipped when the provider is a non-seekable pipe).
3. On ANY failure: `closeWithError` (well-behaved providers, esp. cloud, discard the partial write) **and restore the backup**, so the file is never left empty.

The algorithm is Android-free behind a `DocumentIo` seam; `ContentResolverDocumentIo` is the only Android-coupled part. Encoding/BOM/line-ending fidelity is untouched — the exact `MarkdownCodec.validateBytes` output is what's moved atomically. A `TODO` marks a deferred write-ahead-snapshot layer for the near-impossible process-kill-mid-write case; the recovery-draft-gate (unconditional crash recovery) is split out as a separate follow-up.

## Verification

- **Native unit (`SafeDocumentWriterTest`, 8):** happy path, create-without-backup, write-failure rollback, verify-failure rollback, non-seekable skip, no-backup abort, deletion-before-truncate, restore-also-fails. Existing `MarkdownCodec`/`IncomingIntentParser`/`SharePreparation` tests unchanged and green.
- **Build:** `assembleDebug` green. **Zero JS changes** → the JS save/recovery contract is identical.
- **Device (Xiaomi 14, real Downloads-provider `.md`):** a normal save round-trips; a forced mid-write failure — the real file truncated, then the write throws — leaves the file holding the **original content** (restore ran on a real SAF document); a subsequent normal save works.
