### PR TITLE
Keep every local draft instead of evicting the oldest past twenty

### DIFF
--- a/src/lib/localDrafts.test.ts
+++ b/src/lib/localDrafts.test.ts
@@ -87,6 +87,36 @@ describe('localDrafts', () => {
     expect(drafts[0].createdAt).toBe(olderDraft.createdAt)
   })
 
+  it('keeps every draft when a new one pushes past the old 20-draft cap', () => {
+    // Twenty saved drafts, oldest (draft-1) to newest (draft-20).
+    const existing: LocalDraftRecord[] = Array.from({ length: 20 }, (_, index) => {
+      const minute = String(index).padStart(2, '0')
+      return {
+        id: `draft-${index + 1}`,
+        markdown: `# Draft ${index + 1}\n\nbody`,
+        createdAt: `2026-06-29T00:${minute}:00.000Z`,
+        updatedAt: `2026-06-29T00:${minute}:00.000Z`,
+        lastSavedAt: `2026-06-29T00:${minute}:00.000Z`,
+      }
+    })
+
+    const withTwentyFirst = upsertLocalDraft(existing, {
+      id: 'draft-21',
+      markdown: '# Draft 21\n\nbody',
+      createdAt: '2026-06-29T00:20:00.000Z',
+      updatedAt: '2026-06-29T00:20:00.000Z',
+      lastSavedAt: '2026-06-29T00:20:00.000Z',
+    })
+
+    // The 21st draft must not evict the oldest — all 21 survive, in storage too.
+    expect(withTwentyFirst).toHaveLength(21)
+    const persistedIds = parseLocalDrafts(serializeLocalDrafts(withTwentyFirst)).map(
+      draft => draft.id,
+    )
+    expect(persistedIds).toContain('draft-1')
+    expect(persistedIds).toHaveLength(21)
+  })
+
   it('migrates legacy draft records without created time', () => {
     const legacyDraft = {
       id: 'legacy',

--- a/src/lib/localDrafts.ts
+++ b/src/lib/localDrafts.ts
@@ -18,8 +18,6 @@ type StoredLocalDraftRecord = Omit<LocalDraftRecord, 'createdAt'> & {
   createdAt?: string
 }
 
-const DEFAULT_DRAFT_LIMIT = 20
-
 function isStoredLocalDraftRecord(value: unknown): value is StoredLocalDraftRecord {
   if (!value || typeof value !== 'object') {
     return false
@@ -47,10 +45,15 @@ function compareDraftsByUpdateTime(left: StoredLocalDraftRecord, right: StoredLo
   return Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
 }
 
-export function normalizeLocalDrafts(
-  records: StoredLocalDraftRecord[],
-  limit = DEFAULT_DRAFT_LIMIT,
-) {
+/**
+ * Sorts drafts newest-first and drops duplicates and empty drafts, keeping
+ * EVERY remaining draft. Persistence must never cap this list: each record is
+ * the only durable copy of that draft's content, so evicting the oldest to fit
+ * a limit would silently lose a user's work ("never lose a word"). Any list
+ * length limit belongs to the home projection as a presentation-only slice
+ * (see `normalizeRecentDocuments`), never here.
+ */
+export function normalizeLocalDrafts(records: StoredLocalDraftRecord[]) {
   const seen = new Set<string>()
   const normalized: LocalDraftRecord[] = []
 
@@ -64,7 +67,7 @@ export function normalizeLocalDrafts(
     normalized.push(record)
   }
 
-  return normalized.slice(0, limit)
+  return normalized
 }
 
 export function parseLocalDrafts(value: string | null) {
@@ -88,11 +91,7 @@ export function serializeLocalDrafts(records: LocalDraftRecord[]) {
   return JSON.stringify(normalizeLocalDrafts(records))
 }
 
-export function upsertLocalDraft(
-  records: LocalDraftRecord[],
-  draft: LocalDraftRecord,
-  limit = DEFAULT_DRAFT_LIMIT,
-) {
+export function upsertLocalDraft(records: LocalDraftRecord[], draft: LocalDraftRecord) {
   const existingDraft = records.find(record => record.id === draft.id)
   const nextDraft = {
     ...draft,
@@ -100,10 +99,10 @@ export function upsertLocalDraft(
     displayName: draft.displayName ?? existingDraft?.displayName,
   }
 
-  return normalizeLocalDrafts(
-    [nextDraft, ...records.filter(record => record.id !== draft.id)],
-    limit,
-  )
+  return normalizeLocalDrafts([
+    nextDraft,
+    ...records.filter(record => record.id !== draft.id),
+  ])
 }
 
 export function removeLocalDraft(records: LocalDraftRecord[], id: string) {


### PR DESCRIPTION
## Problem

Saving the twenty-first local draft silently deleted the oldest saved draft. **[P1 — data safety]**

The durable local-draft store hard-capped itself at twenty records. `normalizeLocalDrafts()` sorted by update time and returned `normalized.slice(0, limit)` (`DEFAULT_DRAFT_LIMIT = 20`), and **every** persistence path ran through it:

- `parseLocalDrafts()` (read)
- `serializeLocalDrafts()` (write to `localStorage`)
- `upsertLocalDraft()` (each normal autosave)

So saving a twenty-first non-empty draft dropped the oldest draft from **both** in-memory state and `localStorage` — no warning, confirmation, export, archive, or secondary durable store. Android recovery drafts share the same array, so they could evict ordinary user drafts as well.

These records are the only durable copy of a local draft's content, so this lost user work and directly violated the product principle **"never lose a word."**

## Fix

Remove the destructive cap from persistence:

- `normalizeLocalDrafts()` still sorts newest-first, de-duplicates by id, and drops empty drafts — but now keeps **every** remaining record.
- `upsertLocalDraft()` no longer thins the list.

Nothing depended on the persistence cap for display: the home list already applies its own **presentation-only** limit at the recent-documents projection (`normalizeRecentDocuments`, capped at 50, non-destructive). No caller passed a custom `limit`, so the parameter is removed rather than left as a footgun.

## Test

Added a regression test proving a twenty-first draft preserves drafts 1–20, both in memory and across a `serialize -> parse` storage round-trip.

## Verification

- `localDrafts.test.ts` — 12 passed (incl. the new regression)
- Tests consuming `upsertLocalDraft` / draft persistence (local-drafts, currentDocumentPersistence, homeDocumentActions, incomingDocumentOrchestration, documentStorage) — 50 passed
- `npm run typecheck` (vue-tsc -b) — clean
- eslint on changed files — clean

## Out of scope (follow-up)

Drafts can now grow unbounded, and `localStorage` has a finite quota; `writeStoredLocalDrafts` does not yet handle a quota exception. The correct response is to surface an explicit error at the quota edge rather than silently evict the oldest draft — a separate change that does not conflict with this one.
