### PR TITLE
Unify modal accessibility behavior

### DIFF
--- a/refs/modal-accessibility-audit-2026-07-14.md
+++ b/refs/modal-accessibility-audit-2026-07-14.md
@@ -1,0 +1,91 @@
+# Android modal accessibility audit (2026-07-14)
+
+## Decision
+
+All ten application dialogs now share one focus and background-isolation
+contract. The browser test matrix and representative Android accessibility
+trees show that focus enters the active dialog, keyboard focus cannot escape,
+background controls leave the accessibility tree, and focus is restored after
+close.
+
+## Scope
+
+- Editor document actions
+- Outline
+- Link insertion
+- Table insertion
+- Local-draft exit decision
+- Android-document exit decision
+- Incoming-document decision
+- Home delete confirmation
+- Home rename
+- Settings maintenance confirmation
+
+Every `role="dialog"` component uses `useModalFocus`. The shared helper owns
+initial focus, Escape handling, Tab and Shift+Tab wrapping, sibling isolation,
+attribute restoration, and trigger focus restoration.
+
+Link insertion is the only deliberate non-inert exception. Muya must briefly
+focus the mounted editor to restore its saved selection. While the sheet is
+open, EditorScreen removes background surfaces from the accessibility tree
+with `aria-hidden`; immediately before insertion it removes that state, waits
+for Vue to flush, restores the selection, and then returns focus to the sheet
+if it remains open.
+
+## Automated evidence
+
+- `src/lib/modalFocus.test.ts`: Tab wrapping, stray-focus recovery, complete
+  sibling isolation, exact attribute restoration, and no-control behavior.
+- `src/lib/modalFocusContract.test.ts`: all ten dialogs use the shared
+  lifecycle; link insertion is the sole non-inert exception.
+- `tests/e2e/mobile-modal-accessibility.spec.ts`: editor actions, exit prompt,
+  incoming open, home delete/rename, and settings maintenance. Each case checks
+  initial focus, every background branch, repeated Tab traversal, close, and
+  focus restoration.
+
+The existing related mobile E2E set also covers outline, link, table, Android
+Back, and editor selection restoration.
+
+## Device evidence
+
+- Device: Xiaomi 23127PN0CC (`4dd67ae4`)
+- Android: 14 / API 34
+- WebView: `com.google.android.webview` 149.0.7827.91
+- TalkBack service: `com.google.android.marvin.talkback/.TalkBackService`
+
+With TalkBack active, the settings maintenance tree contained only one
+`AlertDialog`, its title/body, and its two actions. Home, settings navigation,
+and bottom navigation were absent; focus was inside the dialog. The captured
+tree is local at `logs/talkback-settings-modal.xml`.
+
+After spoken feedback was stopped, CDP accessibility trees were collected for
+three additional app surfaces:
+
+| Surface | Exposed interactive nodes | Background | Initial focus |
+| --- | --- | --- | --- |
+| Editor actions | Dialog plus Share, Export PDF, Save to device | Absent | Share |
+| Link insertion | Dialog, Text/URL fields, Insert, Cancel | Absent | URL field |
+| Home delete | Dialog, Delete, Cancel | Absent | Inside dialog |
+
+The incoming-document prompt is covered by the Android event mock E2E because
+reproducing a blocked preservation transaction on the user's live document
+would require changing persistence settings and injecting unsaved content.
+
+## Device restoration
+
+The device began with accessibility disabled, no enabled accessibility
+services, and touch exploration disabled. Those exact values were restored:
+
+- `accessibility_enabled=0`
+- `enabled_accessibility_services=null`
+- `touch_exploration_enabled=0`
+
+Media volume was restored to its original index 75 and verified unmuted.
+
+## Remaining limit
+
+Spoken announcement wording and swipe order were not listened through on every
+dialog. TalkBack was stopped when its speech disturbed the device owner. The
+structural accessibility and focus contract is covered across all dialogs;
+future manual release checks can sample spoken wording without changing the
+implementation contract.

--- a/src/features/editor/EditorScreen.vue
+++ b/src/features/editor/EditorScreen.vue
@@ -267,7 +267,6 @@ onBeforeUnmount(() => {
       v-if="searchOpen"
       class="top-bar search-bar"
       data-testid="editor-search-bar"
-      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
       :aria-hidden="linkSheetBackgroundAriaHidden"
     >
       <button
@@ -337,7 +336,6 @@ onBeforeUnmount(() => {
     <header
       v-else
       class="top-bar"
-      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
       :aria-hidden="linkSheetBackgroundAriaHidden"
     >
       <button
@@ -409,7 +407,6 @@ onBeforeUnmount(() => {
     <section
       class="editor-pane"
       :aria-label="t('editor.markdownEditor')"
-      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
       :aria-hidden="linkSheetBackgroundAriaHidden"
     >
       <div
@@ -443,7 +440,6 @@ onBeforeUnmount(() => {
     </section>
 
     <MobileSelectionToolbar
-      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
       :aria-hidden="linkSheetBackgroundAriaHidden"
       :editor-ready="editorReady"
       :suspended="selectionToolbarSuspended"
@@ -462,7 +458,6 @@ onBeforeUnmount(() => {
     />
 
     <LinkActionOverlay
-      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
       :aria-hidden="linkSheetBackgroundAriaHidden"
       :editor-ready="editorReady"
       :suspended="selectionToolbarSuspended"
@@ -474,7 +469,6 @@ onBeforeUnmount(() => {
 
     <MobileEditorToolbar
       v-if="toolbarVisible && !editorFailed"
-      :inert="outlineOpen || tableSheetOpen || incomingOpenPromptOpen"
       :aria-hidden="linkSheetBackgroundAriaHidden"
       :expanded="toolbarExpanded"
       :active-panel="toolbarPanel"

--- a/src/features/editor/components/AndroidExitPrompt.vue
+++ b/src/features/editor/components/AndroidExitPrompt.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useI18n } from '../../../lib/i18n'
+import { useModalFocus } from '../../../lib/modalFocus'
 
 defineProps<{
   message: string
@@ -15,15 +17,20 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const modalRoot = ref<HTMLElement | null>(null)
+const { onModalKeydown } = useModalFocus({ root: modalRoot })
 </script>
 
 <template>
   <section
+    ref="modalRoot"
     class="draft-save-sheet"
     role="dialog"
     aria-modal="true"
     aria-labelledby="android-exit-title"
+    tabindex="-1"
     data-testid="android-exit-prompt"
+    @keydown="onModalKeydown"
   >
     <div class="draft-save-panel">
       <h2 id="android-exit-title">{{ t('editor.exit.androidTitle') }}</h2>

--- a/src/features/editor/components/EditorActionSheet.vue
+++ b/src/features/editor/components/EditorActionSheet.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useI18n } from '../../../lib/i18n'
+import { useModalFocus } from '../../../lib/modalFocus'
 
 defineProps<{
   canShare: boolean
@@ -21,17 +23,24 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const modalRoot = ref<HTMLElement | null>(null)
+const { onModalKeydown } = useModalFocus({
+  root: modalRoot,
+  onEscape: () => emit('close'),
+})
 </script>
 
 <template>
   <section
+    ref="modalRoot"
     class="editor-action-sheet"
     role="dialog"
     aria-modal="true"
     :aria-label="t('editor.actions.documentActions')"
+    tabindex="-1"
     data-testid="editor-action-sheet"
     @click="emit('close')"
-    @keydown.esc="emit('close')"
+    @keydown="onModalKeydown"
   >
     <div class="editor-action-panel" @click.stop>
       <div class="editor-action-grabber" aria-hidden="true" />

--- a/src/features/editor/components/IncomingOpenPrompt.vue
+++ b/src/features/editor/components/IncomingOpenPrompt.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { ref } from 'vue'
 import { useI18n } from '../../../lib/i18n'
+import { useModalFocus } from '../../../lib/modalFocus'
 
 defineProps<{
   incomingName: string
@@ -12,69 +13,27 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const panel = ref<HTMLElement | null>(null)
+const modalRoot = ref<HTMLElement | null>(null)
 const keepButton = ref<HTMLButtonElement | null>(null)
-// Return focus to wherever it was (typically the editor) once the prompt closes.
-let previouslyFocused: HTMLElement | null = null
-
-onMounted(() => {
-  previouslyFocused =
-    document.activeElement instanceof HTMLElement ? document.activeElement : null
-  // "Keep editing" is the safe default, so it takes focus on open.
-  void nextTick(() => {
-    keepButton.value?.focus()
-  })
+const { onModalKeydown } = useModalFocus({
+  root: modalRoot,
+  initialFocus: () => keepButton.value,
+  onEscape: () => emit('keep'),
 })
-
-onBeforeUnmount(() => {
-  if (previouslyFocused?.isConnected) {
-    previouslyFocused.focus({ preventScroll: true })
-  }
-})
-
-// aria-modal does not contain focus, so trap Tab within the two actions.
-function trapTabKey(event: KeyboardEvent) {
-  const root = panel.value
-  if (!root) {
-    return
-  }
-
-  const focusables = Array.from(root.querySelectorAll<HTMLElement>('button:not(:disabled)'))
-  if (focusables.length === 0) {
-    event.preventDefault()
-    return
-  }
-
-  const first = focusables[0]
-  const last = focusables[focusables.length - 1]
-  const active = document.activeElement
-
-  if (event.shiftKey) {
-    if (active === first || active === root) {
-      event.preventDefault()
-      last.focus()
-    }
-    return
-  }
-
-  if (active === last) {
-    event.preventDefault()
-    first.focus()
-  }
-}
 </script>
 
 <template>
   <section
+    ref="modalRoot"
     class="draft-save-sheet"
     role="dialog"
     aria-modal="true"
     aria-labelledby="incoming-open-title"
+    tabindex="-1"
     data-testid="incoming-open-prompt"
-    @keydown.esc="emit('keep')"
-    @keydown.tab="trapTabKey"
+    @keydown="onModalKeydown"
   >
-    <div ref="panel" class="draft-save-panel">
+    <div class="draft-save-panel">
       <h2 id="incoming-open-title">{{ t('editor.incomingOpen.title') }}</h2>
       <p>{{ t('editor.incomingOpen.body', { name: incomingName }) }}</p>
       <div class="draft-save-actions">

--- a/src/features/editor/components/LinkInsertSheet.vue
+++ b/src/features/editor/components/LinkInsertSheet.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from '../../../lib/i18n'
+import { useModalFocus } from '../../../lib/modalFocus'
 
 const props = defineProps<{
   text: string
@@ -15,7 +16,7 @@ const emit = defineEmits<{
 }>()
 
 const linkUrlInput = ref<HTMLInputElement | null>(null)
-const panel = ref<HTMLElement | null>(null)
+const modalRoot = ref<HTMLElement | null>(null)
 const { t } = useI18n()
 const canInsert = computed(() => props.url.trim().length > 0)
 const textValue = computed({
@@ -27,67 +28,31 @@ const urlValue = computed({
   set: value => emit('update:url', value),
 })
 
-function focusInitialInput() {
-  linkUrlInput.value?.focus()
-}
-
-defineExpose({ focusInitialInput })
-
-onMounted(() => {
-  void nextTick(() => {
-    focusInitialInput()
-  })
+const { focusInitial: focusInitialInput, onModalKeydown } = useModalFocus({
+  root: modalRoot,
+  initialFocus: () => linkUrlInput.value,
+  onEscape: () => emit('cancel'),
+  restoreFocus: false,
+  // Insertion briefly focuses the mounted editor to restore Muya's selection.
+  // EditorScreen hides that background from accessibility without making it inert.
+  isolateBackground: false,
 })
 
-// Keyboard containment relies on this Tab trap ALONE (aria-modal does not
-// contain focus). EditorScreen removes the background from the accessibility
-// tree with aria-hidden, but keeps it non-inert so confirm can temporarily
-// focus the still-mounted editor for insertion.
-function trapTabKey(event: KeyboardEvent) {
-  const root = panel.value
-  if (!root) {
-    return
-  }
-
-  const focusables = Array.from(
-    root.querySelectorAll<HTMLElement>('input:not(:disabled), button:not(:disabled)'),
-  )
-  if (focusables.length === 0) {
-    event.preventDefault()
-    return
-  }
-
-  const first = focusables[0]
-  const last = focusables[focusables.length - 1]
-  const active = document.activeElement
-
-  if (event.shiftKey) {
-    if (active === first || active === root) {
-      event.preventDefault()
-      last.focus()
-    }
-    return
-  }
-
-  if (active === last) {
-    event.preventDefault()
-    first.focus()
-  }
-}
+defineExpose({ focusInitialInput })
 </script>
 
 <template>
   <section
+    ref="modalRoot"
     class="draft-save-sheet"
     role="dialog"
     aria-modal="true"
     aria-labelledby="link-sheet-title"
+    tabindex="-1"
     data-testid="link-insert-sheet"
-    @keydown.esc="emit('cancel')"
-    @keydown.tab="trapTabKey"
+    @keydown="onModalKeydown"
   >
     <form
-      ref="panel"
       class="draft-save-panel link-insert-panel"
       @submit.prevent="emit('insert')"
     >

--- a/src/features/editor/components/LocalDraftExitPrompt.vue
+++ b/src/features/editor/components/LocalDraftExitPrompt.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useI18n } from '../../../lib/i18n'
+import { useModalFocus } from '../../../lib/modalFocus'
 
 defineProps<{
   canSaveToDevice: boolean
@@ -14,15 +16,20 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const modalRoot = ref<HTMLElement | null>(null)
+const { onModalKeydown } = useModalFocus({ root: modalRoot })
 </script>
 
 <template>
   <section
+    ref="modalRoot"
     class="draft-save-sheet"
     role="dialog"
     aria-modal="true"
     aria-labelledby="draft-save-title"
+    tabindex="-1"
     data-testid="draft-save-prompt"
+    @keydown="onModalKeydown"
   >
     <div class="draft-save-panel">
       <h2 id="draft-save-title">{{ t('editor.exit.localDraftTitle') }}</h2>

--- a/src/features/editor/components/OutlineSheet.vue
+++ b/src/features/editor/components/OutlineSheet.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref, watch, nextTick } from 'vue'
+import { ref } from 'vue'
 import type { OutlineItem } from '../documentOutline'
 import { useI18n } from '../../../lib/i18n'
+import { useModalFocus } from '../../../lib/modalFocus'
 
 defineProps<{
   items: OutlineItem[]
@@ -14,46 +15,13 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-// Move accessibility focus into the dialog on open. This is DOM focus only:
-// the editor was blurred before the sheet opened, so Muya's cached editing
-// selection is untouched and the keyboard stays closed.
 const panel = ref<HTMLElement | null>(null)
-
-watch(panel, element => {
-  if (element) {
-    void nextTick(() => element.focus({ preventScroll: true }))
-  }
+const { onModalKeydown } = useModalFocus({
+  root: panel,
+  initialFocus: () => panel.value,
+  onEscape: () => emit('close'),
+  restoreFocus: false,
 })
-
-// The background is inert while the sheet is open, but hardware Tab could
-// still walk focus out of the dialog to the document body. Cycle it inside
-// the panel instead (aria-modal alone does not contain keyboard focus).
-function trapTabKey(event: KeyboardEvent) {
-  const root = panel.value
-  if (!root) {
-    return
-  }
-
-  const focusables = Array.from(root.querySelectorAll<HTMLElement>('button:not(:disabled)'))
-  if (focusables.length === 0) {
-    event.preventDefault()
-    return
-  }
-
-  const first = focusables[0]
-  const last = focusables[focusables.length - 1]
-  const active = document.activeElement
-
-  if (event.shiftKey) {
-    if (active === first || active === root) {
-      event.preventDefault()
-      last.focus()
-    }
-  } else if (active === last) {
-    event.preventDefault()
-    first.focus()
-  }
-}
 </script>
 
 <template>
@@ -72,8 +40,7 @@ function trapTabKey(event: KeyboardEvent) {
       tabindex="-1"
       data-testid="outline-sheet"
       @click.stop
-      @keydown.esc="emit('close')"
-      @keydown.tab="trapTabKey"
+      @keydown="onModalKeydown"
     >
       <header class="outline-header">
         <div class="editor-action-grabber" aria-hidden="true" />

--- a/src/features/editor/components/TableInsertSheet.vue
+++ b/src/features/editor/components/TableInsertSheet.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from '../../../lib/i18n'
+import { useModalFocus } from '../../../lib/modalFocus'
 import {
   TABLE_SHEET_LIMITS,
   clampTableSheetDimension,
@@ -22,7 +23,7 @@ const emit = defineEmits<{
 }>()
 
 const insertButton = ref<HTMLButtonElement | null>(null)
-const panel = ref<HTMLElement | null>(null)
+const modalRoot = ref<HTMLElement | null>(null)
 const { t } = useI18n()
 
 const canDecrease = computed(() => ({
@@ -44,60 +45,26 @@ function step(kind: 'rows' | 'columns', delta: 1 | -1) {
   }
 }
 
-onMounted(() => {
-  // The default size is ready to insert, so lead the focus there; steppers
-  // never summon the soft keyboard.
-  void nextTick(() => {
-    insertButton.value?.focus({ preventScroll: true })
-  })
+const { onModalKeydown } = useModalFocus({
+  root: modalRoot,
+  initialFocus: () => insertButton.value,
+  onEscape: () => emit('cancel'),
+  restoreFocus: false,
 })
-
-// The background is inert while the sheet is open, but hardware Tab could
-// still walk focus out of the dialog to the document body. Cycle it inside
-// the panel instead (aria-modal alone does not contain keyboard focus).
-function trapTabKey(event: KeyboardEvent) {
-  const root = panel.value
-  if (!root) {
-    return
-  }
-
-  const focusables = Array.from(root.querySelectorAll<HTMLElement>('button:not(:disabled)'))
-  if (focusables.length === 0) {
-    event.preventDefault()
-    return
-  }
-
-  const first = focusables[0]
-  const last = focusables[focusables.length - 1]
-  const active = document.activeElement
-
-  if (event.shiftKey) {
-    if (active === first || active === root) {
-      event.preventDefault()
-      last.focus()
-    }
-    return
-  }
-
-  if (active === last) {
-    event.preventDefault()
-    first.focus()
-  }
-}
 </script>
 
 <template>
   <section
+    ref="modalRoot"
     class="draft-save-sheet"
     role="dialog"
     aria-modal="true"
     aria-labelledby="table-sheet-title"
+    tabindex="-1"
     data-testid="table-insert-sheet"
-    @keydown.esc="emit('cancel')"
-    @keydown.tab="trapTabKey"
+    @keydown="onModalKeydown"
   >
     <form
-      ref="panel"
       class="draft-save-panel table-insert-panel"
       @submit.prevent="emit('insert')"
     >

--- a/src/features/home/DocumentHome.vue
+++ b/src/features/home/DocumentHome.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import DocumentDeleteConfirmSheet from './components/DocumentDeleteConfirmSheet.vue'
 import DocumentRenameSheet from './components/DocumentRenameSheet.vue'
 import DocumentSelectionBar from './components/DocumentSelectionBar.vue'
@@ -41,6 +41,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const homeScreen = ref<HTMLElement | null>(null)
 
 const longPress = useLongPress({
   onLongPress: id => emit('selectDocument', id),
@@ -113,10 +114,28 @@ watch(
     }
   },
 )
+
+watch(
+  () => props.renameSheetOpen,
+  (open, wasOpen) => {
+    if (!open && wasOpen) {
+      void nextTick(() => {
+        homeScreen.value
+          ?.querySelector<HTMLElement>('[data-testid="home-selection-menu"]')
+          ?.focus({ preventScroll: true })
+      })
+    }
+  },
+)
 </script>
 
 <template>
-  <section class="home-screen" :aria-label="t('home.documents.aria')" data-testid="documents-screen">
+  <section
+    ref="homeScreen"
+    class="home-screen"
+    :aria-label="t('home.documents.aria')"
+    data-testid="documents-screen"
+  >
     <header class="home-top">
       <Transition name="home-top-swap" mode="out-in">
         <DocumentSelectionBar

--- a/src/features/home/components/DocumentDeleteConfirmSheet.vue
+++ b/src/features/home/components/DocumentDeleteConfirmSheet.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from '../../../lib/i18n'
+import { useModalFocus } from '../../../lib/modalFocus'
 
 const props = defineProps<{
   count: number
@@ -16,7 +17,6 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const sheet = ref<HTMLElement | null>(null)
 const cancelButton = ref<HTMLButtonElement | null>(null)
-let restoreFocusTo: HTMLElement | null = null
 
 const bodyText = computed(() => {
   if (props.draftCount > 0 && props.androidDocumentCount > 0) {
@@ -30,40 +30,10 @@ function cancel() {
   emit('cancel')
 }
 
-function onKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape') {
-    event.preventDefault()
-    cancel()
-    return
-  }
-
-  if (event.key !== 'Tab') {
-    return
-  }
-
-  const focusable = [...(sheet.value?.querySelectorAll<HTMLElement>('button:not(:disabled)') ?? [])]
-  const first = focusable[0]
-  const last = focusable.at(-1)
-  if (!first || !last) {
-    return
-  }
-
-  if (event.shiftKey && document.activeElement === first) {
-    event.preventDefault()
-    last.focus()
-  } else if (!event.shiftKey && document.activeElement === last) {
-    event.preventDefault()
-    first.focus()
-  }
-}
-
-onMounted(() => {
-  restoreFocusTo = document.activeElement instanceof HTMLElement ? document.activeElement : null
-  void nextTick(() => cancelButton.value?.focus())
-})
-
-onBeforeUnmount(() => {
-  restoreFocusTo?.focus()
+const { onModalKeydown } = useModalFocus({
+  root: sheet,
+  initialFocus: () => cancelButton.value,
+  onEscape: cancel,
 })
 </script>
 
@@ -74,9 +44,10 @@ onBeforeUnmount(() => {
     role="dialog"
     aria-modal="true"
     aria-labelledby="home-delete-title"
+    tabindex="-1"
     data-testid="home-delete-sheet"
     @click.self="cancel"
-    @keydown="onKeydown"
+    @keydown="onModalKeydown"
   >
     <div class="draft-save-panel">
       <h2 id="home-delete-title">

--- a/src/features/home/components/DocumentRenameSheet.vue
+++ b/src/features/home/components/DocumentRenameSheet.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from '../../../lib/i18n'
+import { useModalFocus } from '../../../lib/modalFocus'
 
 const props = defineProps<{
   initialName: string
@@ -26,23 +27,28 @@ function submit() {
   }
 }
 
-onMounted(() => {
-  void nextTick(() => {
-    nameInput.value?.focus()
+const modalRoot = ref<HTMLElement | null>(null)
+const { onModalKeydown } = useModalFocus({
+  root: modalRoot,
+  initialFocus: () => {
     nameInput.value?.select()
-  })
+    return nameInput.value
+  },
+  onEscape: () => emit('cancel'),
 })
 </script>
 
 <template>
   <section
+    ref="modalRoot"
     class="draft-save-sheet"
     role="dialog"
     aria-modal="true"
     aria-labelledby="home-rename-title"
+    tabindex="-1"
     data-testid="home-rename-sheet"
     @click.self="emit('cancel')"
-    @keydown.esc="emit('cancel')"
+    @keydown="onModalKeydown"
   >
     <form class="draft-save-panel link-insert-panel" @submit.prevent="submit">
       <h2 id="home-rename-title">{{ t('home.rename.title') }}</h2>

--- a/src/features/home/components/DocumentRenameSheet.vue
+++ b/src/features/home/components/DocumentRenameSheet.vue
@@ -35,6 +35,7 @@ const { onModalKeydown } = useModalFocus({
     return nameInput.value
   },
   onEscape: () => emit('cancel'),
+  restoreFocus: false,
 })
 </script>
 

--- a/src/features/settings/components/SettingsDetailPage.test.ts
+++ b/src/features/settings/components/SettingsDetailPage.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+
+import { createApp, nextTick, type App } from 'vue'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { SETTINGS_PAGES } from '../settingsNavigation'
+import SettingsDetailPage from './SettingsDetailPage.vue'
+
+describe('SettingsDetailPage maintenance focus', () => {
+  let app: App<Element> | null = null
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="app"></div>'
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    app = null
+  })
+
+  it('keeps focus in the dialog while every action is disabled', async () => {
+    app = createApp(SettingsDetailPage, {
+      page: SETTINGS_PAGES.ADVANCED,
+      runMaintenanceAction: () => new Promise<void>(() => {}),
+    })
+    app.mount('#app')
+    await nextTick()
+
+    document.querySelector<HTMLButtonElement>('[data-testid="settings-advanced-clear-drafts-action"]')
+      ?.click()
+    await nextTick()
+    await nextTick()
+
+    const dialog = document.querySelector<HTMLElement>('[data-testid="settings-maintenance-sheet"]')!
+    const confirm = document.querySelector<HTMLButtonElement>(
+      '[data-testid="settings-maintenance-clear-confirm"]',
+    )!
+    confirm.focus()
+    confirm.click()
+    await nextTick()
+
+    expect(confirm.disabled).toBe(true)
+    expect(document.activeElement).toBe(dialog)
+  })
+})

--- a/src/features/settings/components/SettingsDetailPage.vue
+++ b/src/features/settings/components/SettingsDetailPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import SettingsChoiceRow from './SettingsChoiceRow.vue'
 import SettingsRow from './SettingsRow.vue'
 import SettingsSection from './SettingsSection.vue'
@@ -218,7 +218,7 @@ function closeMaintenanceSheet() {
   maintenanceActionResult.value = null
 }
 
-const { onModalKeydown } = useModalFocus({
+const { focusInitial, onModalKeydown } = useModalFocus({
   root: maintenanceModalRoot,
   initialFocus: () => maintenanceCancelButton.value,
   onEscape: closeMaintenanceSheet,
@@ -230,6 +230,7 @@ async function confirmMaintenanceAction() {
     return
   }
 
+  maintenanceModalRoot.value?.focus({ preventScroll: true })
   maintenanceActionBusy.value = true
   maintenanceActionError.value = null
   maintenanceActionResult.value = null
@@ -247,6 +248,8 @@ async function confirmMaintenanceAction() {
       : t('settings.maintenance.genericError')
   } finally {
     maintenanceActionBusy.value = false
+    await nextTick()
+    focusInitial()
   }
 }
 

--- a/src/features/settings/components/SettingsDetailPage.vue
+++ b/src/features/settings/components/SettingsDetailPage.vue
@@ -32,6 +32,7 @@ import {
   getImportedAndroidImageStorageStats,
   type ImportedAndroidImageStorageStats,
 } from '../../../lib/androidImages'
+import { useModalFocus } from '../../../lib/modalFocus'
 
 const props = defineProps<{
   page: SettingsPage
@@ -51,6 +52,8 @@ const advancedDiagnostics = ref<Record<string, string>>({})
 const importedImageStorageStats = ref<ImportedAndroidImageStorageStats | null>(null)
 const importedImageStorageLoading = ref(false)
 const importedImageStorageError = ref(false)
+const maintenanceModalRoot = ref<HTMLElement | null>(null)
+const maintenanceCancelButton = ref<HTMLButtonElement | null>(null)
 const maintenanceActionCopies: Record<
   MaintenanceActionId,
   {
@@ -215,6 +218,12 @@ function closeMaintenanceSheet() {
   maintenanceActionResult.value = null
 }
 
+const { onModalKeydown } = useModalFocus({
+  root: maintenanceModalRoot,
+  initialFocus: () => maintenanceCancelButton.value,
+  onEscape: closeMaintenanceSheet,
+})
+
 async function confirmMaintenanceAction() {
   const action = maintenanceAction.value
   if (!action || maintenanceActionBusy.value) {
@@ -367,12 +376,15 @@ watch(
   <Transition name="editor-sheet">
     <section
       v-if="activeMaintenanceActionCopy"
+      ref="maintenanceModalRoot"
       class="draft-save-sheet"
       role="dialog"
       aria-modal="true"
       aria-labelledby="settings-maintenance-title"
+      tabindex="-1"
       data-testid="settings-maintenance-sheet"
       @click.self="closeMaintenanceSheet"
+      @keydown="onModalKeydown"
     >
       <div class="draft-save-panel">
         <h2 id="settings-maintenance-title">{{ t(activeMaintenanceActionCopy.titleKey) }}</h2>
@@ -396,6 +408,7 @@ watch(
             {{ t(activeMaintenanceActionCopy.confirmKey) }}
           </button>
           <button
+            ref="maintenanceCancelButton"
             type="button"
             :disabled="maintenanceActionBusy"
             data-testid="settings-maintenance-cancel"

--- a/src/lib/modalFocus.test.ts
+++ b/src/lib/modalFocus.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isolateModalBackground,
+  trapModalTabKey,
+} from './modalFocus'
+
+function createTabEvent(shiftKey = false) {
+  return new KeyboardEvent('keydown', {
+    key: 'Tab',
+    shiftKey,
+    bubbles: true,
+    cancelable: true,
+  })
+}
+
+describe('modal focus', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('wraps Tab in both directions and pulls stray focus back into the dialog', () => {
+    document.body.innerHTML = `
+      <button id="outside">Outside</button>
+      <section id="dialog" tabindex="-1">
+        <input id="first">
+        <button disabled>Disabled</button>
+        <button id="last">Last</button>
+      </section>
+    `
+    const dialog = document.querySelector<HTMLElement>('#dialog')!
+    const outside = document.querySelector<HTMLElement>('#outside')!
+    const first = document.querySelector<HTMLElement>('#first')!
+    const last = document.querySelector<HTMLElement>('#last')!
+
+    last.focus()
+    const forward = createTabEvent()
+    trapModalTabKey(dialog, forward)
+    expect(forward.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(first)
+
+    const backward = createTabEvent(true)
+    trapModalTabKey(dialog, backward)
+    expect(backward.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(last)
+
+    outside.focus()
+    const stray = createTabEvent()
+    trapModalTabKey(dialog, stray)
+    expect(stray.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(first)
+  })
+
+  it('isolates every background branch up to the app shell and restores prior attributes', () => {
+    document.body.innerHTML = `
+      <main class="app-shell">
+        <header id="header"></header>
+        <div id="content">
+          <div id="already-hidden" aria-hidden="false" inert></div>
+          <section id="dialog"></section>
+          <button id="row"></button>
+        </div>
+        <nav id="navigation"></nav>
+      </main>
+      <div id="outside-app"></div>
+    `
+    const dialog = document.querySelector<HTMLElement>('#dialog')!
+    const backgroundIds = ['already-hidden', 'row', 'header', 'navigation']
+
+    const restore = isolateModalBackground(dialog)
+
+    for (const id of backgroundIds) {
+      const element = document.querySelector<HTMLElement>(`#${id}`)!
+      expect(element.hasAttribute('inert')).toBe(true)
+      expect(element.getAttribute('aria-hidden')).toBe('true')
+    }
+    expect(document.querySelector('#outside-app')?.hasAttribute('inert')).toBe(false)
+
+    restore()
+
+    expect(document.querySelector('#already-hidden')?.hasAttribute('inert')).toBe(true)
+    expect(document.querySelector('#already-hidden')?.getAttribute('aria-hidden')).toBe('false')
+    for (const id of ['row', 'header', 'navigation']) {
+      const element = document.querySelector<HTMLElement>(`#${id}`)!
+      expect(element.hasAttribute('inert')).toBe(false)
+      expect(element.hasAttribute('aria-hidden')).toBe(false)
+    }
+  })
+
+  it('prevents Tab when a dialog temporarily has no enabled controls', () => {
+    document.body.innerHTML = '<section id="dialog"><button disabled>Busy</button></section>'
+    const dialog = document.querySelector<HTMLElement>('#dialog')!
+    const event = createTabEvent()
+    const focusSpy = vi.spyOn(dialog, 'focus')
+
+    trapModalTabKey(dialog, event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(focusSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/modalFocus.test.ts
+++ b/src/lib/modalFocus.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import {
   isolateModalBackground,
   trapModalTabKey,
@@ -88,15 +88,42 @@ describe('modal focus', () => {
     }
   })
 
-  it('prevents Tab when a dialog temporarily has no enabled controls', () => {
-    document.body.innerHTML = '<section id="dialog"><button disabled>Busy</button></section>'
+  it('keeps focus on a dialog that temporarily has no enabled controls', () => {
+    document.body.innerHTML = `
+      <section id="dialog" tabindex="-1"><button disabled>Busy</button></section>
+    `
     const dialog = document.querySelector<HTMLElement>('#dialog')!
     const event = createTabEvent()
-    const focusSpy = vi.spyOn(dialog, 'focus')
 
     trapModalTabKey(dialog, event)
 
     expect(event.defaultPrevented).toBe(true)
-    expect(focusSpy).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(dialog)
+  })
+
+  it('keeps shared background branches isolated until the last modal closes', () => {
+    document.body.innerHTML = `
+      <main class="app-shell">
+        <header id="header"></header>
+        <section id="first-dialog"></section>
+      </main>
+    `
+    const shell = document.querySelector<HTMLElement>('.app-shell')!
+    const firstDialog = document.querySelector<HTMLElement>('#first-dialog')!
+    const header = document.querySelector<HTMLElement>('#header')!
+
+    const restoreFirst = isolateModalBackground(firstDialog)
+    const secondDialog = document.createElement('section')
+    secondDialog.id = 'second-dialog'
+    shell.append(secondDialog)
+    const restoreSecond = isolateModalBackground(secondDialog)
+
+    restoreFirst()
+    expect(header.hasAttribute('inert')).toBe(true)
+    expect(header.getAttribute('aria-hidden')).toBe('true')
+
+    restoreSecond()
+    expect(header.hasAttribute('inert')).toBe(false)
+    expect(header.hasAttribute('aria-hidden')).toBe(false)
   })
 })

--- a/src/lib/modalFocus.ts
+++ b/src/lib/modalFocus.ts
@@ -1,0 +1,162 @@
+import { nextTick, onBeforeUnmount, watch, type Ref } from 'vue'
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not(:disabled)',
+  'input:not(:disabled)',
+  'select:not(:disabled)',
+  'textarea:not(:disabled)',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ')
+
+interface BackgroundAttributeState {
+  element: HTMLElement
+  inert: string | null
+  ariaHidden: string | null
+}
+
+interface ModalFocusOptions {
+  root: Ref<HTMLElement | null>
+  initialFocus?: () => HTMLElement | null
+  onEscape?: () => void
+  restoreFocus?: boolean
+  isolateBackground?: boolean
+}
+
+function restoreAttribute(element: HTMLElement, name: string, value: string | null) {
+  if (value === null) {
+    element.removeAttribute(name)
+  } else {
+    element.setAttribute(name, value)
+  }
+}
+
+export function getModalFocusableElements(root: HTMLElement) {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    element => !element.closest('[hidden], [aria-hidden="true"], [inert]'),
+  )
+}
+
+export function trapModalTabKey(root: HTMLElement, event: KeyboardEvent) {
+  if (event.key !== 'Tab') {
+    return
+  }
+
+  const focusables = getModalFocusableElements(root)
+  if (focusables.length === 0) {
+    event.preventDefault()
+    return
+  }
+
+  const first = focusables[0]
+  const last = focusables[focusables.length - 1]
+  const active = document.activeElement
+  const focusIsOutside = !active || !root.contains(active)
+
+  if (focusIsOutside || active === root) {
+    event.preventDefault()
+    const target = event.shiftKey ? last : first
+    target.focus({ preventScroll: true })
+  } else if (event.shiftKey && active === first) {
+    event.preventDefault()
+    last.focus({ preventScroll: true })
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault()
+    first.focus({ preventScroll: true })
+  }
+}
+
+export function isolateModalBackground(modal: HTMLElement) {
+  const state: BackgroundAttributeState[] = []
+  const boundary = modal.closest<HTMLElement>('.app-shell') ?? document.body
+  let branch = modal
+
+  while (branch !== boundary && branch.parentElement) {
+    const parent = branch.parentElement
+    for (const sibling of parent.children) {
+      if (sibling === branch || !(sibling instanceof HTMLElement)) {
+        continue
+      }
+      state.push({
+        element: sibling,
+        inert: sibling.getAttribute('inert'),
+        ariaHidden: sibling.getAttribute('aria-hidden'),
+      })
+      sibling.setAttribute('inert', '')
+      sibling.setAttribute('aria-hidden', 'true')
+    }
+    branch = parent
+  }
+
+  return () => {
+    for (const entry of state.reverse()) {
+      restoreAttribute(entry.element, 'inert', entry.inert)
+      restoreAttribute(entry.element, 'aria-hidden', entry.ariaHidden)
+    }
+  }
+}
+
+export function useModalFocus({
+  root,
+  initialFocus,
+  onEscape,
+  restoreFocus = true,
+  isolateBackground = true,
+}: ModalFocusOptions) {
+  let previouslyFocused: HTMLElement | null = null
+  let restoreBackground: (() => void) | null = null
+
+  function deactivate() {
+    restoreBackground?.()
+    restoreBackground = null
+    if (restoreFocus && previouslyFocused?.isConnected) {
+      previouslyFocused.focus({ preventScroll: true })
+    }
+    previouslyFocused = null
+  }
+
+  function focusInitial() {
+    const modal = root.value
+    if (!modal) {
+      return
+    }
+    const target = initialFocus?.() ?? getModalFocusableElements(modal)[0] ?? modal
+    target.focus({ preventScroll: true })
+  }
+
+  function onModalKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape' && onEscape) {
+      event.preventDefault()
+      event.stopPropagation()
+      onEscape()
+      return
+    }
+    const modal = root.value
+    if (modal) {
+      trapModalTabKey(modal, event)
+    }
+  }
+
+  watch(root, modal => {
+    if (!modal) {
+      deactivate()
+      return
+    }
+    previouslyFocused =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null
+    void nextTick(() => {
+      if (root.value !== modal) {
+        return
+      }
+      if (isolateBackground) {
+        restoreBackground = isolateModalBackground(modal)
+      }
+      focusInitial()
+    })
+  }, { flush: 'post' })
+
+  onBeforeUnmount(deactivate)
+
+  return { focusInitial, onModalKeydown }
+}

--- a/src/lib/modalFocus.ts
+++ b/src/lib/modalFocus.ts
@@ -10,11 +10,13 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(', ')
 
-interface BackgroundAttributeState {
-  element: HTMLElement
+interface BackgroundIsolationState {
+  activeCount: number
   inert: string | null
   ariaHidden: string | null
 }
+
+const backgroundIsolationStates = new WeakMap<HTMLElement, BackgroundIsolationState>()
 
 interface ModalFocusOptions {
   root: Ref<HTMLElement | null>
@@ -46,6 +48,7 @@ export function trapModalTabKey(root: HTMLElement, event: KeyboardEvent) {
   const focusables = getModalFocusableElements(root)
   if (focusables.length === 0) {
     event.preventDefault()
+    root.focus({ preventScroll: true })
     return
   }
 
@@ -68,7 +71,7 @@ export function trapModalTabKey(root: HTMLElement, event: KeyboardEvent) {
 }
 
 export function isolateModalBackground(modal: HTMLElement) {
-  const state: BackgroundAttributeState[] = []
+  const isolatedElements: HTMLElement[] = []
   const boundary = modal.closest<HTMLElement>('.app-shell') ?? document.body
   let branch = modal
 
@@ -78,21 +81,42 @@ export function isolateModalBackground(modal: HTMLElement) {
       if (sibling === branch || !(sibling instanceof HTMLElement)) {
         continue
       }
-      state.push({
-        element: sibling,
-        inert: sibling.getAttribute('inert'),
-        ariaHidden: sibling.getAttribute('aria-hidden'),
-      })
+      const existingState = backgroundIsolationStates.get(sibling)
+      if (existingState) {
+        existingState.activeCount += 1
+      } else {
+        backgroundIsolationStates.set(sibling, {
+          activeCount: 1,
+          inert: sibling.getAttribute('inert'),
+          ariaHidden: sibling.getAttribute('aria-hidden'),
+        })
+      }
+      isolatedElements.push(sibling)
       sibling.setAttribute('inert', '')
       sibling.setAttribute('aria-hidden', 'true')
     }
     branch = parent
   }
 
+  let active = true
   return () => {
-    for (const entry of state.reverse()) {
-      restoreAttribute(entry.element, 'inert', entry.inert)
-      restoreAttribute(entry.element, 'aria-hidden', entry.ariaHidden)
+    if (!active) {
+      return
+    }
+    active = false
+
+    for (const element of isolatedElements.reverse()) {
+      const state = backgroundIsolationStates.get(element)
+      if (!state) {
+        continue
+      }
+      state.activeCount -= 1
+      if (state.activeCount > 0) {
+        continue
+      }
+      restoreAttribute(element, 'inert', state.inert)
+      restoreAttribute(element, 'aria-hidden', state.ariaHidden)
+      backgroundIsolationStates.delete(element)
     }
   }
 }

--- a/src/lib/modalFocus.ts
+++ b/src/lib/modalFocus.ts
@@ -16,6 +16,8 @@ interface BackgroundIsolationState {
   ariaHidden: string | null
 }
 
+// Overlapping modal transitions share background branches. Capture each
+// branch's original attributes once and restore them after the final release.
 const backgroundIsolationStates = new WeakMap<HTMLElement, BackgroundIsolationState>()
 
 interface ModalFocusOptions {
@@ -48,6 +50,8 @@ export function trapModalTabKey(root: HTMLElement, event: KeyboardEvent) {
   const focusables = getModalFocusableElements(root)
   if (focusables.length === 0) {
     event.preventDefault()
+    // Every shared modal root has tabindex="-1", so it remains a focus sink
+    // while all controls are temporarily disabled.
     root.focus({ preventScroll: true })
     return
   }

--- a/src/lib/modalFocusContract.test.ts
+++ b/src/lib/modalFocusContract.test.ts
@@ -19,6 +19,7 @@ describe('modal focus contract', () => {
     const source = readFileSync(new URL(relativePath, import.meta.url), 'utf8')
 
     expect(source).toContain('role="dialog"')
+    expect(source).toContain('tabindex="-1"')
     expect(source).toContain('useModalFocus({')
     expect(source).toContain('@keydown="onModalKeydown"')
   })

--- a/src/lib/modalFocusContract.test.ts
+++ b/src/lib/modalFocusContract.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const modalComponents = [
+  '../features/editor/components/AndroidExitPrompt.vue',
+  '../features/editor/components/EditorActionSheet.vue',
+  '../features/editor/components/IncomingOpenPrompt.vue',
+  '../features/editor/components/LinkInsertSheet.vue',
+  '../features/editor/components/LocalDraftExitPrompt.vue',
+  '../features/editor/components/OutlineSheet.vue',
+  '../features/editor/components/TableInsertSheet.vue',
+  '../features/home/components/DocumentDeleteConfirmSheet.vue',
+  '../features/home/components/DocumentRenameSheet.vue',
+  '../features/settings/components/SettingsDetailPage.vue',
+] as const
+
+describe('modal focus contract', () => {
+  it.each(modalComponents)('%s uses the shared modal focus lifecycle', relativePath => {
+    const source = readFileSync(new URL(relativePath, import.meta.url), 'utf8')
+
+    expect(source).toContain('role="dialog"')
+    expect(source).toContain('useModalFocus({')
+    expect(source).toContain('@keydown="onModalKeydown"')
+  })
+
+  it('keeps link insertion as the sole non-inert modal because it restores the editor selection', () => {
+    const source = readFileSync(
+      new URL('../features/editor/components/LinkInsertSheet.vue', import.meta.url),
+      'utf8',
+    )
+
+    expect(source).toContain('isolateBackground: false')
+  })
+})

--- a/tests/e2e/mobile-modal-accessibility.spec.ts
+++ b/tests/e2e/mobile-modal-accessibility.spec.ts
@@ -79,6 +79,9 @@ test('incoming-open safety prompt isolates the unsaved editor', async ({ page })
     const win = window as unknown as MockCapacitorWindow
     return (win.__androidDocumentListenerCount?.('openWithDocument') ?? 0) > 0
   })
+  await page.getByTestId('outline-open-button').click()
+  const outlineSheet = page.getByTestId('outline-sheet')
+  await expect(outlineSheet).toBeVisible()
 
   await page.evaluate(() => {
     const win = window as unknown as MockCapacitorWindow
@@ -94,6 +97,7 @@ test('incoming-open safety prompt isolates the unsaved editor', async ({ page })
   })
 
   const prompt = page.getByTestId('incoming-open-prompt')
+  await expect(outlineSheet).toHaveCount(0)
   await expectModalContract(page, prompt)
   await page.getByTestId('prompt-keep-editing-button').click()
   await expect(prompt).toHaveCount(0)

--- a/tests/e2e/mobile-modal-accessibility.spec.ts
+++ b/tests/e2e/mobile-modal-accessibility.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type Locator, type Page } from '@playwright/test'
+import { installAndroidAppMock, longPress, type MockCapacitorWindow } from './helpers/androidAppMock'
+import { newBlankDocument, openLocalDraft } from './helpers/drafts'
+
+test.describe.configure({ timeout: 60_000 })
+
+async function expectModalContract(page: Page, modal: Locator) {
+  await expect(modal).toBeVisible()
+  await expect.poll(() => modal.evaluate(element => element.contains(document.activeElement))).toBe(true)
+
+  const unisolatedBackground = await modal.evaluate(element => {
+    const boundary = element.closest('.app-shell')
+    const failures: string[] = []
+    let branch: Element | null = element
+    while (branch && branch !== boundary && branch.parentElement) {
+      for (const sibling of branch.parentElement.children) {
+        if (sibling === branch || !(sibling instanceof HTMLElement)) {
+          continue
+        }
+        if (!sibling.hasAttribute('inert') || sibling.getAttribute('aria-hidden') !== 'true') {
+          failures.push(sibling.getAttribute('data-testid') ?? sibling.tagName.toLowerCase())
+        }
+      }
+      branch = branch.parentElement
+    }
+    return failures
+  })
+  expect(unisolatedBackground).toEqual([])
+
+  const focusableCount = await modal.locator(
+    'a[href], button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])',
+  ).count()
+  for (let index = 0; index < focusableCount + 2; index += 1) {
+    await page.keyboard.press('Tab')
+    expect(await modal.evaluate(element => element.contains(document.activeElement))).toBe(true)
+  }
+  await page.keyboard.press('Shift+Tab')
+  expect(await modal.evaluate(element => element.contains(document.activeElement))).toBe(true)
+}
+
+async function expectBackgroundRestored(page: Page) {
+  await expect(page.locator('.app-shell [inert]')).toHaveCount(0)
+}
+
+test('document actions and local-exit prompts isolate the editor', async ({ page }) => {
+  await installAndroidAppMock(page)
+  await openLocalDraft(page, {
+    id: 'modal-editor-draft',
+    markdown: '# Modal editor draft\n\nbody',
+    title: /Modal editor draft/,
+  })
+
+  const menuButton = page.getByTestId('editor-menu-button')
+  await menuButton.click()
+  const actionSheet = page.getByTestId('editor-action-sheet')
+  await expectModalContract(page, actionSheet)
+  await page.keyboard.press('Escape')
+  await expect(actionSheet).toHaveCount(0)
+  await expect(menuButton).toBeFocused()
+  await expectBackgroundRestored(page)
+
+  await newBlankDocument(page)
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('new draft that needs an exit decision')
+  await page.getByTestId('back-button').click()
+  const exitPrompt = page.getByTestId('draft-save-prompt')
+  await expectModalContract(page, exitPrompt)
+  await page.getByTestId('prompt-keep-draft-button').click()
+  await expect(exitPrompt).toHaveCount(0)
+  await expectBackgroundRestored(page)
+})
+
+test('incoming-open safety prompt isolates the unsaved editor', async ({ page }) => {
+  await installAndroidAppMock(page)
+  await newBlankDocument(page, { localDrafts: false })
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('unsaved incoming modal content')
+  await page.waitForFunction(() => {
+    const win = window as unknown as MockCapacitorWindow
+    return (win.__androidDocumentListenerCount?.('openWithDocument') ?? 0) > 0
+  })
+
+  await page.evaluate(() => {
+    const win = window as unknown as MockCapacitorWindow
+    win.__emitAndroidOpenWithDocument?.({
+      document: {
+        sourceUri: 'content://test/modal-incoming',
+        displayName: 'Incoming modal.md',
+        markdown: '# Incoming modal',
+        canWrite: true,
+        persisted: true,
+      },
+    })
+  })
+
+  const prompt = page.getByTestId('incoming-open-prompt')
+  await expectModalContract(page, prompt)
+  await page.getByTestId('prompt-keep-editing-button').click()
+  await expect(prompt).toHaveCount(0)
+  await expect(page.getByTestId('editor-host')).toContainText('unsaved incoming modal content')
+  await expectBackgroundRestored(page)
+})
+
+test('delete and rename dialogs isolate the document home and bottom navigation', async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => {
+    localStorage.clear()
+    localStorage.setItem('marktext-for-android:drafts', JSON.stringify([{
+      id: 'modal-home-draft',
+      markdown: '# Modal home draft\n\nbody',
+      updatedAt: '2026-07-14T08:00:00.000Z',
+      lastSavedAt: '2026-07-14T08:00:00.000Z',
+    }]))
+  })
+  await page.reload()
+  await longPress(page, page.getByRole('button', { name: /Modal home draft/ }))
+
+  const deleteButton = page.getByTestId('home-selection-delete')
+  await deleteButton.click()
+  const deleteSheet = page.getByTestId('home-delete-sheet')
+  await expectModalContract(page, deleteSheet)
+  await page.keyboard.press('Escape')
+  await expect(deleteSheet).toHaveCount(0)
+  await expect(deleteButton).toBeFocused()
+  await expectBackgroundRestored(page)
+
+  await page.getByTestId('home-selection-menu').click()
+  const renameButton = page.getByTestId('home-selection-rename')
+  await renameButton.click()
+  const renameSheet = page.getByTestId('home-rename-sheet')
+  await expectModalContract(page, renameSheet)
+  await page.keyboard.press('Escape')
+  await expect(renameSheet).toHaveCount(0)
+  await expect(page.getByTestId('home-selection-menu')).toBeFocused()
+  await expectBackgroundRestored(page)
+})
+
+test('maintenance dialogs isolate settings navigation and restore the trigger', async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+  await page.getByTestId('bottom-nav-settings').click()
+  await page.getByTestId('settings-entry-advanced').click()
+
+  const trigger = page.getByTestId('settings-advanced-clear-drafts-action')
+  await trigger.click()
+  const sheet = page.getByTestId('settings-maintenance-sheet')
+  await expectModalContract(page, sheet)
+  await page.keyboard.press('Escape')
+  await expect(sheet).toHaveCount(0)
+  await expect(trigger).toBeFocused()
+  await expectBackgroundRestored(page)
+})


### PR DESCRIPTION
## Summary

- add a shared modal focus lifecycle for all 10 `role="dialog"` surfaces
- trap Tab and Shift+Tab, isolate sibling branches with `inert` and `aria-hidden`, and restore focus on close
- keep link insertion's Muya selection-restoration path accessible without making the mounted editor inert
- add unit, contract, E2E, and API 34 device evidence

## Verification

- `pnpm test` (529 passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec playwright test tests/e2e/mobile-modal-accessibility.spec.ts` (4 passed)
- Android 14 / API 34 accessibility-tree inspection for editor actions, link insertion, home delete, and settings maintenance

## Notes

The full audit and device restoration details are in `refs/modal-accessibility-audit-2026-07-14.md`.