### PR TITLE
Scroll a wide table inside its figure, not the whole editor

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -835,7 +835,12 @@ body {
   width: min(100%, 980px);
   height: 100%;
   margin: 0 auto;
-  overflow: auto;
+  /* Vertical-only scroll owner. Horizontal overflow must never slide the whole
+     editor: each wide block owns its own horizontal scroll — tables via the
+     figure.mu-table rule below, code and math blocks internally — while images
+     cap at 100% and Muya's floating UI mounts on <body>, so nothing inside
+     needs to scroll the root sideways. */
+  overflow: hidden auto;
   border: var(--hairline) solid var(--separator);
   border-radius: var(--radius);
   background: var(--surface);
@@ -850,6 +855,17 @@ body {
 .editor-host-shell .mu-editor {
   min-height: 100%;
   padding: 42px 0 56px;
+}
+
+/* A wide table scrolls inside its own figure instead of sliding the whole
+   editor. Muya's 10em cell min-width keeps columns readable, so a normal
+   multi-column table is wider than a phone column; the figure clips and scrolls
+   it horizontally while the vertical-only host stays put. Android registers no
+   table drag/resize plugins and Muya's float UI lives on <body>, so nothing is
+   clipped by owning the overflow here. */
+.editor-host-shell figure.mu-table {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* MIUI WebViews pin CJK glyphs to one weight: 400 and 700 rasterize to

--- a/tests/e2e/mobile-table-scroll.spec.ts
+++ b/tests/e2e/mobile-table-scroll.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test'
+import { openLocalDraft } from './helpers/drafts'
+
+test.describe.configure({ timeout: 60000 })
+
+// Five 10em columns are far wider than a Pixel 5 portrait editor column, so the
+// table reliably exercises the horizontal-overflow path.
+const WIDE_TABLE_MARKDOWN = `# Wide table
+
+| Alpha | Bravo | Charlie | Delta | Echo |
+| --- | --- | --- | --- | --- |
+| one | two | three | four | five |
+| six | seven | eight | nine | ten |
+`
+
+async function overflow(locator: import('@playwright/test').Locator) {
+  return locator.evaluate(el => ({
+    scrollWidth: el.scrollWidth,
+    clientWidth: el.clientWidth,
+    scrollLeft: el.scrollLeft,
+  }))
+}
+
+test('a wide table scrolls inside its own figure, never the editor root', async ({ page }) => {
+  await openLocalDraft(page, {
+    id: 'wide-table-draft',
+    markdown: WIDE_TABLE_MARKDOWN,
+    title: /Wide table/,
+    now: '2026-07-01T10:00:00.000Z',
+  })
+
+  const table = page.getByTestId('editor-host').locator('figure.mu-table')
+  const shell = page.locator('.editor-host-shell')
+  await expect(table).toBeVisible()
+
+  // The table genuinely overflows its own figure — the horizontal scroll it owns.
+  const tableBefore = await overflow(table)
+  expect(tableBefore.scrollWidth).toBeGreaterThan(tableBefore.clientWidth)
+
+  // The editor root does not overflow sideways: nothing slides the whole editor.
+  const shellBefore = await overflow(shell)
+  expect(shellBefore.scrollWidth).toBeLessThanOrEqual(shellBefore.clientWidth + 1)
+
+  // Swiping the table scrolls the table itself...
+  await table.evaluate(el => el.scrollTo({ left: 9999 }))
+  expect((await overflow(table)).scrollLeft).toBeGreaterThan(0)
+
+  // ...while the editor root stays pinned and cannot be scrolled horizontally.
+  await shell.evaluate(el => el.scrollTo({ left: 9999 }))
+  expect((await overflow(shell)).scrollLeft).toBe(0)
+
+  // Landscape keeps the same invariant: the wide table still owns its overflow
+  // and the root never slides horizontally.
+  await page.setViewportSize({ width: 851, height: 393 })
+  const shellLandscape = await overflow(shell)
+  expect(shellLandscape.scrollWidth).toBeLessThanOrEqual(shellLandscape.clientWidth + 1)
+})


### PR DESCRIPTION
## Problem

A wide table scrolled the entire editor instead of the table itself. **[P1 — responsive design / editor usability]**

`.editor-host-shell` owned both horizontal and vertical scrolling via `overflow: auto`, and no block owned the table's horizontal overflow. Muya gives table cells a `10em` min-width (`blockSyntax.css:978`), so a normal four-column table is wider than a portrait phone column. Swiping horizontally over it moved the **entire editor root** — paragraphs, code blocks, images, and the document itself slid off-screen, leaving a large blank area while the app chrome stayed fixed.

## Fix

Make the table figure own its horizontal overflow, and make the editor root vertical-only.

- **`.editor-host-shell figure.mu-table { overflow-x: auto }`** — a table wider than its column now scrolls **within its own figure**. The caret still scrolls the table into view while editing.
- **`.editor-host-shell { overflow: hidden auto }`** (was `overflow: auto`) — the editor root is now vertical-only and can never slide sideways again.

### Why the root can be vertical-only without clipping anything

Every other wide block already owns its overflow, so nothing legitimately needs to scroll the root horizontally:

- code blocks scroll internally (`.mu-code { overflow: auto }`);
- math previews scroll internally (`overflow: auto hidden`);
- images cap at `max-width: 100%`;
- text/inline code wrap (`overflow-wrap: break-word`);
- Muya's floating UI (toolbars, selectors) mounts on `document.body`, outside the shell.

Android also registers **no** table drag/resize plugins (only `PreviewToolBar`, `CodeBlockLanguageSelector`, `EmojiSelector`), so no external table control extends outside the figure to be clipped by it owning the overflow.

### Notes

- The `10em` cell min-width is kept — columns stay readable and editable; the fix adds scroll ownership rather than shrinking cells.
- Narrow tables that already fit the column are visually unchanged.
- Implemented as an **app-layer override in `src/style.css`**, cohesive with the root change and leaving vendored Muya untouched (avoids the node_modules vendor-sync step). A vendored-Muya edit was an option and is easy to switch to if preferred.

## Verification

- New e2e `mobile-table-scroll.spec.ts`: a five-column table's `figure.mu-table` overflows its own client width and scrolls, while `.editor-host-shell` does not overflow horizontally and cannot be scrolled sideways — asserted in **portrait and landscape**. Passing.
- Regression `mobile-markdown-rendering.spec.ts` (renders a table + code + math + diagrams + images): **5/5 passed**.
- `npm run typecheck` (vue-tsc -b): clean. eslint on the new spec: clean.
