### PR TITLE
Ask before an incoming Intent discards an unpreservable document

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1541,6 +1541,19 @@ function confirmIncomingOpenAfterBlockedPreserve(request: {
   incomingName: string
   proceed: () => Promise<void>
 }) {
+  // The safety prompt must be the only surface on screen so it is visible and
+  // Android Back answers it — otherwise an open menu/outline (z-index 40) would
+  // cover it. Close transient editor chrome WITHOUT touching the editor, which
+  // stays mounted with its unsaved content.
+  closeEditorMenu()
+  closeEditorToolbar()
+  closeEditorOutline()
+  closeEditorSearch({ restoreCursor: false })
+  closeLinkSheet()
+  closeTableSheet()
+  draftExitPromptOpen.value = false
+  androidExitPromptOpen.value = false
+
   pendingIncomingOpenProceed = request.proceed
   incomingOpenName.value = request.incomingName
   incomingOpenPromptOpen.value = true
@@ -1557,6 +1570,8 @@ function keepEditingInsteadOfIncomingOpen() {
     documentState.value.autosaveTarget === 'android-document'
       ? getAndroidEditorStatus()
       : 'Edited'
+  // Resume the queue: any intent that arrived while the prompt was open runs now.
+  void incomingDocuments.resolveIncomingDecision()
 }
 
 async function discardCurrentAndOpenIncoming() {
@@ -1567,6 +1582,8 @@ async function discardCurrentAndOpenIncoming() {
   if (proceed) {
     await proceed()
   }
+  // Drain after the replacement so a queued intent preserves the new editor.
+  void incomingDocuments.resolveIncomingDecision()
 }
 
 function requestLifecycleFlush(reason: string) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1579,11 +1579,21 @@ async function discardCurrentAndOpenIncoming() {
   pendingIncomingOpenProceed = null
   incomingOpenPromptOpen.value = false
   incomingOpenName.value = ''
-  if (proceed) {
-    await proceed()
+  try {
+    if (proceed) {
+      await proceed()
+    }
+  } catch (error) {
+    const message = getAndroidDocumentUserMessage(error)
+    homeNotice.value = message
+    status.value = message
+    androidDocumentLog.error('open incoming Android document after discard failed', error)
+  } finally {
+    // Always release the decision gate, even when the deferred open fails.
+    // Otherwise every future incoming Intent stays queued with no prompt left
+    // on screen to resume it.
+    void incomingDocuments.resolveIncomingDecision()
   }
-  // Drain after the replacement so a queued intent preserves the new editor.
-  void incomingDocuments.resolveIncomingDecision()
 }
 
 function requestLifecycleFlush(reason: string) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1566,10 +1566,12 @@ function keepEditingInsteadOfIncomingOpen() {
   pendingIncomingOpenProceed = null
   incomingOpenPromptOpen.value = false
   incomingOpenName.value = ''
-  status.value =
-    documentState.value.autosaveTarget === 'android-document'
-      ? getAndroidEditorStatus()
-      : 'Edited'
+  if (documentState.value.autosaveState !== 'save-failed') {
+    status.value =
+      documentState.value.autosaveTarget === 'android-document'
+        ? getAndroidEditorStatus()
+        : 'Edited'
+  }
   // Resume the queue: any intent that arrived while the prompt was open runs now.
   void incomingDocuments.resolveIncomingDecision()
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1566,12 +1566,6 @@ function keepEditingInsteadOfIncomingOpen() {
   pendingIncomingOpenProceed = null
   incomingOpenPromptOpen.value = false
   incomingOpenName.value = ''
-  if (documentState.value.autosaveState !== 'save-failed') {
-    status.value =
-      documentState.value.autosaveTarget === 'android-document'
-        ? getAndroidEditorStatus()
-        : 'Edited'
-  }
   // Resume the queue: any intent that arrived while the prompt was open runs now.
   void incomingDocuments.resolveIncomingDecision()
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -210,6 +210,11 @@ const homeTab = ref<HomeTab>(DEFAULT_HOME_TAB)
 const settingsPage = ref<SettingsPage>(DEFAULT_SETTINGS_PAGE)
 const draftExitPromptOpen = ref(false)
 const androidExitPromptOpen = ref(false)
+const incomingOpenPromptOpen = ref(false)
+const incomingOpenName = ref('')
+// The deferred replacement to run if the user discards the current document
+// after preservation was blocked; cleared whenever the prompt resolves.
+let pendingIncomingOpenProceed: (() => Promise<void>) | null = null
 const promptLocalDraftSaveOnExit = ref(false)
 const savingLocalDraftToAndroid = ref(false)
 const savingAndroidDocumentCopy = ref(false)
@@ -1530,6 +1535,40 @@ function discardAndroidChangesAndShowHome() {
   closeEditorToHome()
 }
 
+// An incoming Intent could not durably preserve the current document. Keep the
+// editor mounted and let the user decide instead of silently replacing it.
+function confirmIncomingOpenAfterBlockedPreserve(request: {
+  incomingName: string
+  proceed: () => Promise<void>
+}) {
+  pendingIncomingOpenProceed = request.proceed
+  incomingOpenName.value = request.incomingName
+  incomingOpenPromptOpen.value = true
+  appLog.warn('incoming open blocked: current document could not be preserved', {
+    incomingName: request.incomingName,
+  })
+}
+
+function keepEditingInsteadOfIncomingOpen() {
+  pendingIncomingOpenProceed = null
+  incomingOpenPromptOpen.value = false
+  incomingOpenName.value = ''
+  status.value =
+    documentState.value.autosaveTarget === 'android-document'
+      ? getAndroidEditorStatus()
+      : 'Edited'
+}
+
+async function discardCurrentAndOpenIncoming() {
+  const proceed = pendingIncomingOpenProceed
+  pendingIncomingOpenProceed = null
+  incomingOpenPromptOpen.value = false
+  incomingOpenName.value = ''
+  if (proceed) {
+    await proceed()
+  }
+}
+
 function requestLifecycleFlush(reason: string) {
   void flushCurrentDocument(reason)
   // Same lifecycle moments the document flush uses; the position write is
@@ -1554,6 +1593,7 @@ async function handleAppBackButton() {
     currentScreen: currentScreen.value,
     homeTab: homeTab.value,
     settingsPage: settingsPage.value,
+    incomingOpenPromptOpen: incomingOpenPromptOpen.value,
     androidExitPromptOpen: androidExitPromptOpen.value,
     draftExitPromptOpen: draftExitPromptOpen.value,
     linkSheetOpen: linkSheetOpen.value,
@@ -1567,6 +1607,9 @@ async function handleAppBackButton() {
   })
 
   switch (action) {
+    case 'close-incoming-open-prompt':
+      keepEditingInsteadOfIncomingOpen()
+      return
     case 'close-android-exit-prompt':
       androidExitPromptOpen.value = false
       status.value = getAndroidEditorStatus()
@@ -1657,6 +1700,7 @@ const incomingDocuments = createIncomingDocumentOrchestration({
   persistAndroidRecoveryDraft,
   canPersistLocalDrafts,
   persistLocalDrafts,
+  confirmIncomingOpenAfterBlockedPreserve,
   getAndroidDocumentUserMessage,
   appLogger: appLog,
   documentLogger: androidDocumentLog,
@@ -1893,6 +1937,8 @@ onBeforeUnmount(() => {
     :android-can-save-copy="canSaveAndroidDocumentCopy()"
     :android-can-keep-recovery="canPersistAndroidRecoveryDrafts()"
     :android-saving="savingAndroidDocumentCopy"
+    :incoming-open-prompt-open="incomingOpenPromptOpen"
+    :incoming-open-name="incomingOpenName"
     :text-direction="appearanceTextSettings.textDirection"
     :editor-style-vars="editorStyleVars"
     :can-paste-selection="selectionClipboardHasText"
@@ -1942,6 +1988,8 @@ onBeforeUnmount(() => {
     @save-android-copy="saveAndroidDocumentCopy({ returnHomeAfterSave: true })"
     @keep-android-recovery="keepAndroidRecoveryAndShowHome"
     @discard-android-changes="discardAndroidChangesAndShowHome"
+    @keep-incoming="keepEditingInsteadOfIncomingOpen"
+    @discard-incoming="discardCurrentAndOpenIncoming"
     @editor-host-change="setEditorElement"
   />
 </template>

--- a/src/features/android-documents/incomingDocumentOrchestration.test.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.test.ts
@@ -147,7 +147,10 @@ describe('incomingDocumentOrchestration', () => {
     await orchestration.handleOpenWithDocumentEvent({ document: incomingDocument, error: null })
 
     expect(options.syncDocumentFromEditor).toHaveBeenCalledWith(true, true)
-    expect(options.saveAndroidDocument).toHaveBeenCalled()
+    expect(options.saveAndroidDocument).toHaveBeenCalledWith({
+      waitForPendingSave: true,
+      persistRecoveryDraftOnFailure: false,
+    })
     expect(options.persistAndroidRecoveryDraft).toHaveBeenCalledWith(
       'content://test/current.md',
       '# Device doc',

--- a/src/features/android-documents/incomingDocumentOrchestration.test.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.test.ts
@@ -43,6 +43,8 @@ function createOrchestration(overrides: {
   documentState?: ReturnType<typeof createUntitledDocument>
   hasEditor?: boolean
   saveResult?: boolean
+  draftSaved?: boolean
+  recoveryKept?: boolean
   canPersistDrafts?: boolean
 } = {}) {
   const options = {
@@ -66,11 +68,12 @@ function createOrchestration(overrides: {
     closeEditorToolbar: vi.fn(),
     openAndroidDocumentResult: vi.fn().mockResolvedValue(undefined),
     saveAndroidDocument: vi.fn().mockResolvedValue(overrides.saveResult ?? true),
-    saveDraft: vi.fn(),
+    saveDraft: vi.fn(() => overrides.draftSaved ?? true),
     syncDocumentFromEditor: vi.fn(),
-    persistAndroidRecoveryDraft: vi.fn(),
+    persistAndroidRecoveryDraft: vi.fn(() => overrides.recoveryKept ?? true),
     canPersistLocalDrafts: () => overrides.canPersistDrafts ?? true,
     persistLocalDrafts: vi.fn(),
+    confirmIncomingOpenAfterBlockedPreserve: vi.fn(),
     getAndroidDocumentUserMessage,
     appLogger: noopLogger,
     documentLogger: noopLogger,
@@ -149,7 +152,88 @@ describe('incomingDocumentOrchestration', () => {
       'content://test/current.md',
       '# Device doc',
     )
+    // A durable recovery write counts as preserved, so the incoming doc opens.
+    expect(options.confirmIncomingOpenAfterBlockedPreserve).not.toHaveBeenCalled()
     expect(options.openAndroidDocumentResult).toHaveBeenCalled()
+  })
+
+  it('blocks the incoming open when a failed Android save cannot be recovered', async () => {
+    const documentState = {
+      ...createUntitledDocument({
+        markdown: '# Device doc',
+        autosaveTarget: 'android-document',
+        sourceUri: 'content://test/current.md',
+      }),
+      isDirty: true,
+    }
+    const { orchestration, options } = createOrchestration({
+      currentScreen: 'editor',
+      hasEditor: true,
+      documentState,
+      saveResult: false,
+      recoveryKept: false,
+    })
+
+    await orchestration.handleOpenWithDocumentEvent({ document: incomingDocument, error: null })
+
+    expect(options.confirmIncomingOpenAfterBlockedPreserve).toHaveBeenCalledTimes(1)
+    const [request] = options.confirmIncomingOpenAfterBlockedPreserve.mock.calls[0]
+    expect(request.incomingName).toBe('incoming.md')
+    expect(typeof request.proceed).toBe('function')
+    // The editor is not replaced and its chrome stays mounted.
+    expect(options.openAndroidDocumentResult).not.toHaveBeenCalled()
+    expect(options.closeEditorMenu).not.toHaveBeenCalled()
+  })
+
+  it('blocks the incoming open when an unsaved local draft cannot be kept', async () => {
+    const { orchestration, options } = createOrchestration({
+      currentScreen: 'editor',
+      hasEditor: true,
+      documentState: createUntitledDocument({ markdown: '# Draft', autosaveTarget: 'local-draft' }),
+      draftSaved: false,
+    })
+
+    await orchestration.handleShareDocumentEvent({ document: sharedTextDocument, error: null })
+
+    expect(options.saveDraft).toHaveBeenCalled()
+    expect(options.confirmIncomingOpenAfterBlockedPreserve).toHaveBeenCalledTimes(1)
+    expect(options.confirmIncomingOpenAfterBlockedPreserve.mock.calls[0][0].incomingName).toBe(
+      'Shared text',
+    )
+    // The shared text is not imported and the editor is not replaced.
+    expect(options.openEditor).not.toHaveBeenCalled()
+    expect(options.persistLocalDrafts).not.toHaveBeenCalled()
+  })
+
+  it('opens the incoming document when the user discards after a blocked preserve', async () => {
+    const documentState = {
+      ...createUntitledDocument({
+        markdown: '# Device doc',
+        autosaveTarget: 'android-document',
+        sourceUri: 'content://test/current.md',
+      }),
+      isDirty: true,
+    }
+    const { orchestration, options } = createOrchestration({
+      currentScreen: 'editor',
+      hasEditor: true,
+      documentState,
+      saveResult: false,
+      recoveryKept: false,
+    })
+
+    await orchestration.handleOpenWithDocumentEvent({ document: incomingDocument, error: null })
+    expect(options.openAndroidDocumentResult).not.toHaveBeenCalled()
+
+    // Running the deferred proceed is the user's "Discard & open" choice.
+    const [request] = options.confirmIncomingOpenAfterBlockedPreserve.mock.calls[0]
+    await request.proceed()
+
+    expect(options.closeEditorMenu).toHaveBeenCalled()
+    expect(options.openAndroidDocumentResult).toHaveBeenCalledWith(incomingDocument, {
+      source: 'open-with',
+      remember: true,
+    })
   })
 
   it('routes a shared Markdown file through the shared open path', async () => {

--- a/src/features/android-documents/incomingDocumentOrchestration.test.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.test.ts
@@ -236,6 +236,83 @@ describe('incomingDocumentOrchestration', () => {
     })
   })
 
+  it('recovers the latest content after the awaited save, not the pre-save snapshot', async () => {
+    const documentState = {
+      ...createUntitledDocument({
+        markdown: '# Before save',
+        autosaveTarget: 'android-document',
+        sourceUri: 'content://test/current.md',
+      }),
+      isDirty: true,
+    }
+    const { orchestration, options } = createOrchestration({
+      currentScreen: 'editor',
+      hasEditor: true,
+      documentState,
+    })
+    // The provider write is still pending while the user keeps typing: the save
+    // reports changed-during-save (false) and the editor now holds newer text.
+    options.saveAndroidDocument.mockImplementation(async () => {
+      options.documentState.value = {
+        ...options.documentState.value,
+        markdown: '# Edited during save',
+      }
+      return false
+    })
+
+    await orchestration.handleOpenWithDocumentEvent({ document: incomingDocument, error: null })
+
+    // The recovery payload must be the freshest content, never the stale snapshot.
+    expect(options.persistAndroidRecoveryDraft).toHaveBeenCalledWith(
+      'content://test/current.md',
+      '# Edited during save',
+    )
+  })
+
+  it('holds a second incoming open while a blocked prompt is still pending', async () => {
+    const documentState = {
+      ...createUntitledDocument({
+        markdown: '# Device doc',
+        autosaveTarget: 'android-document',
+        sourceUri: 'content://test/current.md',
+      }),
+      isDirty: true,
+    }
+    const { orchestration, options } = createOrchestration({
+      currentScreen: 'editor',
+      hasEditor: true,
+      documentState,
+      saveResult: false,
+      recoveryKept: false,
+    })
+
+    // First intent blocks and shows the prompt.
+    await orchestration.handleOpenWithDocumentEvent({ document: incomingDocument, error: null })
+    expect(options.confirmIncomingOpenAfterBlockedPreserve).toHaveBeenCalledTimes(1)
+    expect(options.saveAndroidDocument).toHaveBeenCalledTimes(1)
+
+    // A second intent arrives while the decision is pending. It must neither open
+    // behind the prompt nor even run its own preservation yet (serialized).
+    const secondDocument = {
+      ...incomingDocument,
+      sourceUri: 'content://test/second.md',
+      displayName: 'second.md',
+    }
+    await orchestration.handleOpenWithDocumentEvent({ document: secondDocument, error: null })
+    expect(options.openAndroidDocumentResult).not.toHaveBeenCalled()
+    expect(options.saveAndroidDocument).toHaveBeenCalledTimes(1)
+
+    // Resolving the first decision drains the queued second intent, which then
+    // preserves the current editor (still blocked) and prompts for the new doc.
+    await orchestration.resolveIncomingDecision()
+    expect(options.saveAndroidDocument).toHaveBeenCalledTimes(2)
+    expect(options.confirmIncomingOpenAfterBlockedPreserve).toHaveBeenCalledTimes(2)
+    expect(options.confirmIncomingOpenAfterBlockedPreserve.mock.calls[1][0].incomingName).toBe(
+      'second.md',
+    )
+    expect(options.openAndroidDocumentResult).not.toHaveBeenCalled()
+  })
+
   it('routes a shared Markdown file through the shared open path', async () => {
     const { orchestration, options } = createOrchestration()
 

--- a/src/features/android-documents/incomingDocumentOrchestration.test.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.test.ts
@@ -185,6 +185,30 @@ describe('incomingDocumentOrchestration', () => {
     expect(options.closeEditorMenu).not.toHaveBeenCalled()
   })
 
+  it('blocks when a failed save leaves a dirty Android document blank', async () => {
+    const documentState = {
+      ...createUntitledDocument({
+        markdown: '',
+        autosaveTarget: 'android-document',
+        sourceUri: 'content://test/current.md',
+      }),
+      isDirty: true,
+    }
+    const { orchestration, options } = createOrchestration({
+      currentScreen: 'editor',
+      hasEditor: true,
+      documentState,
+      saveResult: false,
+      recoveryKept: false,
+    })
+
+    await orchestration.handleOpenWithDocumentEvent({ document: incomingDocument, error: null })
+
+    expect(options.confirmIncomingOpenAfterBlockedPreserve).toHaveBeenCalledTimes(1)
+    expect(options.persistAndroidRecoveryDraft).not.toHaveBeenCalled()
+    expect(options.openAndroidDocumentResult).not.toHaveBeenCalled()
+  })
+
   it('blocks the incoming open when an unsaved local draft cannot be kept', async () => {
     const { orchestration, options } = createOrchestration({
       currentScreen: 'editor',
@@ -311,6 +335,39 @@ describe('incomingDocumentOrchestration', () => {
       'second.md',
     )
     expect(options.openAndroidDocumentResult).not.toHaveBeenCalled()
+  })
+
+  it('continues with a queued incoming open after the active transaction fails', async () => {
+    const { orchestration, options } = createOrchestration({ currentScreen: 'home' })
+    let rejectFirst!: (error: Error) => void
+    const firstOpen = new Promise<void>((_resolve, reject) => {
+      rejectFirst = reject
+    })
+    options.openAndroidDocumentResult
+      .mockImplementationOnce(() => firstOpen)
+      .mockResolvedValue(undefined)
+
+    const first = orchestration.handleOpenWithDocumentEvent({
+      document: incomingDocument,
+      error: null,
+    })
+    await vi.waitFor(() => expect(options.openAndroidDocumentResult).toHaveBeenCalledTimes(1))
+
+    const secondDocument = {
+      ...incomingDocument,
+      sourceUri: 'content://test/second.md',
+      displayName: 'second.md',
+    }
+    await orchestration.handleOpenWithDocumentEvent({ document: secondDocument, error: null })
+
+    rejectFirst(new Error('open failed'))
+    await first
+
+    expect(options.openAndroidDocumentResult).toHaveBeenCalledTimes(2)
+    expect(options.openAndroidDocumentResult).toHaveBeenLastCalledWith(secondDocument, {
+      source: 'open-with',
+      remember: true,
+    })
   })
 
   it('routes a shared Markdown file through the shared open path', async () => {

--- a/src/features/android-documents/incomingDocumentOrchestration.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.ts
@@ -20,6 +20,7 @@ import type {
 import type { AppScreen } from '../../lib/appExitDecisions'
 import type { MarkdownDocumentState } from '../../lib/documentState'
 import { upsertLocalDraft, type LocalDraftRecord } from '../../lib/localDrafts'
+import type { SaveAndroidDocumentOptions } from '../document-session/currentDocumentPersistence'
 
 interface OrchestrationLogger {
   info(message: string, context?: unknown): void
@@ -63,7 +64,7 @@ export interface IncomingDocumentOrchestrationOptions {
     document: OpenedAndroidDocument,
     options?: { source?: AndroidDocumentOpenSource, remember?: boolean },
   ) => Promise<void>
-  saveAndroidDocument: () => Promise<boolean>
+  saveAndroidDocument: (options?: SaveAndroidDocumentOptions) => Promise<boolean>
   saveDraft: () => boolean
   syncDocumentFromEditor: (markDirty: boolean, flushPending: boolean) => void
   persistAndroidRecoveryDraft: (sourceUri: string, markdown: string) => boolean
@@ -129,7 +130,10 @@ export function createIncomingDocumentOrchestration(
 
     if (preservationAction.kind === 'save-android-document') {
       options.syncDocumentFromEditor(options.documentState.value.isDirty, true)
-      const saved = await options.saveAndroidDocument()
+      const saved = await options.saveAndroidDocument({
+        waitForPendingSave: true,
+        persistRecoveryDraftOnFailure: false,
+      })
 
       // Read the payload AFTER the awaited save. A `changed-during-save` result
       // returns false while the editor already holds newer text than the

--- a/src/features/android-documents/incomingDocumentOrchestration.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.ts
@@ -82,6 +82,8 @@ export interface IncomingDocumentOrchestration {
   removeListeners(): void
   handleOpenWithDocumentEvent(event: AndroidOpenWithDocumentEvent): Promise<void>
   handleShareDocumentEvent(event: AndroidShareDocumentEvent): Promise<void>
+  /** Resume the incoming-open queue after the blocked prompt is answered. */
+  resolveIncomingDecision(): Promise<void>
 }
 
 /**
@@ -127,9 +129,16 @@ export function createIncomingDocumentOrchestration(
 
     if (preservationAction.kind === 'save-android-document') {
       options.syncDocumentFromEditor(options.documentState.value.isDirty, true)
+      const saved = await options.saveAndroidDocument()
+
+      // Read the payload AFTER the awaited save. A `changed-during-save` result
+      // returns false while the editor already holds newer text than the
+      // snapshot the save used, so flush and re-read the current content — the
+      // recovery draft and the block decision must reflect the latest edits,
+      // never the pre-save snapshot.
+      options.syncDocumentFromEditor(options.documentState.value.isDirty, true)
       const sourceUri = options.documentState.value.sourceUri
       const markdown = options.documentState.value.markdown
-      const saved = await options.saveAndroidDocument()
 
       // Saved to its file, or there is nothing to lose.
       if (saved || markdown.trim().length === 0) {
@@ -159,19 +168,64 @@ export function createIncomingDocumentOrchestration(
     return { kind: 'blocked' }
   }
 
-  // Either replaces the editor with the incoming document now, or — when the
-  // current document could not be preserved — keeps the editor and asks first.
-  async function runIncomingOpen(
-    preservation: IncomingPreservationResult,
-    incomingName: string,
-    proceed: () => Promise<void>,
-  ) {
+  // Incoming opens are serialized so two intents can never race or replace the
+  // editor behind a pending prompt. Only one transaction runs at a time; while a
+  // blocked prompt awaits the user's decision the editor is frozen, so newer
+  // intents wait (latest-wins) instead of opening. `awaitingDecision` is cleared
+  // by resolveIncomingDecision when the user keeps or discards.
+  let transactionActive = false
+  let awaitingDecision = false
+  let queuedTransaction: (() => Promise<void>) | null = null
+
+  function scheduleIncomingTransaction(transaction: () => Promise<void>) {
+    // Latest-wins: only the newest waiting intent survives.
+    queuedTransaction = transaction
+    return drainIncomingTransactions()
+  }
+
+  async function drainIncomingTransactions(): Promise<void> {
+    if (transactionActive || awaitingDecision) {
+      return
+    }
+
+    const next = queuedTransaction
+    queuedTransaction = null
+    if (!next) {
+      return
+    }
+
+    transactionActive = true
+    try {
+      await next()
+    } finally {
+      transactionActive = false
+    }
+
+    // A blocked transaction leaves awaitingDecision set and pauses the queue
+    // until the user resolves it; otherwise keep draining any newer intent.
+    if (!awaitingDecision) {
+      await drainIncomingTransactions()
+    }
+  }
+
+  // Runs one incoming open: replace the editor now when the current document is
+  // preserved, or keep it mounted and ask (freezing the queue) when it is not.
+  async function runIncomingTransaction(incomingName: string, proceed: () => Promise<void>) {
+    const preservation = await preserveCurrentDocumentBeforeIncomingOpen()
     if (preservation.kind === 'blocked') {
+      awaitingDecision = true
       options.confirmIncomingOpenAfterBlockedPreserve({ incomingName, proceed })
       return
     }
 
     await proceed()
+  }
+
+  // Called by App once the user answers the blocked prompt (keep or discard);
+  // resumes the queue so any intent that arrived while it was open is processed.
+  function resolveIncomingDecision() {
+    awaitingDecision = false
+    return drainIncomingTransactions()
   }
 
   function closeEditorChromeForIncomingOpen() {
@@ -193,14 +247,15 @@ export function createIncomingDocumentOrchestration(
       return
     }
 
-    const preservation = await preserveCurrentDocumentBeforeIncomingOpen()
-    await runIncomingOpen(preservation, action.document.displayName, async () => {
-      closeEditorChromeForIncomingOpen()
-      await options.openAndroidDocumentResult(action.document, {
-        source: action.source,
-        remember: action.remember,
-      })
-    })
+    await scheduleIncomingTransaction(() =>
+      runIncomingTransaction(action.document.displayName, async () => {
+        closeEditorChromeForIncomingOpen()
+        await options.openAndroidDocumentResult(action.document, {
+          source: action.source,
+          remember: action.remember,
+        })
+      }),
+    )
   }
 
   async function handleShareDocumentEvent(event: AndroidShareDocumentEvent) {
@@ -215,23 +270,25 @@ export function createIncomingDocumentOrchestration(
       return
     }
 
-    const preservation = await preserveCurrentDocumentBeforeIncomingOpen()
-
     if (action.kind === 'open-document') {
-      await runIncomingOpen(preservation, action.document.displayName, async () => {
-        closeEditorChromeForIncomingOpen()
-        await options.openAndroidDocumentResult(action.document, {
-          source: action.source,
-          remember: action.remember,
-        })
-      })
+      await scheduleIncomingTransaction(() =>
+        runIncomingTransaction(action.document.displayName, async () => {
+          closeEditorChromeForIncomingOpen()
+          await options.openAndroidDocumentResult(action.document, {
+            source: action.source,
+            remember: action.remember,
+          })
+        }),
+      )
       return
     }
 
-    await runIncomingOpen(preservation, action.document.displayName, async () => {
-      closeEditorChromeForIncomingOpen()
-      await openSharedTextDocument(action.document)
-    })
+    await scheduleIncomingTransaction(() =>
+      runIncomingTransaction(action.document.displayName, async () => {
+        closeEditorChromeForIncomingOpen()
+        await openSharedTextDocument(action.document)
+      }),
+    )
   }
 
   function installListeners() {
@@ -260,5 +317,6 @@ export function createIncomingDocumentOrchestration(
     removeListeners,
     handleOpenWithDocumentEvent,
     handleShareDocumentEvent,
+    resolveIncomingDecision,
   }
 }

--- a/src/features/android-documents/incomingDocumentOrchestration.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.ts
@@ -27,6 +27,20 @@ interface OrchestrationLogger {
   error(message: string, context?: unknown): void
 }
 
+/**
+ * Whether the current document was durably preserved before replacing it with
+ * an incoming one. `blocked` means it holds unsaved content that could not be
+ * saved or recovered, so the editor must stay mounted and the user decides.
+ */
+type IncomingPreservationResult = { kind: 'preserved' } | { kind: 'blocked' }
+
+export interface BlockedIncomingOpenRequest {
+  /** Display name of the incoming document, for the confirmation copy. */
+  incomingName: string
+  /** Runs the deferred replacement once the user chooses to discard. */
+  proceed: () => Promise<void>
+}
+
 export interface IncomingDocumentOrchestrationOptions {
   // App-owned state the incoming flows read and write.
   currentScreen: Ref<AppScreen>
@@ -50,11 +64,14 @@ export interface IncomingDocumentOrchestrationOptions {
     options?: { source?: AndroidDocumentOpenSource, remember?: boolean },
   ) => Promise<void>
   saveAndroidDocument: () => Promise<boolean>
-  saveDraft: () => void
+  saveDraft: () => boolean
   syncDocumentFromEditor: (markDirty: boolean, flushPending: boolean) => void
-  persistAndroidRecoveryDraft: (sourceUri: string, markdown: string) => void
+  persistAndroidRecoveryDraft: (sourceUri: string, markdown: string) => boolean
   canPersistLocalDrafts: () => boolean
   persistLocalDrafts: (drafts: LocalDraftRecord[]) => void
+  // Called instead of replacing the editor when preservation was blocked: keep
+  // the current editor mounted and let the user keep editing or discard + open.
+  confirmIncomingOpenAfterBlockedPreserve: (request: BlockedIncomingOpenRequest) => void
   getAndroidDocumentUserMessage: (error: unknown) => string
   appLogger: OrchestrationLogger
   documentLogger: OrchestrationLogger
@@ -95,7 +112,7 @@ export function createIncomingDocumentOrchestration(
     options.releaseEditorFocusAfterOpen()
   }
 
-  async function preserveCurrentDocumentBeforeIncomingOpen() {
+  async function preserveCurrentDocumentBeforeIncomingOpen(): Promise<IncomingPreservationResult> {
     const preservationAction = getIncomingDocumentPreservationAction({
       currentScreen: options.currentScreen.value,
       hasEditor: options.hasEditor(),
@@ -103,7 +120,7 @@ export function createIncomingDocumentOrchestration(
     })
 
     if (preservationAction.kind === 'none') {
-      return
+      return { kind: 'preserved' }
     }
 
     options.appLogger.info('preserve current document before incoming Android document')
@@ -111,17 +128,50 @@ export function createIncomingDocumentOrchestration(
     if (preservationAction.kind === 'save-android-document') {
       options.syncDocumentFromEditor(options.documentState.value.isDirty, true)
       const sourceUri = options.documentState.value.sourceUri
+      const markdown = options.documentState.value.markdown
       const saved = await options.saveAndroidDocument()
-      if (
-        sourceUri
-        && shouldKeepAndroidRecoveryAfterPreserveFailure(saved, sourceUri, options.documentState.value.markdown)
-      ) {
-        options.persistAndroidRecoveryDraft(sourceUri, options.documentState.value.markdown)
+
+      // Saved to its file, or there is nothing to lose.
+      if (saved || markdown.trim().length === 0) {
+        return { kind: 'preserved' }
       }
+
+      // The save failed with unsaved content: keep it as a recovery draft when
+      // we can. Only a durable recovery write counts as preserved.
+      if (
+        shouldKeepAndroidRecoveryAfterPreserveFailure(saved, sourceUri, markdown)
+        && sourceUri
+        && options.persistAndroidRecoveryDraft(sourceUri, markdown)
+      ) {
+        return { kind: 'preserved' }
+      }
+
+      options.appLogger.warn('incoming open would drop unsaved Android document edits')
+      return { kind: 'blocked' }
+    }
+
+    // Local draft: saveDraft reports whether the content is durably safe.
+    if (options.saveDraft()) {
+      return { kind: 'preserved' }
+    }
+
+    options.appLogger.warn('incoming open would drop an unsaved local draft')
+    return { kind: 'blocked' }
+  }
+
+  // Either replaces the editor with the incoming document now, or — when the
+  // current document could not be preserved — keeps the editor and asks first.
+  async function runIncomingOpen(
+    preservation: IncomingPreservationResult,
+    incomingName: string,
+    proceed: () => Promise<void>,
+  ) {
+    if (preservation.kind === 'blocked') {
+      options.confirmIncomingOpenAfterBlockedPreserve({ incomingName, proceed })
       return
     }
 
-    options.saveDraft()
+    await proceed()
   }
 
   function closeEditorChromeForIncomingOpen() {
@@ -143,11 +193,13 @@ export function createIncomingDocumentOrchestration(
       return
     }
 
-    await preserveCurrentDocumentBeforeIncomingOpen()
-    closeEditorChromeForIncomingOpen()
-    await options.openAndroidDocumentResult(action.document, {
-      source: action.source,
-      remember: action.remember,
+    const preservation = await preserveCurrentDocumentBeforeIncomingOpen()
+    await runIncomingOpen(preservation, action.document.displayName, async () => {
+      closeEditorChromeForIncomingOpen()
+      await options.openAndroidDocumentResult(action.document, {
+        source: action.source,
+        remember: action.remember,
+      })
     })
   }
 
@@ -163,18 +215,23 @@ export function createIncomingDocumentOrchestration(
       return
     }
 
-    await preserveCurrentDocumentBeforeIncomingOpen()
-    closeEditorChromeForIncomingOpen()
+    const preservation = await preserveCurrentDocumentBeforeIncomingOpen()
 
     if (action.kind === 'open-document') {
-      await options.openAndroidDocumentResult(action.document, {
-        source: action.source,
-        remember: action.remember,
+      await runIncomingOpen(preservation, action.document.displayName, async () => {
+        closeEditorChromeForIncomingOpen()
+        await options.openAndroidDocumentResult(action.document, {
+          source: action.source,
+          remember: action.remember,
+        })
       })
       return
     }
 
-    await openSharedTextDocument(action.document)
+    await runIncomingOpen(preservation, action.document.displayName, async () => {
+      closeEditorChromeForIncomingOpen()
+      await openSharedTextDocument(action.document)
+    })
   }
 
   function installListeners() {

--- a/src/features/android-documents/incomingDocumentOrchestration.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.ts
@@ -140,8 +140,10 @@ export function createIncomingDocumentOrchestration(
       const sourceUri = options.documentState.value.sourceUri
       const markdown = options.documentState.value.markdown
 
-      // Saved to its file, or there is nothing to lose.
-      if (saved || markdown.trim().length === 0) {
+      // A blank snapshot can still be an unsaved deletion of previously
+      // persisted content. Only the save result proves that the current editor
+      // state reached the provider.
+      if (saved) {
         return { kind: 'preserved' }
       }
 
@@ -197,6 +199,11 @@ export function createIncomingDocumentOrchestration(
     transactionActive = true
     try {
       await next()
+    } catch (error) {
+      const message = options.getAndroidDocumentUserMessage(error)
+      options.homeNotice.value = message
+      options.status.value = message
+      options.documentLogger.error('incoming Android document transaction failed', error)
     } finally {
       transactionActive = false
     }

--- a/src/features/document-session/currentDocumentPersistence.test.ts
+++ b/src/features/document-session/currentDocumentPersistence.test.ts
@@ -177,6 +177,52 @@ describe('currentDocumentPersistence', () => {
     expect(disabled.options.persistLocalDrafts).not.toHaveBeenCalled()
   })
 
+  it('reports whether the local draft is durably safe for the incoming-open guard', () => {
+    const dirty = updateDocumentMarkdown(
+      createUntitledDocument({ markdown: '', autosaveTarget: 'local-draft' }),
+      '# Draft body',
+      { markDirty: true },
+    )
+
+    // Persisted content, or nothing to keep, is durable.
+    expect(createPersistence({ documentState: dirty }).persistence.saveDraft()).toBe(true)
+    expect(
+      createPersistence({ canPersistLocalDrafts: false, markdownSnapshot: '   ' })
+        .persistence.saveDraft(),
+    ).toBe(true)
+
+    // Content that cannot be persisted (drafts disabled, or a storage failure) is not.
+    expect(
+      createPersistence({ canPersistLocalDrafts: false, markdownSnapshot: '# unsaved' })
+        .persistence.saveDraft(),
+    ).toBe(false)
+
+    const failing = createPersistence({ documentState: dirty })
+    failing.options.persistLocalDrafts.mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+    expect(failing.persistence.saveDraft()).toBe(false)
+    expect(failing.options.status.value).toBe('Autosave failed')
+  })
+
+  it('reports whether an Android recovery draft was durably written', () => {
+    const kept = createPersistence()
+    expect(kept.persistence.persistAndroidRecoveryDraft(ANDROID_URI, '# edits')).toBe(true)
+    expect(
+      kept.options.localDrafts.value.some(draft => draft.id === `android-recovery:${ANDROID_URI}`),
+    ).toBe(true)
+
+    const disabled = createPersistence({ canPersistRecoveryDrafts: false })
+    expect(disabled.persistence.persistAndroidRecoveryDraft(ANDROID_URI, '# edits')).toBe(false)
+    expect(disabled.options.persistLocalDrafts).not.toHaveBeenCalled()
+
+    const failing = createPersistence()
+    failing.options.persistLocalDrafts.mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+    expect(failing.persistence.persistAndroidRecoveryDraft(ANDROID_URI, '# edits')).toBe(false)
+  })
+
   it('saves a dirty Android document, updates recents, and drops its recovery draft', async () => {
     const recoveryDraft: LocalDraftRecord = {
       id: `android-recovery:${ANDROID_URI}`,

--- a/src/features/document-session/currentDocumentPersistence.test.ts
+++ b/src/features/document-session/currentDocumentPersistence.test.ts
@@ -279,6 +279,35 @@ describe('currentDocumentPersistence', () => {
     expect(options.status.value).toBe('user message: disk full')
   })
 
+  it('defers recovery persistence when the caller needs the latest editor snapshot', async () => {
+    const { persistence, options } = createPersistence({
+      documentState: dirtyAndroidDocumentState(),
+      androidDocuments: [androidRecentRecord()],
+    })
+    options.writeAndroidMarkdownDocument.mockRejectedValue(new Error('disk full'))
+
+    const saved = await persistence.saveAndroidDocument({ persistRecoveryDraftOnFailure: false })
+
+    expect(saved).toBe(false)
+    expect(options.persistLocalDrafts).not.toHaveBeenCalled()
+    expect(options.status.value).toBe('user message: disk full')
+  })
+
+  it('does not report a recovery draft that storage failed to persist', async () => {
+    const { persistence, options } = createPersistence({
+      documentState: dirtyAndroidDocumentState(),
+      androidDocuments: [androidRecentRecord()],
+    })
+    options.writeAndroidMarkdownDocument.mockRejectedValue(new Error('disk full'))
+    options.persistLocalDrafts.mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+
+    await persistence.saveAndroidDocument()
+
+    expect(options.status.value).toBe('user message: disk full')
+  })
+
   it('coalesces overlapping Android saves and reschedules once the first completes', async () => {
     const { persistence, options } = createPersistence({
       documentState: dirtyAndroidDocumentState(),
@@ -300,6 +329,30 @@ describe('currentDocumentPersistence', () => {
     await first
 
     expect(options.scheduleAndroidDocumentSave).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for an active Android save and then persists the latest editor snapshot', async () => {
+    const { persistence, options } = createPersistence({
+      documentState: dirtyAndroidDocumentState(),
+      androidDocuments: [androidRecentRecord()],
+    })
+    let releaseFirstWrite!: () => void
+    options.writeAndroidMarkdownDocument
+      .mockImplementationOnce(() => new Promise<void>(resolve => (releaseFirstWrite = resolve)))
+      .mockResolvedValueOnce(undefined)
+
+    const first = persistence.saveAndroidDocument()
+    options.documentState.value = dirtyAndroidDocumentState('# latest edits')
+    const guarded = persistence.saveAndroidDocument({ waitForPendingSave: true })
+
+    await Promise.resolve()
+    expect(options.writeAndroidMarkdownDocument).toHaveBeenCalledTimes(1)
+
+    releaseFirstWrite()
+    await expect(first).resolves.toBe(false)
+    await expect(guarded).resolves.toBe(true)
+    expect(options.writeAndroidMarkdownDocument).toHaveBeenCalledTimes(2)
+    expect(options.writeAndroidMarkdownDocument.mock.calls[1][1]).toBe('# latest edits')
   })
 
   it('flushes to the save path matching the current autosave target', async () => {

--- a/src/features/document-session/currentDocumentPersistence.test.ts
+++ b/src/features/document-session/currentDocumentPersistence.test.ts
@@ -365,6 +365,32 @@ describe('currentDocumentPersistence', () => {
     expect(home.options.clearDraftSaveTimer).not.toHaveBeenCalled()
   })
 
+  it('waits for an active Android save during a lifecycle flush', async () => {
+    const { persistence, options } = createPersistence({
+      documentState: dirtyAndroidDocumentState(),
+      androidDocuments: [androidRecentRecord()],
+    })
+    let releaseFirstWrite!: () => void
+    options.writeAndroidMarkdownDocument
+      .mockImplementationOnce(() => new Promise<void>(resolve => (releaseFirstWrite = resolve)))
+      .mockResolvedValueOnce(undefined)
+
+    const first = persistence.saveAndroidDocument()
+    options.documentState.value = dirtyAndroidDocumentState('# edits before backgrounding')
+    const flush = persistence.flushCurrentDocument('app pause')
+
+    await Promise.resolve()
+    expect(options.writeAndroidMarkdownDocument).toHaveBeenCalledTimes(1)
+
+    releaseFirstWrite()
+    await expect(first).resolves.toBe(false)
+    await flush
+    expect(options.writeAndroidMarkdownDocument).toHaveBeenCalledTimes(2)
+    expect(options.writeAndroidMarkdownDocument.mock.calls[1][1]).toBe(
+      '# edits before backgrounding',
+    )
+  })
+
   it('saves a local draft to the device and cleans up the draft copy', async () => {
     const dirtyDraft = updateDocumentMarkdown(
       createUntitledDocument({ markdown: '', autosaveTarget: 'local-draft' }),

--- a/src/features/document-session/currentDocumentPersistence.ts
+++ b/src/features/document-session/currentDocumentPersistence.ts
@@ -610,7 +610,7 @@ export function createCurrentDocumentPersistence(
     })
 
     if (options.documentState.value.autosaveTarget === 'android-document') {
-      await saveAndroidDocument()
+      await saveAndroidDocument({ waitForPendingSave: true })
     } else {
       saveDraft()
     }

--- a/src/features/document-session/currentDocumentPersistence.ts
+++ b/src/features/document-session/currentDocumentPersistence.ts
@@ -124,12 +124,19 @@ export interface CurrentDocumentPersistence {
    * content that could not be kept (drafts disabled, or a storage failure).
    */
   saveDraft(): boolean
-  saveAndroidDocument(): Promise<boolean>
+  saveAndroidDocument(options?: SaveAndroidDocumentOptions): Promise<boolean>
   saveLocalDraftToAndroidDocument(options?: { returnHomeAfterSave?: boolean }): Promise<boolean>
   saveAndroidDocumentCopy(options?: { returnHomeAfterSave?: boolean }): Promise<boolean>
   shareCurrentMarkdownDocument(): Promise<boolean>
   exportCurrentDocumentPdf(): Promise<boolean>
   flushCurrentDocument(reason: string): Promise<void>
+}
+
+export interface SaveAndroidDocumentOptions {
+  /** Wait for a coalesced save and then retry with the current editor snapshot. */
+  waitForPendingSave?: boolean
+  /** Let a caller that owns a fresher snapshot defer recovery persistence. */
+  persistRecoveryDraftOnFailure?: boolean
 }
 
 /**
@@ -142,7 +149,7 @@ export interface CurrentDocumentPersistence {
 export function createCurrentDocumentPersistence(
   options: CurrentDocumentPersistenceOptions,
 ): CurrentDocumentPersistence {
-  let androidSaveInFlight = false
+  let activeAndroidSave: Promise<boolean> | null = null
   let androidSaveRequestedAfterCurrent = false
 
   function persistAndroidRecoveryDraft(sourceUri: string, markdown: string): boolean {
@@ -252,7 +259,7 @@ export function createCurrentDocumentPersistence(
     }
   }
 
-  async function saveAndroidDocument() {
+  async function saveAndroidDocument(saveOptions: SaveAndroidDocumentOptions = {}) {
     options.clearAndroidDocumentSaveTimer()
 
     if (!options.hasEditor()) {
@@ -288,16 +295,20 @@ export function createCurrentDocumentPersistence(
       return startResult.saved
     }
 
-    if (androidSaveInFlight) {
+    if (activeAndroidSave) {
+      if (saveOptions.waitForPendingSave) {
+        await activeAndroidSave
+        return saveAndroidDocument(saveOptions)
+      }
+
       androidSaveRequestedAfterCurrent = true
       return false
     }
 
-    androidSaveInFlight = true
     options.documentState.value = startResult.request.savingDocument
     options.status.value = startResult.status
 
-    try {
+    const saveOperation = (async () => {
       const result = await saveAndroidDocumentWorkflow({
         request: startResult.request,
         getCurrentDocumentState: () => options.documentState.value,
@@ -320,15 +331,23 @@ export function createCurrentDocumentPersistence(
       }
 
       options.documentState.value = result.failedDocument
-      if (options.canPersistAndroidRecoveryDrafts()) {
-        persistAndroidRecoveryDraft(result.recoveryDraft.sourceUri, result.recoveryDraft.markdown)
-        options.status.value = result.status
-      } else {
-        options.status.value = options.getAndroidDocumentUserMessage(result.error)
-      }
+      const recoveryKept =
+        saveOptions.persistRecoveryDraftOnFailure !== false
+        && options.canPersistAndroidRecoveryDrafts()
+        && persistAndroidRecoveryDraft(result.recoveryDraft.sourceUri, result.recoveryDraft.markdown)
+      options.status.value = recoveryKept
+        ? result.status
+        : options.getAndroidDocumentUserMessage(result.error)
       return false
+    })()
+    activeAndroidSave = saveOperation
+
+    try {
+      return await saveOperation
     } finally {
-      androidSaveInFlight = false
+      if (activeAndroidSave === saveOperation) {
+        activeAndroidSave = null
+      }
       if (androidSaveRequestedAfterCurrent) {
         androidSaveRequestedAfterCurrent = false
         if (

--- a/src/features/document-session/currentDocumentPersistence.ts
+++ b/src/features/document-session/currentDocumentPersistence.ts
@@ -115,9 +115,15 @@ export interface CurrentDocumentPersistenceOptions {
 }
 
 export interface CurrentDocumentPersistence {
-  persistAndroidRecoveryDraft(sourceUri: string, markdown: string): void
+  /** Returns whether the recovery draft was durably written to storage. */
+  persistAndroidRecoveryDraft(sourceUri: string, markdown: string): boolean
   removeAndroidRecoveryDraft(sourceUri: string): void
-  saveDraft(): void
+  /**
+   * Returns whether the current local-draft content is durably safe: true when
+   * it was persisted or there was nothing to persist, false when there was
+   * content that could not be kept (drafts disabled, or a storage failure).
+   */
+  saveDraft(): boolean
   saveAndroidDocument(): Promise<boolean>
   saveLocalDraftToAndroidDocument(options?: { returnHomeAfterSave?: boolean }): Promise<boolean>
   saveAndroidDocumentCopy(options?: { returnHomeAfterSave?: boolean }): Promise<boolean>
@@ -139,25 +145,32 @@ export function createCurrentDocumentPersistence(
   let androidSaveInFlight = false
   let androidSaveRequestedAfterCurrent = false
 
-  function persistAndroidRecoveryDraft(sourceUri: string, markdown: string) {
+  function persistAndroidRecoveryDraft(sourceUri: string, markdown: string): boolean {
     if (!options.canPersistAndroidRecoveryDrafts()) {
       options.documentLogger.warn('skip Android recovery draft because recovery drafts are disabled', {
         sourceUri,
         characters: markdown.length,
       })
-      return
+      return false
     }
 
     const recoveryDraft = createAndroidRecoveryDraft(sourceUri, markdown, new Date().toISOString())
     if (!recoveryDraft) {
-      return
+      return false
     }
 
-    options.persistLocalDrafts(upsertLocalDraft(options.localDrafts.value, recoveryDraft))
+    try {
+      options.persistLocalDrafts(upsertLocalDraft(options.localDrafts.value, recoveryDraft))
+    } catch (error) {
+      options.draftLogger.error('failed to persist Android recovery draft', { sourceUri, error })
+      return false
+    }
+
     options.draftLogger.warn('kept Android document edits as a local recovery draft', {
       sourceUri,
       characters: markdown.length,
     })
+    return true
   }
 
   function removeAndroidRecoveryDraft(sourceUri: string) {
@@ -191,11 +204,11 @@ export function createCurrentDocumentPersistence(
     removeAndroidRecoveryDraft(sourceUri)
   }
 
-  function saveDraft() {
+  function saveDraft(): boolean {
     options.clearDraftSaveTimer()
 
     if (!options.hasEditor()) {
-      return
+      return true
     }
 
     if (options.documentState.value.autosaveTarget !== 'local-draft') {
@@ -204,18 +217,20 @@ export function createCurrentDocumentPersistence(
         sourceUri: options.documentState.value.sourceUri,
         autosaveState: options.documentState.value.autosaveState,
       })
-      return
+      return true
     }
+
+    const value = options.getEditorMarkdownSnapshot(true)
 
     if (!options.canPersistLocalDrafts()) {
       options.clearDraftSaveTimer()
       options.draftLogger.debug('skip local draft save because local drafts are disabled', {
         id: options.documentState.value.id,
       })
-      return
+      // Nothing was persisted; the content is only safe if there is none to keep.
+      return value.trim().length === 0
     }
 
-    const value = options.getEditorMarkdownSnapshot(true)
     const localDraftAutosave = createLocalDraftAutosaveResult(
       options.documentState.value,
       value,
@@ -228,10 +243,12 @@ export function createCurrentDocumentPersistence(
       options.documentState.value = localDraftAutosave.savedDocument
       options.status.value = localDraftAutosave.hasContent ? 'Autosaved locally' : 'Ready'
       options.draftLogger.debug('local draft saved', options.getDraftLogStats())
+      return true
     } catch (error) {
       options.documentState.value = markDocumentSaveFailed(options.documentState.value, error)
       options.status.value = 'Autosave failed'
       options.draftLogger.error('local draft save failed', error)
+      return false
     }
   }
 

--- a/src/features/editor/EditorScreen.vue
+++ b/src/features/editor/EditorScreen.vue
@@ -242,7 +242,7 @@ onBeforeUnmount(() => {
       v-if="searchOpen"
       class="top-bar search-bar"
       data-testid="editor-search-bar"
-      :inert="outlineOpen || tableSheetOpen"
+      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
     >
       <button
         class="nav-button"
@@ -308,7 +308,7 @@ onBeforeUnmount(() => {
         </button>
       </div>
     </header>
-    <header v-else class="top-bar" :inert="outlineOpen || tableSheetOpen">
+    <header v-else class="top-bar" :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen">
       <button
         class="nav-button"
         type="button"
@@ -375,7 +375,7 @@ onBeforeUnmount(() => {
       </div>
     </header>
 
-    <section class="editor-pane" :aria-label="t('editor.markdownEditor')" :inert="outlineOpen || tableSheetOpen">
+    <section class="editor-pane" :aria-label="t('editor.markdownEditor')" :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen">
       <div
         ref="editorShell"
         class="editor-host-shell"
@@ -407,7 +407,7 @@ onBeforeUnmount(() => {
     </section>
 
     <MobileSelectionToolbar
-      :inert="outlineOpen || tableSheetOpen"
+      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
       :editor-ready="editorReady"
       :suspended="selectionToolbarSuspended"
       :host="editorShell"
@@ -425,7 +425,7 @@ onBeforeUnmount(() => {
     />
 
     <LinkActionOverlay
-      :inert="outlineOpen || tableSheetOpen"
+      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
       :editor-ready="editorReady"
       :suspended="selectionToolbarSuspended"
       :caret-session="selectionCaretSession"
@@ -436,7 +436,7 @@ onBeforeUnmount(() => {
 
     <MobileEditorToolbar
       v-if="toolbarVisible && !editorFailed"
-      :inert="outlineOpen || tableSheetOpen"
+      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
       :expanded="toolbarExpanded"
       :active-panel="toolbarPanel"
       :editor-ready="editorReady"

--- a/src/features/editor/EditorScreen.vue
+++ b/src/features/editor/EditorScreen.vue
@@ -8,6 +8,7 @@ import OutlineSheet from './components/OutlineSheet.vue'
 import LinkInsertSheet from './components/LinkInsertSheet.vue'
 import TableInsertSheet from './components/TableInsertSheet.vue'
 import LocalDraftExitPrompt from './components/LocalDraftExitPrompt.vue'
+import IncomingOpenPrompt from './components/IncomingOpenPrompt.vue'
 import MobileEditorToolbar from './components/MobileEditorToolbar.vue'
 import MobileSelectionToolbar from './components/MobileSelectionToolbar.vue'
 import LinkActionOverlay from './components/LinkActionOverlay.vue'
@@ -60,6 +61,8 @@ const props = defineProps<{
   androidCanSaveCopy: boolean
   androidCanKeepRecovery: boolean
   androidSaving: boolean
+  incomingOpenPromptOpen: boolean
+  incomingOpenName: string
   textDirection: 'ltr' | 'rtl'
   editorStyleVars: CSSProperties
   canPasteSelection: boolean
@@ -116,6 +119,8 @@ const emit = defineEmits<{
   'save-android-copy': []
   'keep-android-recovery': []
   'discard-android-changes': []
+  'keep-incoming': []
+  'discard-incoming': []
   'editor-host-change': [element: HTMLElement | null]
 }>()
 
@@ -136,7 +141,8 @@ const selectionToolbarSuspended = computed(
     props.linkSheetOpen ||
     props.tableSheetOpen ||
     props.draftExitPromptOpen ||
-    props.androidExitPromptOpen,
+    props.androidExitPromptOpen ||
+    props.incomingOpenPromptOpen,
 )
 
 const searchInput = ref<HTMLInputElement | null>(null)
@@ -519,6 +525,15 @@ onBeforeUnmount(() => {
         @save-copy="emit('save-android-copy')"
         @keep-recovery="emit('keep-android-recovery')"
         @discard="emit('discard-android-changes')"
+      />
+    </Transition>
+
+    <Transition name="editor-sheet">
+      <IncomingOpenPrompt
+        v-if="incomingOpenPromptOpen"
+        :incoming-name="incomingOpenName"
+        @keep="emit('keep-incoming')"
+        @discard="emit('discard-incoming')"
       />
     </Transition>
   </main>

--- a/src/features/editor/components/IncomingOpenPrompt.vue
+++ b/src/features/editor/components/IncomingOpenPrompt.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useI18n } from '../../../lib/i18n'
 
 defineProps<{
@@ -11,6 +12,56 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const panel = ref<HTMLElement | null>(null)
+const keepButton = ref<HTMLButtonElement | null>(null)
+// Return focus to wherever it was (typically the editor) once the prompt closes.
+let previouslyFocused: HTMLElement | null = null
+
+onMounted(() => {
+  previouslyFocused =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null
+  // "Keep editing" is the safe default, so it takes focus on open.
+  void nextTick(() => {
+    keepButton.value?.focus()
+  })
+})
+
+onBeforeUnmount(() => {
+  if (previouslyFocused?.isConnected) {
+    previouslyFocused.focus({ preventScroll: true })
+  }
+})
+
+// aria-modal does not contain focus, so trap Tab within the two actions.
+function trapTabKey(event: KeyboardEvent) {
+  const root = panel.value
+  if (!root) {
+    return
+  }
+
+  const focusables = Array.from(root.querySelectorAll<HTMLElement>('button:not(:disabled)'))
+  if (focusables.length === 0) {
+    event.preventDefault()
+    return
+  }
+
+  const first = focusables[0]
+  const last = focusables[focusables.length - 1]
+  const active = document.activeElement
+
+  if (event.shiftKey) {
+    if (active === first || active === root) {
+      event.preventDefault()
+      last.focus()
+    }
+    return
+  }
+
+  if (active === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
 </script>
 
 <template>
@@ -20,12 +71,15 @@ const { t } = useI18n()
     aria-modal="true"
     aria-labelledby="incoming-open-title"
     data-testid="incoming-open-prompt"
+    @keydown.esc="emit('keep')"
+    @keydown.tab="trapTabKey"
   >
-    <div class="draft-save-panel">
+    <div ref="panel" class="draft-save-panel">
       <h2 id="incoming-open-title">{{ t('editor.incomingOpen.title') }}</h2>
       <p>{{ t('editor.incomingOpen.body', { name: incomingName }) }}</p>
       <div class="draft-save-actions">
         <button
+          ref="keepButton"
           class="primary-action"
           type="button"
           data-testid="prompt-keep-editing-button"

--- a/src/features/editor/components/IncomingOpenPrompt.vue
+++ b/src/features/editor/components/IncomingOpenPrompt.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { useI18n } from '../../../lib/i18n'
+
+defineProps<{
+  incomingName: string
+}>()
+
+const emit = defineEmits<{
+  keep: []
+  discard: []
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <section
+    class="draft-save-sheet"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="incoming-open-title"
+    data-testid="incoming-open-prompt"
+  >
+    <div class="draft-save-panel">
+      <h2 id="incoming-open-title">{{ t('editor.incomingOpen.title') }}</h2>
+      <p>{{ t('editor.incomingOpen.body', { name: incomingName }) }}</p>
+      <div class="draft-save-actions">
+        <button
+          class="primary-action"
+          type="button"
+          data-testid="prompt-keep-editing-button"
+          @click="emit('keep')"
+        >
+          {{ t('editor.incomingOpen.keep') }}
+        </button>
+        <button
+          class="danger-action"
+          type="button"
+          data-testid="prompt-discard-open-incoming-button"
+          @click="emit('discard')"
+        >
+          {{ t('editor.incomingOpen.discard') }}
+        </button>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/lib/appExitDecisions.test.ts
+++ b/src/lib/appExitDecisions.test.ts
@@ -13,6 +13,7 @@ const baseBackState: AppBackButtonState = {
   currentScreen: 'home',
   homeTab: HOME_TABS.DOCUMENTS,
   settingsPage: SETTINGS_PAGES.INDEX,
+  incomingOpenPromptOpen: false,
   androidExitPromptOpen: false,
   draftExitPromptOpen: false,
   linkSheetOpen: false,
@@ -59,6 +60,18 @@ describe('appExitDecisions', () => {
   })
 
   it('preserves Android back priority for prompts, sheets, menu, toolbar, and editor exit', () => {
+    // The blocked-preservation prompt guards unsaved work above every other layer.
+    expect(getAppBackButtonAction({
+      ...baseBackState,
+      currentScreen: 'editor',
+      incomingOpenPromptOpen: true,
+      androidExitPromptOpen: true,
+      draftExitPromptOpen: true,
+      linkSheetOpen: true,
+      editorMenuOpen: true,
+      editorToolbarExpanded: true,
+    })).toBe('close-incoming-open-prompt')
+
     expect(getAppBackButtonAction({
       ...baseBackState,
       currentScreen: 'editor',

--- a/src/lib/appExitDecisions.ts
+++ b/src/lib/appExitDecisions.ts
@@ -16,6 +16,7 @@ export interface AppBackButtonState {
   currentScreen: AppScreen
   homeTab: HomeTab
   settingsPage: SettingsPage
+  incomingOpenPromptOpen: boolean
   androidExitPromptOpen: boolean
   draftExitPromptOpen: boolean
   linkSheetOpen: boolean
@@ -29,6 +30,7 @@ export interface AppBackButtonState {
 }
 
 export type AppBackButtonAction =
+  | 'close-incoming-open-prompt'
   | 'close-android-exit-prompt'
   | 'close-local-draft-exit-prompt'
   | 'close-link-sheet'
@@ -76,6 +78,7 @@ export function getAppBackButtonAction({
   currentScreen,
   homeTab,
   settingsPage,
+  incomingOpenPromptOpen,
   androidExitPromptOpen,
   draftExitPromptOpen,
   linkSheetOpen,
@@ -87,6 +90,11 @@ export function getAppBackButtonAction({
   homeSelectionActive,
   homeSheetOpen,
 }: AppBackButtonState): AppBackButtonAction {
+  // The blocked-preservation prompt guards unsaved work; Back keeps editing.
+  if (incomingOpenPromptOpen) {
+    return 'close-incoming-open-prompt'
+  }
+
   if (androidExitPromptOpen) {
     return 'close-android-exit-prompt'
   }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -149,6 +149,11 @@ const MESSAGES = {
       'This file cannot be saved directly. Save a copy or keep a recovery draft before leaving.',
     'editor.exit.androidSaveFailedMessage':
       'MarkText could not save this file. Save a copy or keep a recovery draft before leaving.',
+    'editor.incomingOpen.title': 'Discard unsaved changes?',
+    'editor.incomingOpen.body':
+      'Opening “{name}” will replace the current document, but its unsaved changes couldn’t be saved. Keep editing, or discard them and open the new one?',
+    'editor.incomingOpen.keep': 'Keep editing',
+    'editor.incomingOpen.discard': 'Discard & open',
 
     'toolbar.markdownTools': 'Markdown editing tools',
     'toolbar.quickActions': 'Quick editing actions',
@@ -716,6 +721,11 @@ const MESSAGES = {
       '此文件不能直接保存。离开前请保存副本，或保留恢复草稿。',
     'editor.exit.androidSaveFailedMessage':
       'MarkText 未能保存此文件。离开前请保存副本，或保留恢复草稿。',
+    'editor.incomingOpen.title': '要丢弃未保存的更改吗？',
+    'editor.incomingOpen.body':
+      '打开「{name}」会替换当前文档，但它未保存的更改无法保存。是继续编辑，还是丢弃更改并打开新文档？',
+    'editor.incomingOpen.keep': '继续编辑',
+    'editor.incomingOpen.discard': '丢弃并打开',
 
     'toolbar.markdownTools': 'Markdown 编辑工具',
     'toolbar.quickActions': '快捷编辑操作',


### PR DESCRIPTION
## Problem

An incoming Android Intent replaced the live document even when preserving it failed. **[P1 — data safety / document lifecycle]**

`preserveCurrentDocumentBeforeIncomingOpen()` returned no result: it awaited `saveAndroidDocument()`, optionally attempted a recovery draft, and returned. Both incoming handlers then **unconditionally** continued to `openAndroidDocumentResult()` or shared-text replacement. Local-draft preservation had the same gap because `saveDraft()` converted storage failures into UI state but returned nothing.

So the current editor could be silently replaced — losing unsaved work — after:

- the source file was moved or deleted (Android save fails with `FileNotFoundException`);
- an Android document save otherwise failed;
- "Save failed drafts" (recovery drafts) was disabled;
- local drafts were disabled;
- `localStorage` persistence failed;
- or a second save arrived while another Android save was in flight.

An unsolicited external Intent is not a deliberate "leave this document," so dropping unsaved work here violated the product's **"never lose a word"** bar.

## Fix — ask before discarding (honors settings; no silent override)

Make preservation report its outcome and only replace the editor after it durably completes.

- `preserveCurrentDocumentBeforeIncomingOpen()` now returns `preserved | blocked`.
  - `saveDraft()` returns whether the local draft is durably safe (persisted, or there was nothing to keep).
  - `persistAndroidRecoveryDraft()` returns whether it actually wrote, and no longer throws on a storage failure.
  - An Android document is `preserved` when it saved, had nothing to lose, or a recovery draft was durably kept — otherwise `blocked`.
- When preservation is **blocked**, the editor stays mounted and a calm `IncomingOpenPrompt` asks: **Keep editing** (default, safe) or **Discard & open**. This respects the user's recovery/local-draft settings rather than silently overriding them, and mirrors the app's existing unsaved-changes exit prompts. **Android Back** maps to "keep editing" above every other layer.

The **happy path is unchanged**: when preservation succeeds the incoming document opens with no prompt.

### Why ask instead of always keeping a silent recovery draft

The crash-recovery-draft direction is unconditional precisely because a crash can't prompt. Here the app is foregrounded and the user just interacted, so we *can* ask — and asking honors a user who deliberately turned draft persistence off, instead of writing a draft they opted out of.

## Design note

`IncomingOpenPrompt.vue` reuses the existing exit-prompt styles/pattern. The "Keep editing" action is visually primary (the safe default); "Discard & open" is the danger action. If the user keeps editing, the incoming document is dropped and can be re-triggered from the source app. ("Save a copy…" is a natural fast-follow, deliberately left out of this PR.)

## Verification

- Unit (`vitest run src`): **491 passed** — added orchestration `blocked`/`discard` paths, persistence durability signals (`saveDraft` / `persistAndroidRecoveryDraft`), and the Back-priority of the new prompt.
- `npm run typecheck` (vue-tsc -b): clean.
- `npm run lint` (eslint, `--max-warnings 0`): clean.
- Focused e2e `mobile-share-intent.spec.ts`: **9/9 passed** (happy-path preservation unbroken).

## Files

10 changed (+378 / −33) + new `IncomingOpenPrompt.vue`: orchestration result + handlers, persistence durability returns, App state/handlers/Back wiring, `EditorScreen` props/events, `appExitDecisions` Back action, en/zh i18n.
