### PR TITLE
Fix completed task text contrast

### DIFF
--- a/src/styles/theme-tokens.css
+++ b/src/styles/theme-tokens.css
@@ -6,7 +6,7 @@
  * Every theme must define the full semantic contract:
  *
  *   Surfaces   --app-bg --surface --surface-muted --surface-sunken --surface-raised
- *   Content    --text --text-muted --text-faint --on-accent
+ *   Content    --text --text-muted --text-faint --task-completed-color --on-accent
  *   Lines      --border --border-strong --separator
  *   Accent     --accent --accent-strong --accent-hover --accent-soft
  *              --accent-tint-10 --accent-tint-11

--- a/src/styles/themeTokens.test.ts
+++ b/src/styles/themeTokens.test.ts
@@ -7,6 +7,15 @@ import { describe, expect, it } from 'vitest'
 const sourceRoot = join(process.cwd(), 'src')
 const themesRoot = join(sourceRoot, 'styles', 'themes')
 const structuralTokensPath = join(sourceRoot, 'styles', 'theme-tokens.css')
+const taskListStylesPath = join(
+  process.cwd(),
+  'third_party',
+  'muya',
+  'src',
+  'assets',
+  'styles',
+  'blockSyntax.css',
+)
 
 // Every shipped palette; the first entry is the canonical token set the
 // others are compared against. Prism overlay files are rule-only (no token
@@ -31,6 +40,7 @@ const REQUIRED_SEMANTIC_TOKENS = [
   '--text',
   '--text-muted',
   '--text-faint',
+  '--task-completed-color',
   '--on-accent',
   '--border',
   '--border-strong',
@@ -70,6 +80,62 @@ function collectDefinedTokens(css: string): Set<string> {
   return new Set(Array.from(css.matchAll(/(--[\w-]+)\s*:/g), match => match[1]))
 }
 
+function collectTokenValues(css: string): Map<string, string> {
+  return new Map(
+    Array.from(css.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g), match => [
+      match[1],
+      match[2].trim(),
+    ]),
+  )
+}
+
+function resolveHexToken(
+  tokens: Map<string, string>,
+  token: string,
+  visited = new Set<string>(),
+): [number, number, number] {
+  if (visited.has(token)) {
+    throw new Error(`circular color token: ${token}`)
+  }
+  visited.add(token)
+
+  const value = tokens.get(token)
+  if (!value) {
+    throw new Error(`missing color token: ${token}`)
+  }
+
+  const reference = value.match(/^var\(\s*(--[\w-]+)\s*\)$/)
+  if (reference) {
+    return resolveHexToken(tokens, reference[1], visited)
+  }
+
+  const hex = value.match(/^#([\da-f]{6})$/i)
+  if (!hex) {
+    throw new Error(`expected an opaque hex color for ${token}, received: ${value}`)
+  }
+
+  return [
+    Number.parseInt(hex[1].slice(0, 2), 16),
+    Number.parseInt(hex[1].slice(2, 4), 16),
+    Number.parseInt(hex[1].slice(4, 6), 16),
+  ]
+}
+
+function relativeLuminance([red, green, blue]: [number, number, number]) {
+  const linearize = (channel: number) => {
+    const value = channel / 255
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+  }
+
+  return 0.2126 * linearize(red) + 0.7152 * linearize(green) + 0.0722 * linearize(blue)
+}
+
+function contrastRatio(foreground: [number, number, number], background: [number, number, number]) {
+  const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background))
+  const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background))
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
 function collectReferencedTokens(css: string): Set<string> {
   return new Set(Array.from(css.matchAll(/var\(\s*(--[\w-]+)/g), match => match[1]))
 }
@@ -106,6 +172,28 @@ describe('theme token architecture', () => {
       const missing = REQUIRED_SEMANTIC_TOKENS.filter(token => !tokens.has(token))
       expect(missing, `missing in ${relative(process.cwd(), path)}`).toEqual([])
     }
+  })
+
+  it('keeps completed task text at WCAG AA contrast in every theme', () => {
+    for (const path of themePaths) {
+      const tokens = collectTokenValues(readFileSync(path, 'utf8'))
+      const ratio = contrastRatio(
+        resolveHexToken(tokens, '--task-completed-color'),
+        resolveHexToken(tokens, '--editor-bg-color'),
+      )
+      const name = relative(process.cwd(), path)
+
+      expect(ratio, `${name}: ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it('uses the completed-task token for checked task content', () => {
+    const taskListStyles = readFileSync(taskListStylesPath, 'utf8')
+    const checkedTaskRule = taskListStyles.match(
+      /li\.mu-task-list-item > input\.mu-checkbox-checked ~ \*,[\s\S]*?\{([\s\S]*?)\}/,
+    )
+
+    expect(checkedTaskRule?.[1]).toMatch(/color:\s*var\(--task-completed-color\)/)
   })
 
   it('never references an undefined token from app styles', () => {

--- a/src/styles/themes/ayu-light.css
+++ b/src/styles/themes/ayu-light.css
@@ -28,6 +28,7 @@
   --text: #454c54;
   --text-muted: #6c7680;
   --text-faint: #949ea8;
+  --task-completed-color: #6a7177;
   --on-accent: #ffffff;
 
   /* Lines */

--- a/src/styles/themes/cadmium-dark.css
+++ b/src/styles/themes/cadmium-dark.css
@@ -21,6 +21,7 @@
   --text: #e6e8ea;
   --text-muted: #a2a9b0;
   --text-faint: #7c838a;
+  --task-completed-color: #949494;
   --on-accent: #ffffff;
 
   /* Lines */

--- a/src/styles/themes/graphite-light.css
+++ b/src/styles/themes/graphite-light.css
@@ -25,6 +25,7 @@
   --text: #1c2126;
   --text-muted: #5f6a76;
   --text-faint: #8a939e;
+  --task-completed-color: #6d7173;
   --on-accent: #ffffff;
 
   /* Lines */

--- a/src/styles/themes/one-dark.css
+++ b/src/styles/themes/one-dark.css
@@ -25,6 +25,7 @@
   --text: #b9c1cc;
   --text-muted: #949dab;
   --text-faint: #6f7887;
+  --task-completed-color: #8f97a5;
   --on-accent: #ffffff;
 
   /* Lines */

--- a/third_party/muya/src/assets/styles/blockSyntax.css
+++ b/third_party/muya/src/assets/styles/blockSyntax.css
@@ -525,7 +525,7 @@ li.mu-task-list-item > span.mu-task-list-checkbox {
 
 li.mu-task-list-item > input.mu-checkbox-checked ~ *,
 li.mu-task-list-item > span.mu-checkbox-checked ~ * {
-    color: var(--editor-color-50);
+    color: var(--task-completed-color);
 }
 
 li.mu-task-list-item > input[type='checkbox']::before,

--- a/third_party/muya/src/assets/styles/index.css
+++ b/third_party/muya/src/assets/styles/index.css
@@ -6,6 +6,7 @@
     --editor-color: #4d4d4d;
     --editor-color-80: #333;
     --editor-color-50: #808080;
+    --task-completed-color: #6b6b6b;
     --editor-color-30: #b3b3b3;
     --editor-color-10: #e6e6e6;
     --editor-color-04: #f7f7f7;


### PR DESCRIPTION
## Summary

- replace the generic `--editor-color-50` checked-task text color with a dedicated `--task-completed-color` semantic token
- define opaque, WCAG AA-compliant completed-task colors for all four shipped themes and Muya's standalone fallback
- add a theme contract test that calculates WCAG relative luminance/contrast and verifies the checked-task rule consumes the new token

The checkbox remains an additional completion cue. This change does not add or alter strikethrough behavior.

## Contrast

| Theme | Before | After |
| --- | ---: | ---: |
| Graphite Light | 2.89:1 | 4.758:1 |
| Ayu Light | 2.18:1 | 4.744:1 |
| Cadmium Dark | 4.83:1 | 4.860:1 |
| One Dark | 2.52:1 | 4.758:1 |

All completed-task text now meets the WCAG 2.2 SC 1.4.3 minimum of 4.5:1 for ordinary text.

## Validation

- `pnpm exec vitest run src --no-cache --configLoader runner` — 65 files / 502 tests passed
- `pnpm exec vue-tsc -b --pretty false`
- `pnpm exec eslint . --max-warnings 0 --no-cache`
- `pnpm exec vite build --configLoader runner`
- `pnpm --dir third_party/muya run test:app-gate` — 209 files / 1412 tests passed
- `gradlew.bat assembleDebug --offline --no-daemon`
- installed the debug APK on a physical Xiaomi 23127PN0CC and verified the checked-task DOM/computed colors through WebView CDP; all four themes reported the ratios above
- visually inspected Cadmium Dark and Graphite Light task-list rendering on the physical device