### PR TITLE
Hide link sheet background from accessibility

### DIFF
--- a/src/features/editor/EditorScreen.vue
+++ b/src/features/editor/EditorScreen.vue
@@ -144,9 +144,31 @@ const selectionToolbarSuspended = computed(
     props.androidExitPromptOpen ||
     props.incomingOpenPromptOpen,
 )
+const linkInsertDispatching = ref(false)
+const linkInsertSheet = ref<InstanceType<typeof LinkInsertSheet> | null>(null)
 const linkSheetBackgroundAriaHidden = computed(() =>
-  props.linkSheetOpen ? 'true' : undefined,
+  props.linkSheetOpen && !linkInsertDispatching.value ? 'true' : undefined,
 )
+
+async function dispatchLinkInsert() {
+  if (linkInsertDispatching.value) {
+    return
+  }
+
+  linkInsertDispatching.value = true
+  try {
+    // Keep the sheet and captured selection intact, but flush aria-hidden off
+    // the editor before App temporarily focuses it for the insertion.
+    await nextTick()
+    emit('insert-link')
+    await nextTick()
+  } finally {
+    if (props.linkSheetOpen) {
+      linkInsertSheet.value?.focusInitialInput()
+    }
+    linkInsertDispatching.value = false
+  }
+}
 
 const searchInput = ref<HTMLInputElement | null>(null)
 const outlineButton = ref<HTMLButtonElement | null>(null)
@@ -499,12 +521,13 @@ onBeforeUnmount(() => {
     <Transition name="editor-sheet">
       <LinkInsertSheet
         v-if="linkSheetOpen"
+        ref="linkInsertSheet"
         :text="linkText"
         :url="linkUrl"
         @update:text="value => emit('update:linkText', value)"
         @update:url="value => emit('update:linkUrl', value)"
         @cancel="emit('close-link-sheet')"
-        @insert="emit('insert-link')"
+        @insert="dispatchLinkInsert"
       />
     </Transition>
 

--- a/src/features/editor/EditorScreen.vue
+++ b/src/features/editor/EditorScreen.vue
@@ -144,6 +144,9 @@ const selectionToolbarSuspended = computed(
     props.androidExitPromptOpen ||
     props.incomingOpenPromptOpen,
 )
+const linkSheetBackgroundAriaHidden = computed(() =>
+  props.linkSheetOpen ? 'true' : undefined,
+)
 
 const searchInput = ref<HTMLInputElement | null>(null)
 const outlineButton = ref<HTMLButtonElement | null>(null)
@@ -243,6 +246,7 @@ onBeforeUnmount(() => {
       class="top-bar search-bar"
       data-testid="editor-search-bar"
       :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
+      :aria-hidden="linkSheetBackgroundAriaHidden"
     >
       <button
         class="nav-button"
@@ -308,7 +312,12 @@ onBeforeUnmount(() => {
         </button>
       </div>
     </header>
-    <header v-else class="top-bar" :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen">
+    <header
+      v-else
+      class="top-bar"
+      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
+      :aria-hidden="linkSheetBackgroundAriaHidden"
+    >
       <button
         class="nav-button"
         type="button"
@@ -375,7 +384,12 @@ onBeforeUnmount(() => {
       </div>
     </header>
 
-    <section class="editor-pane" :aria-label="t('editor.markdownEditor')" :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen">
+    <section
+      class="editor-pane"
+      :aria-label="t('editor.markdownEditor')"
+      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
+      :aria-hidden="linkSheetBackgroundAriaHidden"
+    >
       <div
         ref="editorShell"
         class="editor-host-shell"
@@ -408,6 +422,7 @@ onBeforeUnmount(() => {
 
     <MobileSelectionToolbar
       :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
+      :aria-hidden="linkSheetBackgroundAriaHidden"
       :editor-ready="editorReady"
       :suspended="selectionToolbarSuspended"
       :host="editorShell"
@@ -426,6 +441,7 @@ onBeforeUnmount(() => {
 
     <LinkActionOverlay
       :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
+      :aria-hidden="linkSheetBackgroundAriaHidden"
       :editor-ready="editorReady"
       :suspended="selectionToolbarSuspended"
       :caret-session="selectionCaretSession"
@@ -437,6 +453,7 @@ onBeforeUnmount(() => {
     <MobileEditorToolbar
       v-if="toolbarVisible && !editorFailed"
       :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
+      :aria-hidden="linkSheetBackgroundAriaHidden"
       :expanded="toolbarExpanded"
       :active-panel="toolbarPanel"
       :editor-ready="editorReady"

--- a/src/features/editor/components/LinkInsertSheet.vue
+++ b/src/features/editor/components/LinkInsertSheet.vue
@@ -34,10 +34,9 @@ onMounted(() => {
 })
 
 // Keyboard containment relies on this Tab trap ALONE (aria-modal does not
-// contain focus). Unlike the outline and table sheets, the background must
-// NOT be inert here: the confirm inserts through focus + execCommand into
-// the still-mounted editor, and an inert editor refuses focus, which turns
-// every insert into a silent failure.
+// contain focus). EditorScreen removes the background from the accessibility
+// tree with aria-hidden, but keeps it non-inert so confirm can temporarily
+// focus the still-mounted editor for insertion.
 function trapTabKey(event: KeyboardEvent) {
   const root = panel.value
   if (!root) {

--- a/src/features/editor/components/LinkInsertSheet.vue
+++ b/src/features/editor/components/LinkInsertSheet.vue
@@ -27,9 +27,15 @@ const urlValue = computed({
   set: value => emit('update:url', value),
 })
 
+function focusInitialInput() {
+  linkUrlInput.value?.focus()
+}
+
+defineExpose({ focusInitialInput })
+
 onMounted(() => {
   void nextTick(() => {
-    linkUrlInput.value?.focus()
+    focusInitialInput()
   })
 })
 

--- a/src/features/editor/editorModalAccessibilityContract.test.ts
+++ b/src/features/editor/editorModalAccessibilityContract.test.ts
@@ -6,12 +6,29 @@ const editorScreenSource = readFileSync(
   'utf8',
 )
 
-function openingTag(marker: string) {
-  const start = editorScreenSource.indexOf(marker)
+function openingTag(source: string, marker: string) {
+  const start = source.indexOf(marker)
   if (start < 0) {
     throw new Error(`Missing editor surface: ${marker}`)
   }
-  return editorScreenSource.slice(start, editorScreenSource.indexOf('>', start) + 1)
+
+  let quote: '"' | "'" | null = null
+  for (let index = start; index < source.length; index += 1) {
+    const character = source[index]
+    if (quote) {
+      if (character === quote) {
+        quote = null
+      }
+      continue
+    }
+    if (character === '"' || character === "'") {
+      quote = character
+    } else if (character === '>') {
+      return source.slice(start, index + 1)
+    }
+  }
+
+  throw new Error(`Unterminated editor surface: ${marker}`)
 }
 
 describe('editor modal accessibility contract', () => {
@@ -26,7 +43,15 @@ describe('editor modal accessibility contract', () => {
     ]
 
     for (const surface of backgroundSurfaces) {
-      expect(openingTag(surface)).toContain(':aria-hidden="linkSheetBackgroundAriaHidden"')
+      expect(openingTag(editorScreenSource, surface)).toContain(
+        ':aria-hidden="linkSheetBackgroundAriaHidden"',
+      )
     }
+  })
+
+  it('does not mistake an arrow handler for the end of an opening tag', () => {
+    const source = '<button @click="value => save(value)" :aria-hidden="hidden">'
+
+    expect(openingTag(source, '<button')).toContain(':aria-hidden="hidden"')
   })
 })

--- a/src/features/editor/editorModalAccessibilityContract.test.ts
+++ b/src/features/editor/editorModalAccessibilityContract.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const editorScreenSource = readFileSync(
+  new URL('./EditorScreen.vue', import.meta.url),
+  'utf8',
+)
+
+function openingTag(marker: string) {
+  const start = editorScreenSource.indexOf(marker)
+  if (start < 0) {
+    throw new Error(`Missing editor surface: ${marker}`)
+  }
+  return editorScreenSource.slice(start, editorScreenSource.indexOf('>', start) + 1)
+}
+
+describe('editor modal accessibility contract', () => {
+  it('hides every editor background surface while the link sheet is open', () => {
+    const backgroundSurfaces = [
+      '<header\n      v-if="searchOpen"',
+      '<header\n      v-else',
+      '<section\n      class="editor-pane"',
+      '<MobileSelectionToolbar',
+      '<LinkActionOverlay',
+      '<MobileEditorToolbar',
+    ]
+
+    for (const surface of backgroundSurfaces) {
+      expect(openingTag(surface)).toContain(':aria-hidden="linkSheetBackgroundAriaHidden"')
+    }
+  })
+})

--- a/tests/e2e/mobile-editor-toolbar.spec.ts
+++ b/tests/e2e/mobile-editor-toolbar.spec.ts
@@ -1016,9 +1016,35 @@ test('inserts a link from selected editor text through the mobile link sheet', a
   await expect(page.getByTestId('link-insert-sheet')).toBeVisible()
   await expect(page.getByTestId('link-text-input')).toHaveValue('MarkText for Android')
   await page.getByTestId('link-url-input').fill('https://github.com/Renakoni/marktext-android')
+  await page.evaluate(() => {
+    const state = window as typeof window & {
+      __linkHiddenFocusViolation?: boolean
+      __linkHiddenFocusListener?: (event: FocusEvent) => void
+    }
+    state.__linkHiddenFocusViolation = false
+    state.__linkHiddenFocusListener = event => {
+      if (
+        event.target instanceof Element
+        && event.target.closest('[aria-hidden="true"]')
+      ) {
+        state.__linkHiddenFocusViolation = true
+      }
+    }
+    document.addEventListener('focusin', state.__linkHiddenFocusListener)
+  })
   await page.getByTestId('link-insert-button').click()
 
   await expect(page.getByTestId('link-insert-sheet')).toBeHidden()
+  expect(await page.evaluate(() => {
+    const state = window as typeof window & {
+      __linkHiddenFocusViolation?: boolean
+      __linkHiddenFocusListener?: (event: FocusEvent) => void
+    }
+    if (state.__linkHiddenFocusListener) {
+      document.removeEventListener('focusin', state.__linkHiddenFocusListener)
+    }
+    return state.__linkHiddenFocusViolation
+  })).toBe(false)
   await expect.poll(() => getDraftStorage(page)).toContain(
     '[MarkText for Android](https://github.com/Renakoni/marktext-android)',
   )

--- a/tests/e2e/mobile-editor-toolbar.spec.ts
+++ b/tests/e2e/mobile-editor-toolbar.spec.ts
@@ -584,6 +584,19 @@ test('the link sheet contains keyboard focus and rescues it on cancel', async ({
   await page.getByTestId('toolbar-command-format.hyperlink').click()
   await expect(page.getByTestId('link-insert-sheet')).toBeVisible()
 
+  const backgroundSurfaces = [
+    page.locator('header.top-bar'),
+    page.locator('section.editor-pane'),
+    page.getByTestId('mobile-editor-toolbar'),
+  ]
+  for (const surface of backgroundSurfaces) {
+    await expect(surface).toHaveAttribute('aria-hidden', 'true')
+  }
+  await expect.poll(() =>
+    page.getByTestId('link-insert-sheet').evaluate(element =>
+      element.closest('[aria-hidden="true"]') === null,
+    )).toBe(true)
+
   const activeTestId = () =>
     page.evaluate(
       () =>
@@ -608,6 +621,9 @@ test('the link sheet contains keyboard focus and rescues it on cancel', async ({
   // Closing without inserting must not leave focus dangling on <body>.
   await page.getByTestId('link-cancel-button').click()
   await expect(page.getByTestId('link-insert-sheet')).toBeHidden()
+  for (const surface of backgroundSurfaces) {
+    await expect(surface).not.toHaveAttribute('aria-hidden', 'true')
+  }
   await expect.poll(activeTestId).toBe('toolbar-expand-button')
 })
 


### PR DESCRIPTION
## Summary

- hide the editor background from the accessibility tree while the link-insert dialog is open
- cover the top bar, editor content, floating selection/link controls, and bottom toolbar
- temporarily remove background `aria-hidden` before Muya focuses the editor for insertion
- restore dialog focus and background isolation when insertion does not complete
- remove `aria-hidden` automatically when the sheet closes

## Why `aria-hidden`

The link insertion path temporarily focuses the still-mounted editor to restore the captured selection and execute the insert. Making the editor inert would block that focus and break insertion. The sheet therefore isolates background accessibility with `aria-hidden`, then waits for Vue to remove it before dispatching the focus-based insertion.

## Tests

- add a source contract covering every editor background surface
- harden the contract helper against `=>` inside Vue attribute values
- extend the existing link-sheet E2E coverage to reject focus entering an `aria-hidden` subtree
- `pnpm test`: 68 files, 511 tests
- `pnpm typecheck`
- `pnpm lint`
- Vite production build and Capacitor Android sync
- offline Android `assembleDebug`

## Physical device verification

Installed the initial PR APK on a Xiaomi 23127PN0CC running Android 14. The WebView AX tree contained only the link dialog, heading, text/URL fields, and Insert/Cancel controls while the sheet was open. Back, Search, Outline, More actions, editor content, and the bottom toolbar were absent. Cancel restored the background attributes and focus to the toolbar trigger.

The device disconnected before the follow-up insertion-transition build could be installed. Spoken TalkBack traversal was not executed.