### PR TITLE
Add imported image storage maintenance

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -515,6 +515,43 @@ public class AndroidDocumentsPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void getImportedImageStorageStats(PluginCall call) {
+        ImportedImageStorage.Stats stats = ImportedImageStorage.inspect(getImportedImageDirectoryFile());
+        JSObject result = new JSObject();
+        result.put("fileCount", stats.fileCount);
+        result.put("bytes", stats.bytes);
+        call.resolve(result);
+    }
+
+    @PluginMethod
+    public void cleanupImportedImages(PluginCall call) {
+        JSArray referencedValues = call.getArray("referencedFileNames");
+        if (referencedValues == null) {
+            call.reject("Imported image references are required", "INVALID_IMAGE_REFERENCES");
+            return;
+        }
+        Set<String> referencedFileNames = new java.util.HashSet<>();
+        for (int index = 0; index < referencedValues.length(); index++) {
+            String fileName = referencedValues.optString(index, "").trim();
+            if (fileName.length() > 0) {
+                referencedFileNames.add(fileName);
+            }
+        }
+
+        ImportedImageStorage.CleanupResult cleanup = ImportedImageStorage.cleanup(
+            getImportedImageDirectoryFile(),
+            referencedFileNames
+        );
+        JSObject result = new JSObject();
+        result.put("fileCount", cleanup.stats.fileCount);
+        result.put("bytes", cleanup.stats.bytes);
+        result.put("removedFileCount", cleanup.removedFileCount);
+        result.put("removedBytes", cleanup.removedBytes);
+        result.put("failedFileCount", cleanup.failedFileCount);
+        call.resolve(result);
+    }
+
+    @PluginMethod
     public void pickImageDocument(PluginCall call) {
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -526,8 +526,9 @@ public class AndroidDocumentsPlugin extends Plugin {
     @PluginMethod
     public void cleanupImportedImages(PluginCall call) {
         JSArray referencedValues = call.getArray("referencedFileNames");
-        if (referencedValues == null) {
-            call.reject("Imported image references are required", "INVALID_IMAGE_REFERENCES");
+        JSArray managedValues = call.getArray("managedFileNames");
+        if (referencedValues == null || managedValues == null) {
+            call.reject("Imported image cleanup metadata is required", "INVALID_IMAGE_REFERENCES");
             return;
         }
         Set<String> referencedFileNames = new java.util.HashSet<>();
@@ -537,10 +538,18 @@ public class AndroidDocumentsPlugin extends Plugin {
                 referencedFileNames.add(fileName);
             }
         }
+        Set<String> managedFileNames = new java.util.HashSet<>();
+        for (int index = 0; index < managedValues.length(); index++) {
+            String fileName = managedValues.optString(index, "").trim();
+            if (fileName.length() > 0) {
+                managedFileNames.add(fileName);
+            }
+        }
 
         ImportedImageStorage.CleanupResult cleanup = ImportedImageStorage.cleanup(
             getImportedImageDirectoryFile(),
-            referencedFileNames
+            referencedFileNames,
+            managedFileNames
         );
         JSObject result = new JSObject();
         result.put("fileCount", cleanup.stats.fileCount);

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/ImportedImageStorage.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/ImportedImageStorage.java
@@ -52,13 +52,21 @@ final class ImportedImageStorage {
         return new Stats(fileCount, bytes);
     }
 
-    static CleanupResult cleanup(File directory, Set<String> referencedFileNames) {
+    static CleanupResult cleanup(
+        File directory,
+        Set<String> referencedFileNames,
+        Set<String> managedFileNames
+    ) {
         int removedFileCount = 0;
         long removedBytes = 0;
         int failedFileCount = 0;
 
         for (File file : listFiles(directory)) {
-            if (!file.isFile() || referencedFileNames.contains(file.getName())) {
+            if (
+                !file.isFile()
+                || !managedFileNames.contains(file.getName())
+                || referencedFileNames.contains(file.getName())
+            ) {
                 continue;
             }
 

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/ImportedImageStorage.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/ImportedImageStorage.java
@@ -1,0 +1,89 @@
+package io.github.renakoni.marktextandroid;
+
+import java.io.File;
+import java.util.Set;
+
+final class ImportedImageStorage {
+
+    static final class Stats {
+
+        final int fileCount;
+        final long bytes;
+
+        Stats(int fileCount, long bytes) {
+            this.fileCount = fileCount;
+            this.bytes = bytes;
+        }
+    }
+
+    static final class CleanupResult {
+
+        final Stats stats;
+        final int removedFileCount;
+        final long removedBytes;
+        final int failedFileCount;
+
+        CleanupResult(
+            Stats stats,
+            int removedFileCount,
+            long removedBytes,
+            int failedFileCount
+        ) {
+            this.stats = stats;
+            this.removedFileCount = removedFileCount;
+            this.removedBytes = removedBytes;
+            this.failedFileCount = failedFileCount;
+        }
+    }
+
+    private ImportedImageStorage() {}
+
+    static Stats inspect(File directory) {
+        File[] files = listFiles(directory);
+        int fileCount = 0;
+        long bytes = 0;
+        for (File file : files) {
+            if (!file.isFile()) {
+                continue;
+            }
+            fileCount += 1;
+            bytes += file.length();
+        }
+        return new Stats(fileCount, bytes);
+    }
+
+    static CleanupResult cleanup(File directory, Set<String> referencedFileNames) {
+        int removedFileCount = 0;
+        long removedBytes = 0;
+        int failedFileCount = 0;
+
+        for (File file : listFiles(directory)) {
+            if (!file.isFile() || referencedFileNames.contains(file.getName())) {
+                continue;
+            }
+
+            long bytes = file.length();
+            if (file.delete()) {
+                removedFileCount += 1;
+                removedBytes += bytes;
+            } else {
+                failedFileCount += 1;
+            }
+        }
+
+        return new CleanupResult(
+            inspect(directory),
+            removedFileCount,
+            removedBytes,
+            failedFileCount
+        );
+    }
+
+    private static File[] listFiles(File directory) {
+        if (!directory.isDirectory()) {
+            return new File[0];
+        }
+        File[] files = directory.listFiles();
+        return files == null ? new File[0] : files;
+    }
+}

--- a/android/app/src/test/java/io/github/renakoni/marktextandroid/ImportedImageStorageTest.java
+++ b/android/app/src/test/java/io/github/renakoni/marktextandroid/ImportedImageStorageTest.java
@@ -1,0 +1,74 @@
+package io.github.renakoni.marktextandroid;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.util.Collections;
+import org.junit.Test;
+
+public class ImportedImageStorageTest {
+
+    @Test
+    public void reportsFilesAndBytesWithoutCountingDirectories() throws Exception {
+        File directory = Files.createTempDirectory("imported-images-test").toFile();
+        writeBytes(new File(directory, "one.png"), 3);
+        writeBytes(new File(directory, "two.webp"), 5);
+        assertTrue(new File(directory, "nested").mkdir());
+
+        ImportedImageStorage.Stats stats = ImportedImageStorage.inspect(directory);
+
+        assertEquals(2, stats.fileCount);
+        assertEquals(8L, stats.bytes);
+    }
+
+    @Test
+    public void removesOnlyUnreferencedFilesAndKeepsDirectories() throws Exception {
+        File directory = Files.createTempDirectory("imported-images-test").toFile();
+        File referenced = new File(directory, "shared.png");
+        File orphan = new File(directory, "orphan.png");
+        File nested = new File(directory, "nested");
+        writeBytes(referenced, 4);
+        writeBytes(orphan, 6);
+        assertTrue(nested.mkdir());
+
+        ImportedImageStorage.CleanupResult result = ImportedImageStorage.cleanup(
+            directory,
+            Collections.singleton("shared.png")
+        );
+
+        assertTrue(referenced.exists());
+        assertFalse(orphan.exists());
+        assertTrue(nested.exists());
+        assertEquals(1, result.removedFileCount);
+        assertEquals(6L, result.removedBytes);
+        assertEquals(0, result.failedFileCount);
+        assertEquals(1, result.stats.fileCount);
+        assertEquals(4L, result.stats.bytes);
+    }
+
+    @Test
+    public void treatsAMissingDirectoryAsEmpty() {
+        File missing = new File("missing-imported-images-" + System.nanoTime());
+
+        ImportedImageStorage.Stats stats = ImportedImageStorage.inspect(missing);
+        ImportedImageStorage.CleanupResult cleanup = ImportedImageStorage.cleanup(
+            missing,
+            Collections.emptySet()
+        );
+
+        assertEquals(0, stats.fileCount);
+        assertEquals(0L, stats.bytes);
+        assertEquals(0, cleanup.removedFileCount);
+        assertEquals(0L, cleanup.removedBytes);
+    }
+
+    private static void writeBytes(File file, int count) throws Exception {
+        try (FileOutputStream output = new FileOutputStream(file)) {
+            output.write(new byte[count]);
+        }
+    }
+}

--- a/android/app/src/test/java/io/github/renakoni/marktextandroid/ImportedImageStorageTest.java
+++ b/android/app/src/test/java/io/github/renakoni/marktextandroid/ImportedImageStorageTest.java
@@ -7,7 +7,9 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import org.junit.Test;
 
 public class ImportedImageStorageTest {
@@ -26,28 +28,32 @@ public class ImportedImageStorageTest {
     }
 
     @Test
-    public void removesOnlyUnreferencedFilesAndKeepsDirectories() throws Exception {
+    public void removesOnlyManagedUnreferencedFilesAndKeepsDirectories() throws Exception {
         File directory = Files.createTempDirectory("imported-images-test").toFile();
         File referenced = new File(directory, "shared.png");
         File orphan = new File(directory, "orphan.png");
+        File legacy = new File(directory, "legacy.png");
         File nested = new File(directory, "nested");
         writeBytes(referenced, 4);
         writeBytes(orphan, 6);
+        writeBytes(legacy, 8);
         assertTrue(nested.mkdir());
 
         ImportedImageStorage.CleanupResult result = ImportedImageStorage.cleanup(
             directory,
-            Collections.singleton("shared.png")
+            Collections.singleton("shared.png"),
+            new HashSet<>(Arrays.asList("shared.png", "orphan.png"))
         );
 
         assertTrue(referenced.exists());
         assertFalse(orphan.exists());
+        assertTrue(legacy.exists());
         assertTrue(nested.exists());
         assertEquals(1, result.removedFileCount);
         assertEquals(6L, result.removedBytes);
         assertEquals(0, result.failedFileCount);
-        assertEquals(1, result.stats.fileCount);
-        assertEquals(4L, result.stats.bytes);
+        assertEquals(2, result.stats.fileCount);
+        assertEquals(12L, result.stats.bytes);
     }
 
     @Test
@@ -57,6 +63,7 @@ public class ImportedImageStorageTest {
         ImportedImageStorage.Stats stats = ImportedImageStorage.inspect(missing);
         ImportedImageStorage.CleanupResult cleanup = ImportedImageStorage.cleanup(
             missing,
+            Collections.emptySet(),
             Collections.emptySet()
         );
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,9 +20,11 @@ import {
 } from './lib/androidDocuments'
 import {
   ensureAndroidImageResolver,
+  formatImportedImageStorageBytes,
   getAndroidImageUserMessage,
   isAndroidImageImportAvailable,
   pickAndroidImageDocument,
+  type ImportedAndroidImageCleanupResult,
 } from './lib/androidImages'
 import {
   installAppLifecycleListeners as installAppLifecycleListenerHandles,
@@ -64,6 +66,10 @@ import {
 import { isAndroidRecoveryDraftId } from './features/android-documents/androidRecoveryDrafts'
 import { rememberAndroidRecentDocument } from './features/android-documents/androidRecentDocuments'
 import { getImageSharingSettings } from './features/android-documents/imageSharingSettings'
+import {
+  ImportedImageCleanupBlockedError,
+  cleanupUnusedImportedImages,
+} from './features/android-documents/importedImageMaintenance'
 import { createUntitledDocument } from './lib/documentState'
 import {
   createDocumentStateFromLocalDraft,
@@ -1769,6 +1775,62 @@ function resetSettingsMaintenanceState() {
   appLog.info('reset settings from Advanced maintenance')
 }
 
+async function cleanImportedImagesMaintenanceState() {
+  if (!isAndroidImageImportAvailable()) {
+    throw new Error(t('settings.maintenance.cleanImagesUnavailable'))
+  }
+
+  let result: ImportedAndroidImageCleanupResult
+  try {
+    result = await cleanupUnusedImportedImages({
+      currentDocument: {
+        sourceUri: documentState.value.sourceUri,
+        markdown: documentState.value.markdown,
+      },
+      localDrafts: localDrafts.value,
+      recentDocuments: androidRecentDocuments.value,
+      readRecentMarkdown: sourceUri =>
+        readAndroidMarkdownDocument(sourceUri, androidMarkdownSettings.value),
+    })
+  } catch (error) {
+    if (error instanceof ImportedImageCleanupBlockedError) {
+      throw new Error(
+        t('settings.maintenance.cleanImagesUnreadable', {
+          count: error.unreadableDocumentCount,
+        }),
+        { cause: error },
+      )
+    }
+    throw error
+  }
+
+  androidDocumentLog.info('cleaned unused imported images from Advanced maintenance', result)
+  if (result.removedFileCount === 0) {
+    if (result.failedFileCount > 0) {
+      return {
+        message: t('settings.maintenance.cleanImagesFailed', {
+          count: result.failedFileCount,
+        }),
+      }
+    }
+    return { message: t('settings.maintenance.cleanImagesNone') }
+  }
+
+  const params = {
+    count: result.removedFileCount,
+    size: formatImportedImageStorageBytes(result.removedBytes, locale.value),
+    failed: result.failedFileCount,
+  }
+  return {
+    message: t(
+      result.failedFileCount > 0
+        ? 'settings.maintenance.cleanImagesPartial'
+        : 'settings.maintenance.cleanImagesSuccess',
+      params,
+    ),
+  }
+}
+
 async function runAdvancedMaintenanceAction(action: AdvancedMaintenanceActionId) {
   if (action === 'exportLogs') {
     const result = await exportNativeLogs()
@@ -1777,6 +1839,10 @@ async function runAdvancedMaintenanceAction(action: AdvancedMaintenanceActionId)
     }
     loggingLog.info('exported native logs', result)
     return
+  }
+
+  if (action === 'cleanImportedImages') {
+    return cleanImportedImagesMaintenanceState()
   }
 
   if (action === 'clearDrafts') {
@@ -1904,12 +1970,12 @@ onBeforeUnmount(() => {
     :all-selected-pinned="allSelectedDocumentsPinned"
     :delete-sheet-open="homeDeleteSheetOpen"
     :rename-sheet-open="homeRenameSheetOpen"
+    :run-maintenance-action="runAdvancedMaintenanceAction"
     @new-document="newDocument"
     @open-document="openDocument"
     @open-file="openFileFromAndroid"
     @set-tab="setHomeTab"
     @set-settings-page="setSettingsPage"
-    @run-maintenance-action="runAdvancedMaintenanceAction"
     @select-document="homeSelection.beginWith"
     @toggle-document="homeSelection.toggle"
     @exit-selection="homeSelection.clear"

--- a/src/App.vue
+++ b/src/App.vue
@@ -70,6 +70,10 @@ import {
   ImportedImageCleanupBlockedError,
   cleanupUnusedImportedImages,
 } from './features/android-documents/importedImageMaintenance'
+import {
+  protectImportedImagesInAndroidDocument,
+  registerImportedImageCopy,
+} from './features/android-documents/importedImageRegistry'
 import { createUntitledDocument } from './lib/documentState'
 import {
   createDocumentStateFromLocalDraft,
@@ -1058,6 +1062,7 @@ async function insertImageFromAndroidPicker(restoreRange: Range | null = null) {
   }
 
   const beforeMarkdown = activeEditor.getMarkdown()
+  const protectImportedImageFromCleanup = Boolean(documentState.value.sourceUri)
   pendingInlineInsertRange = restoreRange?.cloneRange() ?? captureEditorSelection()
   const selectedText = normalizeToolbarSelectionText(pendingInlineInsertRange?.toString() ?? '')
   closeEditorMenu()
@@ -1069,9 +1074,18 @@ async function insertImageFromAndroidPicker(restoreRange: Range | null = null) {
     const result = await insertAndroidImageWorkflow({
       selectedText,
       ensureAndroidImageResolver,
-      pickAndroidImageDocument: () => pickAndroidImageDocument({
-        copyImage: imageSharingSettings.value.imageCopyImages,
-      }),
+      pickAndroidImageDocument: async () => {
+        const image = await pickAndroidImageDocument({
+          copyImage: imageSharingSettings.value.imageCopyImages,
+        })
+        if (
+          !image.canceled
+          && !registerImportedImageCopy(image.markdownSrc, protectImportedImageFromCleanup)
+        ) {
+          editorLog.warn('imported image registry could not be updated')
+        }
+        return image
+      },
       insertMarkdown: insertMarkdownAtPendingSelection,
       getAndroidImageUserMessage,
       logger: editorLog,
@@ -1232,7 +1246,16 @@ const {
   documentLogger: androidDocumentLog,
   draftLogger: draftLog,
 })
+function protectAndroidDocumentImportedImages(document: OpenedAndroidDocument) {
+  if (!protectImportedImagesInAndroidDocument(document.markdown)) {
+    androidDocumentLog.warn('imported image protection could not be updated', {
+      sourceUri: document.sourceUri,
+    })
+  }
+}
+
 function rememberAndroidDocument(document: OpenedAndroidDocument) {
+  protectAndroidDocumentImportedImages(document)
   persistAndroidRecentDocuments(rememberAndroidRecentDocument(androidRecentDocuments.value, document))
 }
 
@@ -1251,6 +1274,8 @@ async function openAndroidDocumentResult(
   homeNotice.value = openResult.homeNotice
   if (openResult.rememberDocument) {
     rememberAndroidDocument(openResult.rememberDocument)
+  } else {
+    protectAndroidDocumentImportedImages(document)
   }
   promptLocalDraftSaveOnExit.value = openResult.promptLocalDraftSaveOnExit
   currentAndroidDocumentCanWrite.value = openResult.currentAndroidDocumentCanWrite
@@ -1795,7 +1820,9 @@ async function cleanImportedImagesMaintenanceState() {
   } catch (error) {
     if (error instanceof ImportedImageCleanupBlockedError) {
       throw new Error(
-        t('settings.maintenance.cleanImagesUnreadable', {
+        t(error.unreadableDocumentCount === 1
+          ? 'settings.maintenance.cleanImagesUnreadable.one'
+          : 'settings.maintenance.cleanImagesUnreadable.other', {
           count: error.unreadableDocumentCount,
         }),
         { cause: error },
@@ -1808,7 +1835,9 @@ async function cleanImportedImagesMaintenanceState() {
   if (result.removedFileCount === 0) {
     if (result.failedFileCount > 0) {
       return {
-        message: t('settings.maintenance.cleanImagesFailed', {
+        message: t(result.failedFileCount === 1
+          ? 'settings.maintenance.cleanImagesFailed.one'
+          : 'settings.maintenance.cleanImagesFailed.other', {
           count: result.failedFileCount,
         }),
       }
@@ -1824,8 +1853,12 @@ async function cleanImportedImagesMaintenanceState() {
   return {
     message: t(
       result.failedFileCount > 0
-        ? 'settings.maintenance.cleanImagesPartial'
-        : 'settings.maintenance.cleanImagesSuccess',
+        ? (result.removedFileCount === 1
+            ? 'settings.maintenance.cleanImagesPartial.one'
+            : 'settings.maintenance.cleanImagesPartial.other')
+        : (result.removedFileCount === 1
+            ? 'settings.maintenance.cleanImagesSuccess.one'
+            : 'settings.maintenance.cleanImagesSuccess.other'),
       params,
     ),
   }

--- a/src/features/android-documents/importedImageMaintenance.test.ts
+++ b/src/features/android-documents/importedImageMaintenance.test.ts
@@ -41,11 +41,35 @@ describe('imported image maintenance', () => {
     })).resolves.toEqual(cleanupResult)
 
     expect(readRecentMarkdown).toHaveBeenCalledTimes(2)
-    expect(cleanup).toHaveBeenCalledWith([
-      'shared.png',
-      'draft.png',
-      'recent.png',
-    ])
+    expect(cleanup).toHaveBeenCalledWith(
+      [
+        'shared.png',
+        'draft.png',
+        'recent.png',
+      ],
+      [],
+    )
+  })
+
+  it('protects Android document references after they leave the recent list', async () => {
+    const cleanup = vi.fn(async () => cleanupResult)
+
+    await cleanupUnusedImportedImages({
+      currentDocument: { sourceUri: null, markdown: '' },
+      localDrafts: [],
+      recentDocuments: [],
+      readRecentMarkdown: vi.fn(),
+      imageRegistry: {
+        managedFileNames: ['archived.png', 'orphan.png'],
+        protectedFileNames: ['archived.png'],
+      },
+      cleanup,
+    })
+
+    expect(cleanup).toHaveBeenCalledWith(
+      ['archived.png'],
+      ['archived.png', 'orphan.png'],
+    )
   })
 
   it('deletes nothing when any tracked recent document cannot be checked', async () => {

--- a/src/features/android-documents/importedImageMaintenance.test.ts
+++ b/src/features/android-documents/importedImageMaintenance.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  ImportedImageCleanupBlockedError,
+  cleanupUnusedImportedImages,
+} from './importedImageMaintenance'
+
+const cleanupResult = {
+  fileCount: 1,
+  bytes: 12,
+  removedFileCount: 2,
+  removedBytes: 34,
+  failedFileCount: 0,
+}
+
+describe('imported image maintenance', () => {
+  it('protects references from the current document, drafts, and readable recents', async () => {
+    const readRecentMarkdown = vi.fn(async (sourceUri: string) => ({
+      markdown: sourceUri.endsWith('/one')
+        ? '![recent](marktext-image://local/recent.png)'
+        : '![shared](marktext-image://local/shared.png)',
+    }))
+    const cleanup = vi.fn(async () => cleanupResult)
+
+    await expect(cleanupUnusedImportedImages({
+      currentDocument: {
+        sourceUri: 'content://current',
+        markdown: '![current](marktext-image://local/shared.png)',
+      },
+      localDrafts: [
+        { markdown: '![draft](marktext-image://local/draft.png)' },
+      ],
+      recentDocuments: [
+        { sourceUri: 'content://current' },
+        { sourceUri: 'content://recent/one' },
+        { sourceUri: 'content://recent/one' },
+        { sourceUri: 'content://recent/two' },
+        { sourceUri: null },
+      ],
+      readRecentMarkdown,
+      cleanup,
+    })).resolves.toEqual(cleanupResult)
+
+    expect(readRecentMarkdown).toHaveBeenCalledTimes(2)
+    expect(cleanup).toHaveBeenCalledWith([
+      'shared.png',
+      'draft.png',
+      'recent.png',
+    ])
+  })
+
+  it('deletes nothing when any tracked recent document cannot be checked', async () => {
+    const cleanup = vi.fn(async () => cleanupResult)
+
+    const operation = cleanupUnusedImportedImages({
+      currentDocument: { sourceUri: null, markdown: '' },
+      localDrafts: [],
+      recentDocuments: [
+        { sourceUri: 'content://recent/readable' },
+        { sourceUri: 'content://recent/unreadable' },
+      ],
+      readRecentMarkdown: vi.fn(async sourceUri => {
+        if (sourceUri.endsWith('/unreadable')) {
+          throw new Error('permission lost')
+        }
+        return { markdown: '' }
+      }),
+      cleanup,
+    })
+
+    await expect(operation).rejects.toBeInstanceOf(ImportedImageCleanupBlockedError)
+    await expect(operation).rejects.toMatchObject({
+      code: 'RECENT_DOCUMENT_UNREADABLE',
+      unreadableDocumentCount: 1,
+    })
+
+    expect(cleanup).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/android-documents/importedImageMaintenance.ts
+++ b/src/features/android-documents/importedImageMaintenance.ts
@@ -3,6 +3,10 @@ import {
   collectMarkTextLocalImageFileNames,
   type ImportedAndroidImageCleanupResult,
 } from '../../lib/androidImages'
+import {
+  readImportedImageRegistry,
+  type ImportedImageRegistrySnapshot,
+} from './importedImageRegistry'
 
 interface MarkdownSource {
   markdown: string
@@ -21,7 +25,11 @@ interface ImportedImageMaintenanceOptions {
   localDrafts: readonly MarkdownSource[]
   recentDocuments: readonly RecentDocumentSource[]
   readRecentMarkdown: (sourceUri: string) => Promise<MarkdownSource>
-  cleanup?: (referencedFileNames: readonly string[]) => Promise<ImportedAndroidImageCleanupResult>
+  imageRegistry?: ImportedImageRegistrySnapshot
+  cleanup?: (
+    referencedFileNames: readonly string[],
+    managedFileNames: readonly string[],
+  ) => Promise<ImportedAndroidImageCleanupResult>
 }
 
 export class ImportedImageCleanupBlockedError extends Error {
@@ -61,6 +69,10 @@ export async function cleanupUnusedImportedImages(options: ImportedImageMaintena
   }
 
   const referencedFileNames = new Set<string>()
+  const imageRegistry = options.imageRegistry ?? readImportedImageRegistry()
+  for (const fileName of imageRegistry.protectedFileNames) {
+    referencedFileNames.add(fileName)
+  }
   for (const markdown of markdownSources) {
     for (const fileName of collectMarkTextLocalImageFileNames(markdown)) {
       referencedFileNames.add(fileName)
@@ -68,5 +80,8 @@ export async function cleanupUnusedImportedImages(options: ImportedImageMaintena
   }
 
   const cleanup = options.cleanup ?? cleanupImportedAndroidImages
-  return cleanup([...referencedFileNames])
+  return cleanup(
+    [...referencedFileNames],
+    [...new Set(imageRegistry.managedFileNames)],
+  )
 }

--- a/src/features/android-documents/importedImageMaintenance.ts
+++ b/src/features/android-documents/importedImageMaintenance.ts
@@ -1,0 +1,72 @@
+import {
+  cleanupImportedAndroidImages,
+  collectMarkTextLocalImageFileNames,
+  type ImportedAndroidImageCleanupResult,
+} from '../../lib/androidImages'
+
+interface MarkdownSource {
+  markdown: string
+}
+
+interface CurrentDocumentSource extends MarkdownSource {
+  sourceUri: string | null
+}
+
+interface RecentDocumentSource {
+  sourceUri: string | null
+}
+
+interface ImportedImageMaintenanceOptions {
+  currentDocument: CurrentDocumentSource
+  localDrafts: readonly MarkdownSource[]
+  recentDocuments: readonly RecentDocumentSource[]
+  readRecentMarkdown: (sourceUri: string) => Promise<MarkdownSource>
+  cleanup?: (referencedFileNames: readonly string[]) => Promise<ImportedAndroidImageCleanupResult>
+}
+
+export class ImportedImageCleanupBlockedError extends Error {
+  readonly code = 'RECENT_DOCUMENT_UNREADABLE'
+  readonly unreadableDocumentCount: number
+
+  constructor(unreadableDocumentCount: number) {
+    super('Could not check every recent document')
+    this.name = 'ImportedImageCleanupBlockedError'
+    this.unreadableDocumentCount = unreadableDocumentCount
+  }
+}
+
+export async function cleanupUnusedImportedImages(options: ImportedImageMaintenanceOptions) {
+  const markdownSources = [
+    options.currentDocument.markdown,
+    ...options.localDrafts.map(draft => draft.markdown),
+  ]
+  const currentSourceUri = options.currentDocument.sourceUri
+  const recentSourceUris = new Set(
+    options.recentDocuments
+      .map(document => document.sourceUri)
+      .filter((sourceUri): sourceUri is string => Boolean(sourceUri) && sourceUri !== currentSourceUri),
+  )
+  let unreadableDocumentCount = 0
+
+  for (const sourceUri of recentSourceUris) {
+    try {
+      markdownSources.push((await options.readRecentMarkdown(sourceUri)).markdown)
+    } catch {
+      unreadableDocumentCount += 1
+    }
+  }
+
+  if (unreadableDocumentCount > 0) {
+    throw new ImportedImageCleanupBlockedError(unreadableDocumentCount)
+  }
+
+  const referencedFileNames = new Set<string>()
+  for (const markdown of markdownSources) {
+    for (const fileName of collectMarkTextLocalImageFileNames(markdown)) {
+      referencedFileNames.add(fileName)
+    }
+  }
+
+  const cleanup = options.cleanup ?? cleanupImportedAndroidImages
+  return cleanup([...referencedFileNames])
+}

--- a/src/features/android-documents/importedImageRegistry.test.ts
+++ b/src/features/android-documents/importedImageRegistry.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  IMPORTED_IMAGE_REGISTRY_STORAGE_KEY,
+  protectImportedImagesInAndroidDocument,
+  readImportedImageRegistry,
+  registerImportedImageCopy,
+} from './importedImageRegistry'
+
+function createMemoryStorage() {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  }
+}
+
+describe('imported image registry', () => {
+  it('keeps pre-registry files outside the managed cleanup set', () => {
+    const storage = createMemoryStorage()
+
+    expect(readImportedImageRegistry(storage)).toEqual({
+      managedFileNames: [],
+      protectedFileNames: [],
+    })
+  })
+
+  it('persists managed imports and Android document protection independently of recents', () => {
+    const storage = createMemoryStorage()
+
+    expect(registerImportedImageCopy(
+      'marktext-image://local/draft.png',
+      false,
+      storage,
+    )).toBe(true)
+    expect(registerImportedImageCopy(
+      'marktext-image://local/android.png',
+      true,
+      storage,
+    )).toBe(true)
+    expect(protectImportedImagesInAndroidDocument(
+      '![shared](marktext-image://local/shared.png)',
+      storage,
+    )).toBe(true)
+
+    expect(readImportedImageRegistry(storage)).toEqual({
+      managedFileNames: ['draft.png', 'android.png'],
+      protectedFileNames: ['android.png', 'shared.png'],
+    })
+    expect(storage.getItem(IMPORTED_IMAGE_REGISTRY_STORAGE_KEY)).not.toBeNull()
+  })
+})

--- a/src/features/android-documents/importedImageRegistry.ts
+++ b/src/features/android-documents/importedImageRegistry.ts
@@ -1,0 +1,128 @@
+import { collectMarkTextLocalImageFileNames } from '../../lib/androidImages'
+
+export const IMPORTED_IMAGE_REGISTRY_STORAGE_KEY =
+  'marktext-for-android:imported-image-registry'
+
+interface ImportedImageRegistryStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+export interface ImportedImageRegistrySnapshot {
+  managedFileNames: string[]
+  protectedFileNames: string[]
+}
+
+interface StoredImportedImageRegistry extends ImportedImageRegistrySnapshot {
+  version: 1
+}
+
+const EMPTY_REGISTRY: ImportedImageRegistrySnapshot = {
+  managedFileNames: [],
+  protectedFileNames: [],
+}
+
+// SAF cannot prove that an external document stopped referencing an image.
+// Protection is therefore monotonic, and pre-registry files never enter the managed cleanup set.
+
+function getDefaultStorage(): ImportedImageRegistryStorage | null {
+  return typeof localStorage === 'undefined' ? null : localStorage
+}
+
+function normalizeStoredFileNames(value: unknown) {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const fileNames = new Set<string>()
+  for (const valueItem of value) {
+    if (typeof valueItem !== 'string') {
+      continue
+    }
+    const markdownSource = `marktext-image://local/${encodeURIComponent(valueItem)}`
+    for (const fileName of collectMarkTextLocalImageFileNames(markdownSource)) {
+      fileNames.add(fileName)
+    }
+  }
+  return [...fileNames]
+}
+
+export function readImportedImageRegistry(
+  storage: ImportedImageRegistryStorage | null = getDefaultStorage(),
+): ImportedImageRegistrySnapshot {
+  if (!storage) {
+    return { ...EMPTY_REGISTRY }
+  }
+
+  try {
+    const value: unknown = JSON.parse(
+      storage.getItem(IMPORTED_IMAGE_REGISTRY_STORAGE_KEY) ?? 'null',
+    )
+    if (!value || typeof value !== 'object' || (value as { version?: unknown }).version !== 1) {
+      return { ...EMPTY_REGISTRY }
+    }
+    const registry = value as Partial<StoredImportedImageRegistry>
+    return {
+      managedFileNames: normalizeStoredFileNames(registry.managedFileNames),
+      protectedFileNames: normalizeStoredFileNames(registry.protectedFileNames),
+    }
+  } catch {
+    return { ...EMPTY_REGISTRY }
+  }
+}
+
+function writeImportedImageRegistry(
+  registry: ImportedImageRegistrySnapshot,
+  storage: ImportedImageRegistryStorage | null,
+) {
+  if (!storage) {
+    return false
+  }
+
+  try {
+    storage.setItem(IMPORTED_IMAGE_REGISTRY_STORAGE_KEY, JSON.stringify({
+      version: 1,
+      ...registry,
+    } satisfies StoredImportedImageRegistry))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function registerImportedImageCopy(
+  markdownSource: string,
+  protectFromCleanup: boolean,
+  storage: ImportedImageRegistryStorage | null = getDefaultStorage(),
+) {
+  const importedFileNames = collectMarkTextLocalImageFileNames(markdownSource)
+  if (importedFileNames.length === 0) {
+    return true
+  }
+
+  const registry = readImportedImageRegistry(storage)
+  return writeImportedImageRegistry({
+    managedFileNames: [...new Set([...registry.managedFileNames, ...importedFileNames])],
+    protectedFileNames: protectFromCleanup
+      ? [...new Set([...registry.protectedFileNames, ...importedFileNames])]
+      : registry.protectedFileNames,
+  }, storage)
+}
+
+export function protectImportedImagesInAndroidDocument(
+  markdown: string,
+  storage: ImportedImageRegistryStorage | null = getDefaultStorage(),
+) {
+  const referencedFileNames = collectMarkTextLocalImageFileNames(markdown)
+  if (referencedFileNames.length === 0) {
+    return true
+  }
+
+  const registry = readImportedImageRegistry(storage)
+  return writeImportedImageRegistry({
+    ...registry,
+    protectedFileNames: [
+      ...new Set([...registry.protectedFileNames, ...referencedFileNames]),
+    ],
+  }, storage)
+}

--- a/src/features/home/HomeScreen.vue
+++ b/src/features/home/HomeScreen.vue
@@ -6,7 +6,7 @@ import SettingsScreen from '../settings/SettingsScreen.vue'
 import type { HomeDocumentItem } from './homeDocuments'
 import { HOME_TABS, type HomeTab } from './homeNavigation'
 import { SETTINGS_PAGES, type SettingsPage } from '../settings/settingsNavigation'
-import type { AdvancedMaintenanceActionId } from '../settings/advancedSettings'
+import type { AdvancedMaintenanceActionHandler } from '../settings/advancedSettings'
 
 interface Props {
   activeTab: HomeTab
@@ -21,6 +21,7 @@ interface Props {
   allSelectedPinned: boolean
   deleteSheetOpen: boolean
   renameSheetOpen: boolean
+  runMaintenanceAction: AdvancedMaintenanceActionHandler
 }
 
 const props = defineProps<Props>()
@@ -31,7 +32,6 @@ const emit = defineEmits<{
   openFile: []
   newDocument: []
   setSettingsPage: [page: SettingsPage]
-  runMaintenanceAction: [action: AdvancedMaintenanceActionId]
   selectDocument: [id: string]
   toggleDocument: [id: string]
   exitSelection: []
@@ -91,8 +91,8 @@ watch(
       <SettingsScreen
         v-else
         :active-page="settingsPage"
+        :run-maintenance-action="runMaintenanceAction"
         @set-page="page => emit('setSettingsPage', page)"
-        @run-maintenance-action="action => emit('runMaintenanceAction', action)"
       />
     </div>
     <AppBottomNavigation

--- a/src/features/settings/SettingsScreen.vue
+++ b/src/features/settings/SettingsScreen.vue
@@ -10,15 +10,15 @@ import {
   SETTINGS_PAGES,
   type SettingsPage,
 } from './settingsNavigation'
-import type { AdvancedMaintenanceActionId } from './advancedSettings'
+import type { AdvancedMaintenanceActionHandler } from './advancedSettings'
 
 defineProps<{
   activePage: SettingsPage
+  runMaintenanceAction: AdvancedMaintenanceActionHandler
 }>()
 
 const emit = defineEmits<{
   setPage: [page: SettingsPage]
-  runMaintenanceAction: [action: AdvancedMaintenanceActionId]
 }>()
 
 const { t } = useI18n()
@@ -73,7 +73,7 @@ const { t } = useI18n()
         <SettingsDetailPage
           v-else
           :page="activePage"
-          :run-maintenance-action="action => emit('runMaintenanceAction', action)"
+          :run-maintenance-action="runMaintenanceAction"
         />
       </div>
     </Transition>

--- a/src/features/settings/advancedSettings.ts
+++ b/src/features/settings/advancedSettings.ts
@@ -41,7 +41,19 @@ export type MarkdownEncoding =
 
 export type AdvancedLineEnding = 'default' | LineEnding
 export type TrailingNewlineMode = 0 | 1 | 2
-export type AdvancedMaintenanceActionId = 'exportLogs' | 'clearDrafts' | 'resetSettings'
+export type AdvancedMaintenanceActionId =
+  | 'exportLogs'
+  | 'cleanImportedImages'
+  | 'clearDrafts'
+  | 'resetSettings'
+
+export interface AdvancedMaintenanceActionResult {
+  message?: string
+}
+
+export type AdvancedMaintenanceActionHandler = (
+  action: AdvancedMaintenanceActionId,
+) => Promise<AdvancedMaintenanceActionResult | void> | AdvancedMaintenanceActionResult | void
 
 export type AdvancedSettingKey =
   | 'defaultEncoding'
@@ -79,6 +91,7 @@ export const ADVANCED_SETTING_KEYS = [
 
 export const ADVANCED_MAINTENANCE_ACTION_IDS = [
   'exportLogs',
+  'cleanImportedImages',
   'clearDrafts',
   'resetSettings',
 ] as const satisfies readonly AdvancedMaintenanceActionId[]

--- a/src/features/settings/components/SettingsDetailPage.vue
+++ b/src/features/settings/components/SettingsDetailPage.vue
@@ -23,13 +23,19 @@ import { SETTINGS_PAGES, type SettingsPage } from '../settingsNavigation'
 import { useSettingsState } from '../settingsState'
 import {
   isAdvancedMaintenanceActionId,
+  type AdvancedMaintenanceActionHandler,
   type AdvancedMaintenanceActionId,
 } from '../advancedSettings'
 import { getAdvancedDiagnostics } from '../advancedDiagnostics'
+import {
+  formatImportedImageStorageBytes,
+  getImportedAndroidImageStorageStats,
+  type ImportedAndroidImageStorageStats,
+} from '../../../lib/androidImages'
 
 const props = defineProps<{
   page: SettingsPage
-  runMaintenanceAction?: (action: AdvancedMaintenanceActionId) => Promise<void> | void
+  runMaintenanceAction: AdvancedMaintenanceActionHandler
 }>()
 
 const { locale, setLocale, t } = useI18n()
@@ -40,7 +46,10 @@ type MaintenanceActionId = AdvancedMaintenanceActionId
 const maintenanceAction = ref<MaintenanceActionId | null>(null)
 const maintenanceActionBusy = ref(false)
 const maintenanceActionError = ref<string | null>(null)
+const maintenanceActionResult = ref<string | null>(null)
 const advancedDiagnostics = ref<Record<string, string>>({})
+const importedImageStorageStats = ref<ImportedAndroidImageStorageStats | null>(null)
+const importedImageStorageLoading = ref(false)
 const maintenanceActionCopies: Record<
   MaintenanceActionId,
   {
@@ -58,6 +67,14 @@ const maintenanceActionCopies: Record<
     actionKey: 'settings.maintenance.exportLogsAction',
     confirmKey: 'settings.maintenance.exportLogsConfirm',
     confirmTestId: 'settings-maintenance-export-confirm',
+  },
+  cleanImportedImages: {
+    titleKey: 'settings.maintenance.cleanImagesTitle',
+    bodyKey: 'settings.maintenance.cleanImagesBody',
+    actionKey: 'settings.maintenance.cleanImagesAction',
+    confirmKey: 'settings.maintenance.cleanImagesConfirm',
+    confirmTestId: 'settings-maintenance-clean-images-confirm',
+    danger: true,
   },
   clearDrafts: {
     titleKey: 'settings.maintenance.clearDraftsTitle',
@@ -124,6 +141,19 @@ function getActionValue(row: SettingsActionRow) {
 }
 
 function getStatusValue(row: SettingsStatusRow) {
+  if (props.page === SETTINGS_PAGES.ADVANCED && row.id === 'importedImageStorage') {
+    if (importedImageStorageLoading.value) {
+      return t('settings.value.checking')
+    }
+    if (!importedImageStorageStats.value) {
+      return t('settings.value.androidOnly')
+    }
+    return t('settings.value.importedImageStorageUsage', {
+      count: importedImageStorageStats.value.fileCount,
+      size: formatImportedImageStorageBytes(importedImageStorageStats.value.bytes, locale.value),
+    })
+  }
+
   if (props.page === SETTINGS_PAGES.ADVANCED) {
     const value = advancedDiagnostics.value[row.id]
     if (value) {
@@ -166,6 +196,7 @@ function recordAction(row: SettingsActionRow) {
   if (maintenanceActionId) {
     maintenanceAction.value = maintenanceActionId
     maintenanceActionError.value = null
+    maintenanceActionResult.value = null
     return
   }
   setValue(`action:${row.id}`, Date.now())
@@ -177,6 +208,7 @@ function closeMaintenanceSheet() {
   }
   maintenanceAction.value = null
   maintenanceActionError.value = null
+  maintenanceActionResult.value = null
 }
 
 async function confirmMaintenanceAction() {
@@ -187,8 +219,14 @@ async function confirmMaintenanceAction() {
 
   maintenanceActionBusy.value = true
   maintenanceActionError.value = null
+  maintenanceActionResult.value = null
   try {
-    await props.runMaintenanceAction?.(action)
+    const result = await props.runMaintenanceAction(action)
+    await refreshImportedImageStorage()
+    if (result?.message) {
+      maintenanceActionResult.value = result.message
+      return
+    }
     maintenanceAction.value = null
   } catch (error) {
     maintenanceActionError.value = error instanceof Error
@@ -199,6 +237,28 @@ async function confirmMaintenanceAction() {
   }
 }
 
+async function refreshImportedImageStorage() {
+  importedImageStorageLoading.value = true
+  try {
+    importedImageStorageStats.value = await getImportedAndroidImageStorageStats()
+  } catch {
+    importedImageStorageStats.value = null
+  } finally {
+    importedImageStorageLoading.value = false
+  }
+}
+
+async function refreshAdvancedInformation() {
+  const [diagnostics] = await Promise.all([
+    getAdvancedDiagnostics(),
+    refreshImportedImageStorage(),
+  ])
+  advancedDiagnostics.value = {
+    deviceInfo: diagnostics.deviceInfo,
+    webviewInfo: diagnostics.webViewInfo,
+  }
+}
+
 watch(
   () => props.page,
   page => {
@@ -206,12 +266,7 @@ watch(
       return
     }
 
-    getAdvancedDiagnostics().then(result => {
-      advancedDiagnostics.value = {
-        deviceInfo: result.deviceInfo,
-        webviewInfo: result.webViewInfo,
-      }
-    })
+    void refreshAdvancedInformation()
   },
   { immediate: true },
 )
@@ -316,11 +371,15 @@ watch(
       <div class="draft-save-panel">
         <h2 id="settings-maintenance-title">{{ t(activeMaintenanceActionCopy.titleKey) }}</h2>
         <p>{{ t(activeMaintenanceActionCopy.bodyKey) }}</p>
+        <p v-if="maintenanceActionResult" role="status">
+          {{ maintenanceActionResult }}
+        </p>
         <p v-if="maintenanceActionError" role="alert">
           {{ maintenanceActionError }}
         </p>
         <div class="draft-save-actions">
           <button
+            v-if="!maintenanceActionResult"
             type="button"
             :class="{ 'danger-action': activeMaintenanceActionCopy.danger, 'primary-action': !activeMaintenanceActionCopy.danger }"
             :disabled="maintenanceActionBusy"
@@ -336,7 +395,7 @@ watch(
             data-testid="settings-maintenance-cancel"
             @click="closeMaintenanceSheet"
           >
-            {{ t('editor.link.cancel') }}
+            {{ maintenanceActionResult ? t('settings.maintenance.done') : t('editor.link.cancel') }}
           </button>
         </div>
       </div>

--- a/src/features/settings/components/SettingsDetailPage.vue
+++ b/src/features/settings/components/SettingsDetailPage.vue
@@ -50,6 +50,7 @@ const maintenanceActionResult = ref<string | null>(null)
 const advancedDiagnostics = ref<Record<string, string>>({})
 const importedImageStorageStats = ref<ImportedAndroidImageStorageStats | null>(null)
 const importedImageStorageLoading = ref(false)
+const importedImageStorageError = ref(false)
 const maintenanceActionCopies: Record<
   MaintenanceActionId,
   {
@@ -144,6 +145,9 @@ function getStatusValue(row: SettingsStatusRow) {
   if (props.page === SETTINGS_PAGES.ADVANCED && row.id === 'importedImageStorage') {
     if (importedImageStorageLoading.value) {
       return t('settings.value.checking')
+    }
+    if (importedImageStorageError.value) {
+      return t('settings.value.unavailable')
     }
     if (!importedImageStorageStats.value) {
       return t('settings.value.androidOnly')
@@ -241,8 +245,10 @@ async function refreshImportedImageStorage() {
   importedImageStorageLoading.value = true
   try {
     importedImageStorageStats.value = await getImportedAndroidImageStorageStats()
+    importedImageStorageError.value = false
   } catch {
     importedImageStorageStats.value = null
+    importedImageStorageError.value = true
   } finally {
     importedImageStorageLoading.value = false
   }

--- a/src/features/settings/settingsContent.test.ts
+++ b/src/features/settings/settingsContent.test.ts
@@ -59,6 +59,7 @@ const EXPECTED_UNFINISHED_ROW_IDS = new Set([
 
 const EXPECTED_DERIVED_ROW_IDS = new Set([
   'deviceInfo',
+  'importedImageStorage',
   'webviewInfo',
 ])
 
@@ -239,7 +240,7 @@ describe('settings content governance', () => {
     const derivedRows = getRows().filter(row => row.implementation === 'derived')
 
     expect(derivedRows.map(row => row.id).sort()).toEqual([...EXPECTED_DERIVED_ROW_IDS].sort())
-    expect(derivedRows.map(row => row.kind)).toEqual(['status', 'status'])
+    expect(derivedRows.map(row => row.kind)).toEqual(['status', 'status', 'status'])
   })
 
   it('keeps choice defaults valid and option ids unique', () => {
@@ -288,5 +289,6 @@ describe('settings content governance', () => {
       .sort()
 
     expect(runtimeActionIds).toEqual([...ADVANCED_MAINTENANCE_ACTION_IDS].sort())
+    expect(runtimeActionIds).toContain('cleanImportedImages')
   })
 })

--- a/src/features/settings/settingsContent.ts
+++ b/src/features/settings/settingsContent.ts
@@ -990,6 +990,21 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
           testId: 'settings-advanced-export-logs',
         },
         {
+          kind: 'status',
+          id: 'importedImageStorage',
+          implementation: 'derived',
+          labelKey: 'settings.advanced.importedImageStorage',
+          valueKey: 'settings.value.androidOnly',
+          testId: 'settings-advanced-imported-image-storage',
+        },
+        {
+          kind: 'action',
+          id: 'cleanImportedImages',
+          implementation: 'runtime',
+          labelKey: 'settings.advanced.cleanImportedImages',
+          testId: 'settings-advanced-clean-imported-images',
+        },
+        {
           kind: 'action',
           id: 'clearDrafts',
           implementation: 'runtime',

--- a/src/lib/androidDocuments.ts
+++ b/src/lib/androidDocuments.ts
@@ -167,7 +167,10 @@ interface AndroidDocumentsPlugin {
   configureMarkdownSettings(options: AndroidMarkdownSettings): Promise<void>
   getImportedImageDirectory(): Promise<{ fileUri: string; webBaseUri?: string }>
   getImportedImageStorageStats(): Promise<{ fileCount: number; bytes: number }>
-  cleanupImportedImages(options: { referencedFileNames: string[] }): Promise<{
+  cleanupImportedImages(options: {
+    referencedFileNames: string[]
+    managedFileNames: string[]
+  }): Promise<{
     fileCount: number
     bytes: number
     removedFileCount: number

--- a/src/lib/androidDocuments.ts
+++ b/src/lib/androidDocuments.ts
@@ -166,6 +166,14 @@ interface AndroidDocumentsPlugin {
   }): Promise<SavedAndroidDocument>
   configureMarkdownSettings(options: AndroidMarkdownSettings): Promise<void>
   getImportedImageDirectory(): Promise<{ fileUri: string; webBaseUri?: string }>
+  getImportedImageStorageStats(): Promise<{ fileCount: number; bytes: number }>
+  cleanupImportedImages(options: { referencedFileNames: string[] }): Promise<{
+    fileCount: number
+    bytes: number
+    removedFileCount: number
+    removedBytes: number
+    failedFileCount: number
+  }>
   pickImageDocument(options?: { copyImage?: boolean }): Promise<{
     canceled?: false
     sourceUri: string

--- a/src/lib/androidImages.test.ts
+++ b/src/lib/androidImages.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { AndroidImageError, resolveMarkTextImageSource } from './androidImages'
+import {
+  AndroidImageError,
+  collectMarkTextLocalImageFileNames,
+  formatImportedImageStorageBytes,
+  resolveMarkTextImageSource,
+} from './androidImages'
 
 describe('androidImages', () => {
   it('resolves app-local Markdown image sources', () => {
@@ -48,5 +53,23 @@ describe('androidImages', () => {
         fileUri: 'file:///data/user/0/io.github.renakoni.marktextandroid/files/images',
       }),
     ).toThrow(AndroidImageError)
+  })
+
+  it('collects unique app-local image references from Markdown and HTML', () => {
+    expect(collectMarkTextLocalImageFileNames(`
+![first](marktext-image://local/1700000000000-a1b2c3d4-first.png)
+<img src="marktext-image://local/1700000000001-b2c3d4e5-second.webp">
+![duplicate](marktext-image://local/1700000000000-a1b2c3d4-first.png)
+![linked](marktext-image://android/content%3A%2F%2Fmedia%2Fimage%2F1)
+`)).toEqual([
+      '1700000000000-a1b2c3d4-first.png',
+      '1700000000001-b2c3d4e5-second.webp',
+    ])
+  })
+
+  it('formats imported image storage without overstating precision', () => {
+    expect(formatImportedImageStorageBytes(0, 'en')).toBe('0 B')
+    expect(formatImportedImageStorageBytes(1536, 'en')).toBe('1.5 KB')
+    expect(formatImportedImageStorageBytes(5 * 1024 * 1024, 'en')).toBe('5 MB')
   })
 })

--- a/src/lib/androidImages.ts
+++ b/src/lib/androidImages.ts
@@ -24,6 +24,17 @@ export interface AndroidImagePickOptions {
   copyImage: boolean
 }
 
+export interface ImportedAndroidImageStorageStats {
+  fileCount: number
+  bytes: number
+}
+
+export interface ImportedAndroidImageCleanupResult extends ImportedAndroidImageStorageStats {
+  removedFileCount: number
+  removedBytes: number
+  failedFileCount: number
+}
+
 export class AndroidImageError extends Error {
   code: string
 
@@ -36,6 +47,7 @@ export class AndroidImageError extends Error {
 
 const MARKTEXT_LOCAL_IMAGE_SOURCE_REGEXP = /^marktext-image:\/\/local\/([^/?#]+)$/i
 const MARKTEXT_ANDROID_IMAGE_SOURCE_REGEXP = /^marktext-image:\/\/android\/([^/?#]+)$/i
+const MARKTEXT_LOCAL_IMAGE_REFERENCE_REGEXP = /marktext-image:\/\/local\/([^/?#\s"'<>()[\]]+)/gi
 
 let imageDirectory: ImportedAndroidImageDirectory | null = null
 
@@ -127,6 +139,56 @@ export async function pickAndroidImageDocument(
   return normalizeImportedImage(result)
 }
 
+export async function getImportedAndroidImageStorageStats() {
+  if (!isAndroidImageImportAvailable()) {
+    return null
+  }
+  return normalizeStorageStats(await AndroidDocuments.getImportedImageStorageStats())
+}
+
+export async function cleanupImportedAndroidImages(referencedFileNames: readonly string[]) {
+  ensureAndroidImagesAvailable()
+  const result = await AndroidDocuments.cleanupImportedImages({
+    referencedFileNames: [...new Set(referencedFileNames)],
+  })
+  return {
+    ...normalizeStorageStats(result),
+    removedFileCount: normalizeCount(result.removedFileCount),
+    removedBytes: normalizeBytes(result.removedBytes),
+    failedFileCount: normalizeCount(result.failedFileCount),
+  } satisfies ImportedAndroidImageCleanupResult
+}
+
+export function collectMarkTextLocalImageFileNames(markdown: string) {
+  const fileNames = new Set<string>()
+  for (const match of markdown.matchAll(MARKTEXT_LOCAL_IMAGE_REFERENCE_REGEXP)) {
+    try {
+      const fileName = getMarkTextLocalImageFileName(`marktext-image://local/${match[1]}`)
+      if (fileName) {
+        fileNames.add(fileName)
+      }
+    } catch {
+      // Malformed sources cannot name a file created by the import workflow.
+    }
+  }
+  return [...fileNames]
+}
+
+export function formatImportedImageStorageBytes(bytes: number, locale: string) {
+  const safeBytes = normalizeBytes(bytes)
+  const units = ['B', 'KB', 'MB', 'GB'] as const
+  let value = safeBytes
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+  const formatted = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: unitIndex === 0 ? 0 : 1,
+  }).format(value)
+  return `${formatted} ${units[unitIndex]}`
+}
+
 function getAndroidImageErrorCode(error: unknown) {
   if (error instanceof AndroidImageError) {
     return error.code
@@ -204,6 +266,21 @@ function normalizeImportedImage(value: ImportedAndroidImage): ImportedAndroidIma
     fileUri: value.fileUri,
     bytes: typeof value.bytes === 'number' ? value.bytes : 0,
   }
+}
+
+function normalizeStorageStats(value: ImportedAndroidImageStorageStats) {
+  return {
+    fileCount: normalizeCount(value.fileCount),
+    bytes: normalizeBytes(value.bytes),
+  }
+}
+
+function normalizeCount(value: number) {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
+}
+
+function normalizeBytes(value: number) {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
 }
 
 function getMarkTextLocalImageFileName(source: string) {

--- a/src/lib/androidImages.ts
+++ b/src/lib/androidImages.ts
@@ -146,10 +146,14 @@ export async function getImportedAndroidImageStorageStats() {
   return normalizeStorageStats(await AndroidDocuments.getImportedImageStorageStats())
 }
 
-export async function cleanupImportedAndroidImages(referencedFileNames: readonly string[]) {
+export async function cleanupImportedAndroidImages(
+  referencedFileNames: readonly string[],
+  managedFileNames: readonly string[],
+) {
   ensureAndroidImagesAvailable()
   const result = await AndroidDocuments.cleanupImportedImages({
     referencedFileNames: [...new Set(referencedFileNames)],
+    managedFileNames: [...new Set(managedFileNames)],
   })
   return {
     ...normalizeStorageStats(result),

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -372,6 +372,8 @@ const MESSAGES = {
     'settings.spelling.removeWord': 'Remove word',
 
     'settings.advanced.exportLogs': 'Export logs',
+    'settings.advanced.importedImageStorage': 'Imported images',
+    'settings.advanced.cleanImportedImages': 'Clean unused images',
     'settings.advanced.clearDrafts': 'Clear local drafts',
     'settings.advanced.reset': 'Reset settings',
     'settings.advanced.diagnostics': 'Device info',
@@ -396,6 +398,18 @@ const MESSAGES = {
     'settings.maintenance.exportLogsAction': 'Export',
     'settings.maintenance.exportLogsConfirm': 'Export ZIP',
     'settings.maintenance.exportLogsUnavailable': 'Export logs from the Android app build.',
+    'settings.maintenance.cleanImagesTitle': 'Clean unused images?',
+    'settings.maintenance.cleanImagesBody':
+      'Checks the current document, local drafts, and recent files for unused imported images.',
+    'settings.maintenance.cleanImagesAction': 'Clean up',
+    'settings.maintenance.cleanImagesConfirm': 'Clean up',
+    'settings.maintenance.cleanImagesUnavailable': 'Clean imported images from the Android app build.',
+    'settings.maintenance.cleanImagesUnreadable': 'Could not check {count} recent files.',
+    'settings.maintenance.cleanImagesNone': 'Nothing to clean up.',
+    'settings.maintenance.cleanImagesSuccess': 'Cleaned up {count} images · {size} freed.',
+    'settings.maintenance.cleanImagesPartial':
+      'Cleaned up {count} images · {size} freed · {failed} failed.',
+    'settings.maintenance.cleanImagesFailed': '{count} images could not be cleaned up.',
     'settings.maintenance.clearDraftsTitle': 'Clear local drafts?',
     'settings.maintenance.clearDraftsBody':
       'This removes local drafts stored inside MarkText. Markdown files on the device are not deleted.',
@@ -406,6 +420,7 @@ const MESSAGES = {
       'This restores settings to defaults. Documents and local drafts are not deleted.',
     'settings.maintenance.resetSettingsAction': 'Reset',
     'settings.maintenance.resetSettingsConfirm': 'Reset',
+    'settings.maintenance.done': 'Done',
     'settings.maintenance.genericError': 'Action failed.',
 
     'settings.value.on': 'On',
@@ -414,6 +429,9 @@ const MESSAGES = {
     'settings.value.default': 'Default',
     'settings.value.medium': 'Medium',
     'settings.value.normal': 'Normal',
+    'settings.value.androidOnly': 'Android app only',
+    'settings.value.checking': 'Checking…',
+    'settings.value.importedImageStorageUsage': 'Files: {count} · {size}',
     'settings.value.format': 'Format',
     'settings.value.atxHeading': 'ATX (#)',
     'settings.value.yaml': 'YAML',
@@ -940,6 +958,8 @@ const MESSAGES = {
     'settings.spelling.removeWord': '移除词',
 
     'settings.advanced.exportLogs': '导出日志',
+    'settings.advanced.importedImageStorage': '导入的图片',
+    'settings.advanced.cleanImportedImages': '清理未使用图片',
     'settings.advanced.clearDrafts': '清除本地草稿',
     'settings.advanced.reset': '重置设置',
     'settings.advanced.diagnostics': '设备信息',
@@ -964,6 +984,18 @@ const MESSAGES = {
     'settings.maintenance.exportLogsAction': '导出',
     'settings.maintenance.exportLogsConfirm': '导出压缩包',
     'settings.maintenance.exportLogsUnavailable': '请在 Android 应用内导出日志。',
+    'settings.maintenance.cleanImagesTitle': '清理未使用的图片？',
+    'settings.maintenance.cleanImagesBody':
+      '检查当前文档、本地草稿和最近文件，清理未引用的导入图片。',
+    'settings.maintenance.cleanImagesAction': '清理',
+    'settings.maintenance.cleanImagesConfirm': '清理',
+    'settings.maintenance.cleanImagesUnavailable': '请在 Android 应用内清理导入图片。',
+    'settings.maintenance.cleanImagesUnreadable': '无法检查 {count} 个最近文件。',
+    'settings.maintenance.cleanImagesNone': '没有可清理的图片。',
+    'settings.maintenance.cleanImagesSuccess': '已清理 {count} 张图片 · 释放 {size}',
+    'settings.maintenance.cleanImagesPartial':
+      '已清理 {count} 张图片 · 释放 {size} · {failed} 张失败',
+    'settings.maintenance.cleanImagesFailed': '{count} 张图片清理失败。',
     'settings.maintenance.clearDraftsTitle': '清除本地草稿？',
     'settings.maintenance.clearDraftsBody':
       '这会删除保存在 MarkText 内的本地草稿，不会删除设备上的 Markdown 文件。',
@@ -974,6 +1006,7 @@ const MESSAGES = {
       '这会恢复所有设置为默认值，不会删除文档和本地草稿。',
     'settings.maintenance.resetSettingsAction': '重置',
     'settings.maintenance.resetSettingsConfirm': '重置',
+    'settings.maintenance.done': '完成',
     'settings.maintenance.genericError': '操作失败。',
 
     'settings.value.on': '开',
@@ -982,6 +1015,9 @@ const MESSAGES = {
     'settings.value.default': '默认',
     'settings.value.medium': '中',
     'settings.value.normal': '标准',
+    'settings.value.androidOnly': '仅 Android 应用',
+    'settings.value.checking': '正在检查…',
+    'settings.value.importedImageStorageUsage': '文件：{count} · {size}',
     'settings.value.format': '格式',
     'settings.value.atxHeading': 'ATX (#)',
     'settings.value.yaml': 'YAML',

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -404,12 +404,17 @@ const MESSAGES = {
     'settings.maintenance.cleanImagesAction': 'Clean up',
     'settings.maintenance.cleanImagesConfirm': 'Clean up',
     'settings.maintenance.cleanImagesUnavailable': 'Clean imported images from the Android app build.',
-    'settings.maintenance.cleanImagesUnreadable': 'Could not check {count} recent files.',
+    'settings.maintenance.cleanImagesUnreadable.one': 'Could not check 1 recent file.',
+    'settings.maintenance.cleanImagesUnreadable.other': 'Could not check {count} recent files.',
     'settings.maintenance.cleanImagesNone': 'Nothing to clean up.',
-    'settings.maintenance.cleanImagesSuccess': 'Cleaned up {count} images · {size} freed.',
-    'settings.maintenance.cleanImagesPartial':
-      'Cleaned up {count} images · {size} freed · {failed} failed.',
-    'settings.maintenance.cleanImagesFailed': '{count} images could not be cleaned up.',
+    'settings.maintenance.cleanImagesSuccess.one': 'Cleaned up 1 image · {size} freed.',
+    'settings.maintenance.cleanImagesSuccess.other': 'Cleaned up {count} images · {size} freed.',
+    'settings.maintenance.cleanImagesPartial.one':
+      'Cleaned up 1 image · {size} freed · Failed: {failed}',
+    'settings.maintenance.cleanImagesPartial.other':
+      'Cleaned up {count} images · {size} freed · Failed: {failed}',
+    'settings.maintenance.cleanImagesFailed.one': '1 image could not be cleaned up.',
+    'settings.maintenance.cleanImagesFailed.other': '{count} images could not be cleaned up.',
     'settings.maintenance.clearDraftsTitle': 'Clear local drafts?',
     'settings.maintenance.clearDraftsBody':
       'This removes local drafts stored inside MarkText. Markdown files on the device are not deleted.',
@@ -430,6 +435,7 @@ const MESSAGES = {
     'settings.value.medium': 'Medium',
     'settings.value.normal': 'Normal',
     'settings.value.androidOnly': 'Android app only',
+    'settings.value.unavailable': 'Unavailable',
     'settings.value.checking': 'Checking…',
     'settings.value.importedImageStorageUsage': 'Files: {count} · {size}',
     'settings.value.format': 'Format',
@@ -990,12 +996,17 @@ const MESSAGES = {
     'settings.maintenance.cleanImagesAction': '清理',
     'settings.maintenance.cleanImagesConfirm': '清理',
     'settings.maintenance.cleanImagesUnavailable': '请在 Android 应用内清理导入图片。',
-    'settings.maintenance.cleanImagesUnreadable': '无法检查 {count} 个最近文件。',
+    'settings.maintenance.cleanImagesUnreadable.one': '无法检查 {count} 个最近文件。',
+    'settings.maintenance.cleanImagesUnreadable.other': '无法检查 {count} 个最近文件。',
     'settings.maintenance.cleanImagesNone': '没有可清理的图片。',
-    'settings.maintenance.cleanImagesSuccess': '已清理 {count} 张图片 · 释放 {size}',
-    'settings.maintenance.cleanImagesPartial':
+    'settings.maintenance.cleanImagesSuccess.one': '已清理 {count} 张图片 · 释放 {size}',
+    'settings.maintenance.cleanImagesSuccess.other': '已清理 {count} 张图片 · 释放 {size}',
+    'settings.maintenance.cleanImagesPartial.one':
       '已清理 {count} 张图片 · 释放 {size} · {failed} 张失败',
-    'settings.maintenance.cleanImagesFailed': '{count} 张图片清理失败。',
+    'settings.maintenance.cleanImagesPartial.other':
+      '已清理 {count} 张图片 · 释放 {size} · {failed} 张失败',
+    'settings.maintenance.cleanImagesFailed.one': '{count} 张图片清理失败。',
+    'settings.maintenance.cleanImagesFailed.other': '{count} 张图片清理失败。',
     'settings.maintenance.clearDraftsTitle': '清除本地草稿？',
     'settings.maintenance.clearDraftsBody':
       '这会删除保存在 MarkText 内的本地草稿，不会删除设备上的 Markdown 文件。',
@@ -1016,6 +1027,7 @@ const MESSAGES = {
     'settings.value.medium': '中',
     'settings.value.normal': '标准',
     'settings.value.androidOnly': '仅 Android 应用',
+    'settings.value.unavailable': '暂不可用',
     'settings.value.checking': '正在检查…',
     'settings.value.importedImageStorageUsage': '文件：{count} · {size}',
     'settings.value.format': '格式',


### PR DESCRIPTION
## Summary

- add native imported-image storage stats and orphan cleanup under Settings > Advanced > Maintenance
- scan the current document, local and recovery drafts, and readable Android recent documents
- keep a persistent, monotonic protection set for images ever observed in Android documents
- use concise English and Simplified Chinese confirmation and result copy

## Safety

- images that existed before this registry are never eligible for deletion
- images ever referenced by an Android document remain protected after that document leaves the 50-item recent list
- abort before deletion if an app-tracked recent document cannot be read
- native cleanup deletes only regular files that are both in the managed allowlist and absent from the reference set
- caller-provided paths are never accepted or constructed

Android SAF cannot enumerate arbitrary Markdown files across device storage. The cleanup therefore fails toward retention: files that cannot be proven safe to remove are kept.

## Review follow-up

- fixed singular English cleanup messages
- distinguish transient storage-stat errors from the non-Android state
- left the theoretical app-private `File.delete()` runtime-exception boundary unchanged because an outer catch cannot reconstruct partial deletion statistics

## Validation

- `pnpm test`: 67 files, 509 tests
- `pnpm typecheck`
- `pnpm lint`
- Vite production build and Capacitor Android sync
- Android Java unit tests and `lintDebug`
- offline `assembleDebug`
- installed the final APK on a Xiaomi 23127PN0CC running Android 14
- verified on-device that a managed orphan is deleted, an unmanaged legacy file is retained, and a managed referenced file is retained
- removed all test files; the app-private image directory is empty