### PR TITLE
Preserve alt text in broken image fallbacks

### DIFF
--- a/tests/e2e/mobile-markdown-editing.spec.ts
+++ b/tests/e2e/mobile-markdown-editing.spec.ts
@@ -38,6 +38,26 @@ test('toggles a task list checkbox and persists the checked markdown state', asy
   await expect.poll(() => getDraftStorage(page)).toContain('- [x] Tap this task')
 })
 
+test('keeps broken image alt text visible and accessible', async ({ page }) => {
+  await page.route('https://example.com/broken-alt.png', route => route.abort())
+  await openLocalDraft(page, {
+    id: 'broken-image-alt-draft',
+    markdown: `# Broken image
+
+![Descriptive broken image alternative](https://example.com/broken-alt.png)
+`,
+    title: /Broken image/,
+  })
+
+  const fallback = page.locator('.mu-inline-image.mu-image-fail')
+  const failureText = 'Load image failed: Descriptive broken image alternative'
+  await expect(fallback).toHaveAttribute('role', 'img')
+  await expect(fallback).toHaveAttribute('aria-label', failureText)
+  await expect.poll(() =>
+    fallback.evaluate(element => getComputedStyle(element, '::before').content),
+  ).toContain(failureText)
+})
+
 test('continues unordered and ordered lists from mobile keyboard input', async ({ page }) => {
   await newBlankDocument(page)
 

--- a/third_party/muya/src/inlineRenderer/renderer/__tests__/image.spec.ts
+++ b/third_party/muya/src/inlineRenderer/renderer/__tests__/image.spec.ts
@@ -72,6 +72,10 @@ function getWrapperSelector(vnodes: VNode | VNode[]): string {
     return arr[0].sel as string;
 }
 
+function getWrapper(vnodes: VNode | VNode[]): VNode {
+    return Array.isArray(vnodes) ? vnodes[0] : vnodes;
+}
+
 function findImgSrc(vnodes: VNode | VNode[]): string | undefined {
     const arr = Array.isArray(vnodes) ? vnodes : [vnodes];
     let found: string | undefined;
@@ -248,6 +252,44 @@ describe('image renderer — fail / empty wrapper classes', () => {
         expect(selector).toContain('.mu-image-fail');
         expect(selector).not.toContain('.mu-image-success');
         expect(selector).not.toContain('.mu-empty-image');
+    });
+
+    it('keeps the image alt in the visible and accessible failure fallback', () => {
+        const renderer = makeRenderer({
+            id: 'mu-image-alt-failure',
+            isSuccess: false,
+        });
+        const token = makeImageToken({ alt: 'Descriptive broken image alternative' });
+
+        const out = image.call(
+            asRenderer(renderer),
+            { h, block: fakeBlock, token, cursor: fakeCursor },
+        );
+
+        expect(getWrapper(out).data?.attrs).toMatchObject({
+            'fail-text': 'Load image failed: Descriptive broken image alternative',
+            'role': 'img',
+            'aria-label': 'Load image failed: Descriptive broken image alternative',
+        });
+    });
+
+    it('does not add empty punctuation to the fallback for an empty alt', () => {
+        const renderer = makeRenderer({
+            id: 'mu-image-empty-alt-failure',
+            isSuccess: false,
+        });
+        const token = makeImageToken({ alt: '' });
+
+        const out = image.call(
+            asRenderer(renderer),
+            { h, block: fakeBlock, token, cursor: fakeCursor },
+        );
+
+        expect(getWrapper(out).data?.attrs).toMatchObject({
+            'fail-text': 'Load image failed',
+            'role': 'img',
+            'aria-label': 'Load image failed',
+        });
     });
 
     it('adds `mu-empty-image` class when the token has no resolvable src', () => {

--- a/third_party/muya/src/inlineRenderer/renderer/__tests__/loadImageAsync.spec.ts
+++ b/third_party/muya/src/inlineRenderer/renderer/__tests__/loadImageAsync.spec.ts
@@ -238,3 +238,39 @@ describe('loadImageAsync — small image class on first load', () => {
         expect(wrapper.classList.contains('mu-small-image')).toBe(false);
     });
 });
+
+describe('loadImageAsync — accessible failure state on first load', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        document.body.innerHTML = '';
+    });
+
+    it('exposes the rendered failure text as the image accessible name', async () => {
+        const { loadImage } = await import('../../../utils/image');
+        vi.mocked(loadImage).mockRejectedValueOnce(new Error('image unavailable'));
+        const r = makeRenderer();
+
+        const { id } = loadImageAsync.call(
+            asRenderer(r),
+            { isUnknownType: false, src: 'https://example.com/broken.png' },
+            { alt: 'Descriptive broken image alternative' },
+        );
+
+        const wrapper = document.createElement('span');
+        wrapper.id = id!;
+        wrapper.classList.add('mu-inline-image', 'mu-image-loading');
+        wrapper.setAttribute(
+            'fail-text',
+            'Load image failed: Descriptive broken image alternative',
+        );
+        wrapper.appendChild(document.createElement('span'));
+        document.body.appendChild(wrapper);
+
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+        expect(wrapper.getAttribute('role')).toBe('img');
+        expect(wrapper.getAttribute('aria-label')).toBe(
+            'Load image failed: Descriptive broken image alternative',
+        );
+    });
+});

--- a/third_party/muya/src/inlineRenderer/renderer/image.ts
+++ b/third_party/muya/src/inlineRenderer/renderer/image.ts
@@ -83,11 +83,16 @@ export default function image(
     const imageSrc = getImageSrc(token.attrs.src);
     const selectedImage = this.muya.editor.selection.image;
     const { i18n } = this.muya;
+    const alt = token.attrs.alt;
+    const plainAlt = alt.replace(/[`*{}[\]()#+\-.!_>~:|<$]/g, '');
+    const loadFailedText = plainAlt
+        ? `${i18n.t('Load image failed')}: ${plainAlt}`
+        : i18n.t('Load image failed');
     const data = {
         attrs: {
             'contenteditable': 'false',
             'empty-text': i18n.t('Click to add an image'),
-            'fail-text': i18n.t('Load image failed'),
+            'fail-text': loadFailedText,
         },
         dataset: {
             raw: token.raw,
@@ -100,7 +105,6 @@ export default function image(
     let resolvedUrl: string | undefined;
     // `src` stays the plain path — it is the key the `urlMap`/cache lookups use.
     const src = imageSrc.src;
-    const alt = token.attrs.alt;
     const title = token.attrs.title;
     const width = token.attrs.width;
     const height = token.attrs.height;
@@ -191,6 +195,10 @@ export default function image(
         }
         else {
             wrapperSelector += `.${CLASS_NAMES.MU_IMAGE_FAIL}`;
+            Object.assign(data.attrs, {
+                'role': 'img',
+                'aria-label': loadFailedText,
+            });
         }
 
         // Add image selected class name.
@@ -200,7 +208,7 @@ export default function image(
         const renderImage = () => {
             const data = {
                 props: {
-                    alt: alt.replace(/[`*{}[\]()#+\-.!_>~:|<$]/g, ''),
+                    alt: plainAlt,
                     src: imgSrc,
                     title,
                 },

--- a/third_party/muya/src/inlineRenderer/renderer/loadImageAsync.ts
+++ b/third_party/muya/src/inlineRenderer/renderer/loadImageAsync.ts
@@ -97,6 +97,13 @@ export default function loadImageAsync(
                 if (imageText) {
                     operateClassName(imageText, 'remove', CLASS_NAMES.MU_IMAGE_LOADING);
                     operateClassName(imageText, 'add', CLASS_NAMES.MU_IMAGE_FAIL);
+                    if (imageText.classList.contains(CLASS_NAMES.MU_INLINE_IMAGE)) {
+                        const failureText = imageText.getAttribute('fail-text');
+                        if (failureText) {
+                            imageText.setAttribute('role', 'img');
+                            imageText.setAttribute('aria-label', failureText);
+                        }
+                    }
                     const image = imageText.querySelector('img');
                     if (image)
                         image.remove();


### PR DESCRIPTION
## Summary

- keep the parsed Markdown alt text in the visible broken-image fallback
- expose the same localized failure text through `role="img"` and `aria-label`
- cover both cached failure renders and the first asynchronous load failure
- leave reference-image rendering unchanged

## Tests

- Muya targeted regression tests: 22 passed
- `pnpm test:muya`: 209 files, 1415 tests
- `pnpm test`: 68 files, 511 tests
- `pnpm typecheck`
- `pnpm lint`
- targeted Muya ESLint with `--no-ignore`
- Vite production build and Capacitor Android sync
- offline Android `assembleDebug`
- added browser E2E coverage for visible pseudo-content and the accessible name; not run locally

## Verification limits

No ADB device was connected, so the final APK was not installed. Muya's standalone `lint:types` still hits the existing `ImportMeta.glob` typing errors, and its package-level `lint` script still references the absent `test` directory.