### PR TITLE
Optimize large document interactions

### DIFF
--- a/refs/large-document-performance-2026-07-14.md
+++ b/refs/large-document-performance-2026-07-14.md
@@ -1,0 +1,82 @@
+# Android large-document performance (2026-07-14)
+
+## Decision
+
+The measured outline, search, and resume paths no longer contain the identified
+quadratic or whole-document redraw behavior. The real-device matrix now
+completes through a 1.5 MB document with 30,001 top-level blocks; the previous
+10,000-section run exceeded the 120-second editor-open timeout.
+
+## Environment
+
+- Device: Xiaomi 23127PN0CC (`4dd67ae4`)
+- Android: 14 / API 34
+- WebView: `com.google.android.webview` 149.0.7827.91
+- Documents: 250, 1,000, 5,000, and 10,000 repeated Markdown sections
+- Evidence: timings, long tasks, and editor/outline CPU profiles under
+  `logs/large-document-matrix/`
+
+## Changes
+
+1. Muya search redraws only the previous and next active blocks during
+   navigation.
+2. Above 100 matches, search retains the exact count and navigation set but
+   renders only the active highlight.
+3. Query input uses a 120 ms trailing debounce and flushes immediately for
+   Enter/Next/Previous.
+4. Resume-anchor lookup uses binary search over ordered block rectangles,
+   reducing layout reads from O(n) to O(log n).
+5. Muya state snapshots use a schema-specific defensive tree clone instead of
+   Android WebView's slow `structuredClone` implementation.
+6. Reference-definition collection is cached by a monotonic JSON-state
+   revision. A document is scanned once after a replacement or applied OT
+   operation, rather than once for every rendered content block.
+
+## Results
+
+| Sections | Markdown | Blocks | Editor ready | Outline | Sparse search | Dense search | Next | Clear | Resume persist |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 250 | 37.5 KB | 751 | 0.75s | 0.26s | 0.21s | 0.17s | 4ms | 55ms | 34ms |
+| 1,000 | 150 KB | 3,001 | 1.58s | 0.49s | 0.21s | 0.20s | 9ms | 76ms | 65ms |
+| 5,000 | 750 KB | 15,001 | 13.26s | 1.53s | 0.37s | 0.45s | 28ms | 250ms | 203ms |
+| 10,000 | 1.50 MB | 30,001 | 45.73s | 3.19s | 3.00s | 1.54s | 34ms | 489ms | 442ms |
+
+The 1,000-section baseline before these changes took about 26.8 seconds to
+open, 6.4 seconds to search 1,000 matches, 12.5 seconds to move to the next
+match, and 6.2 seconds to clear. Before the final reference cache, the
+5,000-section editor took about 60.7 seconds and the 10,000-section case timed
+out above 120 seconds.
+
+## Profiles and boundaries
+
+The pre-fix 5,000-section profile showed reference-definition collection
+scanning the full JSON state for every block. After caching, that path is no
+longer material. At 10,000 sections the remaining editor-open cost is primarily
+Markdown parsing and unavoidable creation of 30,001 editor blocks:
+
+- `walkTokens`: about 19.7s self time
+- `_convertMarkdownToState`: about 5.2s
+- parser `start`: about 5.2s
+- garbage collection: about 3.0s
+
+The outline profile attributes only about 7 ms to `getTOC`; its 3.19-second
+10,000-heading cost is WebView mounting and layout of the complete accessible
+list. A `content-visibility` experiment was rejected after it caused a
+greater-than-30-second interaction stall at 5,000 headings. Virtualizing the
+list would change TalkBack traversal semantics and is not justified for this
+extreme case without a dedicated accessible-list design.
+
+## Data safety
+
+The probe backs up every WebView local-storage key before each matrix and
+restores the original values in `finally`, including failure and timeout paths.
+It does not write Android documents or download dependencies.
+
+## Reproduction
+
+Build and install the current debug APK, then run:
+
+```powershell
+$env:ANDROID_SERIAL = '4dd67ae4'
+node scripts/probe-android-large-document.mjs
+```

--- a/scripts/probe-android-large-document.mjs
+++ b/scripts/probe-android-large-document.mjs
@@ -1,0 +1,374 @@
+import { spawnSync } from 'node:child_process'
+import { Buffer } from 'node:buffer'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+import { setTimeout as delay } from 'node:timers/promises'
+import { chromium } from '@playwright/test'
+
+const PACKAGE_NAME = 'io.github.renakoni.marktextandroid'
+const ACTIVITY_NAME = `${PACKAGE_NAME}/.MainActivity`
+const OUTPUT_DIRECTORY = resolve('logs', 'large-document-matrix')
+const RESULTS_PATH = join(OUTPUT_DIRECTORY, 'matrix-results.json')
+const DRAFTS_STORAGE_KEY = 'marktext-for-android:drafts'
+const SETTINGS_STORAGE_KEY = 'marktext-for-android:settings-ui'
+const RESUME_STORAGE_KEY = 'marktext-for-android:resume-positions'
+const CDP_PORT = 9222
+
+const cases = [250, 1_000, 5_000, 10_000].map(sectionCount => ({
+  id: `large-${sectionCount}`,
+  title: `Large-${sectionCount}`,
+  sectionCount,
+}))
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    maxBuffer: 100 * 1024 * 1024,
+  })
+  if (!options.allowFailure && result.status !== 0) {
+    const detail = result.stderr?.trim() || result.stdout?.trim() || result.status
+    throw new Error(`${command} ${args.join(' ')} failed: ${detail}`)
+  }
+  return result
+}
+
+let serial = process.env.ANDROID_SERIAL ?? ''
+
+function resolveSerial() {
+  if (serial) return serial
+  const devices = run('adb', ['devices']).stdout
+    .split(/\r?\n/)
+    .map(line => line.trim().split(/\s+/))
+    .filter(parts => parts[1] === 'device')
+    .map(parts => parts[0])
+  if (devices.length !== 1) {
+    throw new Error(`Expected one connected Android device, found ${devices.length}`)
+  }
+  serial = devices[0]
+  return serial
+}
+
+function adb(args, options = {}) {
+  return run('adb', ['-s', serial, ...args], options)
+}
+
+function adbText(args, options = {}) {
+  return adb(args, options).stdout?.trim() ?? ''
+}
+
+async function waitFor(check, timeoutMs, description) {
+  const deadline = Date.now() + timeoutMs
+  let lastError
+  while (Date.now() < deadline) {
+    try {
+      const value = await check()
+      if (value) return value
+    } catch (error) {
+      lastError = error
+    }
+    await delay(250)
+  }
+  throw new Error(
+    `Timed out waiting for ${description}${lastError ? `: ${lastError.message}` : ''}`,
+  )
+}
+
+async function connectToApp() {
+  adb(['shell', 'am', 'force-stop', PACKAGE_NAME])
+  adb(['shell', 'am', 'start', '-W', '-n', ACTIVITY_NAME])
+  const pid = await waitFor(
+    async () => adbText(['shell', 'pidof', PACKAGE_NAME]),
+    15_000,
+    'the app process',
+  )
+  run('adb', ['-s', serial, 'forward', '--remove', `tcp:${CDP_PORT}`], {
+    allowFailure: true,
+  })
+  adb(['forward', `tcp:${CDP_PORT}`, `localabstract:webview_devtools_remote_${pid}`])
+  const browser = await waitFor(
+    async () => chromium.connectOverCDP(`http://127.0.0.1:${CDP_PORT}`),
+    15_000,
+    'the app WebView CDP endpoint',
+  )
+  const page = browser.contexts()[0]?.pages()[0]
+  if (!page) {
+    await browser.close()
+    throw new Error('The app WebView did not expose a page')
+  }
+  await page.locator('body').waitFor({ state: 'visible', timeout: 30_000 })
+  return { browser, page }
+}
+
+async function captureStorage() {
+  const { browser, page } = await connectToApp()
+  try {
+    return await page.evaluate(() => Object.fromEntries(
+      Array.from(
+        { length: globalThis.localStorage.length },
+        (_, index) => globalThis.localStorage.key(index),
+      )
+        .filter(key => key !== null)
+        .map(key => [key, globalThis.localStorage.getItem(key)]),
+    ))
+  } finally {
+    await browser.close()
+  }
+}
+
+async function restoreStorage(storage) {
+  const { browser, page } = await connectToApp()
+  try {
+    await page.evaluate(entries => {
+      globalThis.localStorage.clear()
+      for (const [key, value] of Object.entries(entries)) {
+        if (value !== null) globalThis.localStorage.setItem(key, value)
+      }
+    }, storage)
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 30_000 })
+  } finally {
+    await browser.close()
+  }
+}
+
+function createMarkdown(sectionCount) {
+  const sections = Array.from({ length: sectionCount }, (_, index) => {
+    const number = String(index + 1).padStart(5, '0')
+    return `## Section ${number} benchmark\n\nParagraph ${number} carries dense-probe and representative mobile Markdown text. TARGET-${number}\n\n- Item ${number}.1\n- Item ${number}.2\n`
+  })
+  return `# Large-${sectionCount}\n\n${sections.join('\n')}`
+}
+
+async function seedCase(page, testCase, markdown) {
+  const now = new Date().toISOString()
+  await page.evaluate(
+    ({ draftsKey, settingsKey, draft }) => {
+      globalThis.localStorage.clear()
+      globalThis.localStorage.setItem(draftsKey, JSON.stringify([draft]))
+      globalThis.localStorage.setItem(settingsKey, JSON.stringify({
+        startUpAction: 'home',
+        localDrafts: true,
+        recoveryDrafts: true,
+      }))
+    },
+    {
+      draftsKey: DRAFTS_STORAGE_KEY,
+      settingsKey: SETTINGS_STORAGE_KEY,
+      draft: {
+        id: testCase.id,
+        markdown,
+        createdAt: now,
+        updatedAt: now,
+        lastSavedAt: now,
+      },
+    },
+  )
+  await page.reload({ waitUntil: 'domcontentloaded', timeout: 30_000 })
+}
+
+async function installLongTaskObserver(page) {
+  await page.evaluate(() => {
+    globalThis.__marktextLargeDocumentLongTasks = []
+    if (typeof globalThis.PerformanceObserver === 'undefined') return
+    const observer = new globalThis.PerformanceObserver(list => {
+      for (const entry of list.getEntries()) {
+        globalThis.__marktextLargeDocumentLongTasks.push({
+          name: entry.name,
+          startTime: entry.startTime,
+          duration: entry.duration,
+        })
+      }
+    })
+    try {
+      observer.observe({ type: 'longtask', buffered: true })
+      globalThis.__marktextLargeDocumentLongTaskObserver = observer
+    } catch {
+      // Older WebViews may not expose the Long Tasks API.
+    }
+  })
+}
+
+async function setSearchQuery(page, value) {
+  await page.getByTestId('search-input').evaluate((input, query) => {
+    input.value = query
+    input.dispatchEvent(new globalThis.InputEvent('input', {
+      bubbles: true,
+      inputType: 'insertText',
+      data: query,
+    }))
+  }, value)
+}
+
+async function measureSearchQuery(page, value, expectedCountText) {
+  const startedAt = globalThis.performance.now()
+  await setSearchQuery(page, value)
+  await page.waitForFunction(
+    ({ testId, expected }) =>
+      globalThis.document.querySelector(`[data-testid="${testId}"]`)?.textContent === expected,
+    { testId: 'search-count', expected: expectedCountText },
+    { timeout: 120_000 },
+  )
+  return globalThis.performance.now() - startedAt
+}
+
+async function measureCase(page, testCase) {
+  const markdown = createMarkdown(testCase.sectionCount)
+  await seedCase(page, testCase, markdown)
+  await installLongTaskObserver(page)
+
+  const profileClient = await page.context().newCDPSession(page)
+  await profileClient.send('Profiler.enable')
+  await profileClient.send('Profiler.start')
+  const openStartedAt = globalThis.performance.now()
+  await page.getByRole('button', { name: new RegExp(testCase.title) }).click()
+  await page.locator('[data-testid="editor-host"] .mu-editor').waitFor({
+    state: 'visible',
+    timeout: 120_000,
+  })
+  const editorReadyMs = globalThis.performance.now() - openStartedAt
+  const profile = await profileClient.send('Profiler.stop')
+  await profileClient.detach()
+  writeFileSync(
+    join(OUTPUT_DIRECTORY, `${testCase.id}-editor-open-profile.json`),
+    JSON.stringify(profile),
+    'utf8',
+  )
+  const editorState = await page.evaluate(() => {
+    const container = globalThis.document.querySelector('[data-testid="editor-host"] .mu-container')
+    const memory = globalThis.performance.memory
+    return {
+      topLevelBlocks: container?.children.length ?? 0,
+      usedJsHeapBytes: memory?.usedJSHeapSize ?? null,
+    }
+  })
+
+  const outlineProfileClient = await page.context().newCDPSession(page)
+  await outlineProfileClient.send('Profiler.enable')
+  await outlineProfileClient.send('Profiler.start')
+  const outlineStartedAt = globalThis.performance.now()
+  await page.getByTestId('outline-open-button').click()
+  await page.getByTestId('outline-sheet').waitFor({ state: 'visible', timeout: 120_000 })
+  const outlineOpenMs = globalThis.performance.now() - outlineStartedAt
+  const outlineProfile = await outlineProfileClient.send('Profiler.stop')
+  await outlineProfileClient.detach()
+  writeFileSync(
+    join(OUTPUT_DIRECTORY, `${testCase.id}-outline-open-profile.json`),
+    JSON.stringify(outlineProfile),
+    'utf8',
+  )
+  const outlineRows = await page.getByTestId('outline-row').count()
+  await page.getByTestId('outline-close-button').click()
+  await page.getByTestId('outline-sheet').waitFor({ state: 'detached', timeout: 30_000 })
+
+  await page.getByTestId('search-open-button').click()
+  await page.getByTestId('search-input').waitFor({ state: 'visible', timeout: 30_000 })
+
+  const sparseSearchMs = await measureSearchQuery(
+    page,
+    `TARGET-${String(testCase.sectionCount).padStart(5, '0')}`,
+    '1/1',
+  )
+  const sparseSearchCount = await page.getByTestId('search-count').textContent()
+
+  const denseSearchMs = await measureSearchQuery(
+    page,
+    'dense-probe',
+    `1/${testCase.sectionCount}`,
+  )
+  const denseSearchCount = await page.getByTestId('search-count').textContent()
+  const findNextMs = await page.getByTestId('search-next-button').evaluate(button => {
+    const startedAt = globalThis.performance.now()
+    button.click()
+    return globalThis.performance.now() - startedAt
+  })
+  const clearSearchStartedAt = globalThis.performance.now()
+  await setSearchQuery(page, '')
+  await page.getByTestId('search-count').waitFor({ state: 'hidden', timeout: 120_000 })
+  const clearSearchMs = globalThis.performance.now() - clearSearchStartedAt
+  await page.getByTestId('search-close-button').click()
+
+  const previousResume = await page.evaluate(key => globalThis.localStorage.getItem(key), RESUME_STORAGE_KEY)
+  await page.evaluate(() => {
+    const shell = globalThis.document.querySelector('[data-testid="editor-host"]')
+    if (!(shell instanceof globalThis.HTMLElement)) throw new Error('Missing editor scroll container')
+    shell.scrollTo({ top: shell.scrollHeight * 0.8 })
+    shell.dispatchEvent(new globalThis.Event('scroll'))
+  })
+  await delay(50)
+  const resumeStartedAt = globalThis.performance.now()
+  await page.evaluate(() => globalThis.dispatchEvent(new globalThis.PageTransitionEvent('pagehide')))
+  await page.waitForFunction(
+    ({ key, previous }) => globalThis.localStorage.getItem(key) !== previous,
+    { key: RESUME_STORAGE_KEY, previous: previousResume },
+    { timeout: 120_000 },
+  )
+  const resumePersistMs = globalThis.performance.now() - resumeStartedAt
+
+  const longTasks = await page.evaluate(() => globalThis.__marktextLargeDocumentLongTasks ?? [])
+  await page.getByTestId('back-button').click()
+  await page.getByTestId('documents-screen').waitFor({ state: 'visible', timeout: 30_000 })
+  return {
+    id: testCase.id,
+    sectionCount: testCase.sectionCount,
+    markdownBytes: Buffer.byteLength(markdown, 'utf8'),
+    ...editorState,
+    outlineRows,
+    editorReadyMs: Math.round(editorReadyMs),
+    outlineOpenMs: Math.round(outlineOpenMs),
+    sparseSearchMs: Math.round(sparseSearchMs),
+    sparseSearchCount,
+    denseSearchMs: Math.round(denseSearchMs),
+    denseSearchCount,
+    findNextMs: Math.round(findNextMs),
+    clearSearchMs: Math.round(clearSearchMs),
+    resumePersistMs: Math.round(resumePersistMs),
+    longTaskCount: longTasks.length,
+    longestTaskMs: Math.round(Math.max(0, ...longTasks.map(task => task.duration))),
+    longTasks,
+  }
+}
+
+mkdirSync(OUTPUT_DIRECTORY, { recursive: true })
+resolveSerial()
+const storageBackup = await captureStorage()
+const results = []
+let fatalError
+
+try {
+  const { browser, page } = await connectToApp()
+  try {
+    for (const testCase of cases) {
+      const result = await measureCase(page, testCase)
+      results.push(result)
+      globalThis.console.log(JSON.stringify(result))
+    }
+  } finally {
+    await browser.close()
+  }
+} catch (error) {
+  fatalError = error
+} finally {
+  try {
+    await restoreStorage(storageBackup)
+  } catch (error) {
+    fatalError = new Error(
+      `Could not restore app storage: ${error instanceof Error ? error.message : error}`,
+    )
+  }
+}
+
+const report = {
+  capturedAt: new Date().toISOString(),
+  device: {
+    serial,
+    model: adbText(['shell', 'getprop', 'ro.product.model']),
+    android: adbText(['shell', 'getprop', 'ro.build.version.release']),
+    api: Number(adbText(['shell', 'getprop', 'ro.build.version.sdk'])),
+  },
+  results,
+}
+writeFileSync(RESULTS_PATH, JSON.stringify(report, null, 2), 'utf8')
+globalThis.console.log(JSON.stringify(report, null, 2))
+
+if (fatalError) throw fatalError

--- a/src/features/editor/documentSearch.test.ts
+++ b/src/features/editor/documentSearch.test.ts
@@ -39,6 +39,7 @@ function createSearchHarness(options: FakeEditorOptions & { editorMissing?: bool
   const documentSearch = createDocumentSearch({
     getEditor: () => (options.editorMissing ? null : editor),
     scrollActiveMatchIntoView,
+    queryDebounceMs: 0,
   })
 
   return { editor, scrollActiveMatchIntoView, documentSearch }
@@ -221,6 +222,55 @@ describe('createDocumentSearch', () => {
 
     expect(documentSearch.searchOpen.value).toBe(false)
     expect(documentSearch.matchCount.value).toBe(0)
+  })
+
+  it('coalesces rapid query input into one search', () => {
+    vi.useFakeTimers()
+    try {
+      const editor = createFakeEditor({ matchCounts: { apple: 2 } })
+      const documentSearch = createDocumentSearch({
+        getEditor: () => editor,
+        queryDebounceMs: 120,
+      })
+      documentSearch.openSearch()
+
+      documentSearch.setQuery('a')
+      documentSearch.setQuery('app')
+      documentSearch.setQuery('apple')
+
+      expect(editor.search).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(119)
+      expect(editor.search).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(1)
+      expect(editor.search).toHaveBeenCalledTimes(1)
+      expect(editor.search).toHaveBeenCalledWith('apple')
+      expect(documentSearch.matchCount.value).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('flushes a pending query before next-match navigation', () => {
+    vi.useFakeTimers()
+    try {
+      const editor = createFakeEditor({ matchCounts: { apple: 2 } })
+      const documentSearch = createDocumentSearch({
+        getEditor: () => editor,
+        queryDebounceMs: 120,
+      })
+      documentSearch.openSearch()
+      documentSearch.setQuery('apple')
+
+      documentSearch.findNext()
+
+      expect(editor.search).toHaveBeenCalledWith('apple')
+      expect(editor.find).toHaveBeenCalledWith('next')
+      expect(documentSearch.activeMatchIndex.value).toBe(1)
+      vi.runAllTimers()
+      expect(editor.search).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/features/editor/documentSearch.ts
+++ b/src/features/editor/documentSearch.ts
@@ -9,8 +9,12 @@ export interface CreateDocumentSearchOptions {
   getEditor: () => MuyaEditor | null
   /** Bring the active `.mu-highlight` span into view after search/navigation. */
   scrollActiveMatchIntoView?: () => void
+  /** Delay repeated input while typing; zero keeps deterministic synchronous behavior. */
+  queryDebounceMs?: number
   logger?: DocumentSearchLogger
 }
+
+export const DOCUMENT_SEARCH_QUERY_DEBOUNCE_MS = 120
 
 export interface CloseDocumentSearchOptions {
   /**
@@ -62,12 +66,14 @@ export function handleSearchEnterKeydown(event: KeyboardEvent, findNext: () => v
 export function createDocumentSearch({
   getEditor,
   scrollActiveMatchIntoView,
+  queryDebounceMs = DOCUMENT_SEARCH_QUERY_DEBOUNCE_MS,
   logger,
 }: CreateDocumentSearchOptions): DocumentSearch {
   const searchOpen = ref(false)
   const searchQuery = ref('')
   const matchCount = ref(0)
   const activeMatchIndex = ref(-1)
+  let queryTimer: ReturnType<typeof setTimeout> | null = null
 
   function applySearchState(state: { matches: unknown[]; index: number }) {
     matchCount.value = state.matches.length
@@ -78,6 +84,34 @@ export function createDocumentSearch({
     searchQuery.value = ''
     matchCount.value = 0
     activeMatchIndex.value = -1
+  }
+
+  function cancelPendingQuery() {
+    if (queryTimer !== null) {
+      clearTimeout(queryTimer)
+      queryTimer = null
+    }
+  }
+
+  function applyQuery(value: string) {
+    const editor = getEditor()
+    if (!editor) {
+      return
+    }
+
+    applySearchState(editor.search(value))
+
+    if (value && matchCount.value > 0) {
+      scrollActiveMatchIntoView?.()
+    }
+  }
+
+  function flushPendingQuery() {
+    if (queryTimer === null) {
+      return
+    }
+    cancelPendingQuery()
+    applyQuery(searchQuery.value)
   }
 
   function openSearch() {
@@ -94,6 +128,7 @@ export function createDocumentSearch({
       return
     }
 
+    cancelPendingQuery()
     const editor = getEditor()
     const hadActiveMatch = activeMatchIndex.value >= 0
 
@@ -116,20 +151,21 @@ export function createDocumentSearch({
 
   function setQuery(value: string) {
     searchQuery.value = value
+    cancelPendingQuery()
 
-    const editor = getEditor()
-    if (!editor) {
+    if (!value || queryDebounceMs <= 0) {
+      applyQuery(value)
       return
     }
 
-    applySearchState(editor.search(value))
-
-    if (value && matchCount.value > 0) {
-      scrollActiveMatchIntoView?.()
-    }
+    queryTimer = setTimeout(() => {
+      queryTimer = null
+      applyQuery(value)
+    }, queryDebounceMs)
   }
 
   function findInDirection(action: 'previous' | 'next') {
+    flushPendingQuery()
     const editor = getEditor()
     if (!editor || matchCount.value === 0) {
       return
@@ -152,12 +188,8 @@ export function createDocumentSearch({
       return
     }
 
-    const editor = getEditor()
-    if (!editor) {
-      return
-    }
-
-    applySearchState(editor.search(searchQuery.value))
+    cancelPendingQuery()
+    applyQuery(searchQuery.value)
   }
 
   function resetForNewDocument() {
@@ -165,6 +197,7 @@ export function createDocumentSearch({
       return
     }
 
+    cancelPendingQuery()
     // Muya resets its own match state on setContent; only the app-side
     // find-bar state needs dropping here.
     clearSearchState()

--- a/src/features/editor/resumePosition.test.ts
+++ b/src/features/editor/resumePosition.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   computeResumeAnchor,
+  computeResumeAnchorFromRects,
   computeResumeScrollTop,
   createResumePosition,
 } from './resumePosition'
@@ -48,6 +49,30 @@ describe('computeResumeAnchor', () => {
       index: 1,
       ratio: 0,
     })
+  })
+
+  it('finds the same anchors through indexed layout reads', () => {
+    for (const viewportTop of [-600, -290, 0, 130, 500]) {
+      expect(
+        computeResumeAnchorFromRects(viewportTop, BLOCKS.length, index => BLOCKS[index]),
+      ).toEqual(computeResumeAnchor(viewportTop, BLOCKS))
+    }
+  })
+
+  it('uses logarithmic layout reads for a very large block list', () => {
+    const blocks = Array.from({ length: 8_192 }, (_, index) => ({
+      top: index * 20,
+      height: 16,
+    }))
+    let reads = 0
+
+    const anchor = computeResumeAnchorFromRects(120_017, blocks.length, index => {
+      reads += 1
+      return blocks[index]
+    })
+
+    expect(anchor).toEqual({ index: 6_001, ratio: 0 })
+    expect(reads).toBeLessThanOrEqual(15)
   })
 })
 

--- a/src/features/editor/resumePosition.ts
+++ b/src/features/editor/resumePosition.ts
@@ -137,6 +137,54 @@ export function computeResumeAnchor(
   return { index: blocks.length - 1, ratio: 1 }
 }
 
+/**
+ * Indexed equivalent of computeResumeAnchor for vertically ordered DOM
+ * blocks. Binary search avoids forcing layout for every block during an exit
+ * or lifecycle flush on very large documents.
+ */
+export function computeResumeAnchorFromRects(
+  viewportTop: number,
+  blockCount: number,
+  readRect: (index: number) => ResumeBlockRect,
+): { index: number; ratio: number } | null {
+  if (blockCount === 0) {
+    return null
+  }
+
+  const rectCache = new Map<number, ResumeBlockRect>()
+  const getRect = (index: number) => {
+    const cached = rectCache.get(index)
+    if (cached) {
+      return cached
+    }
+    const rect = readRect(index)
+    rectCache.set(index, rect)
+    return rect
+  }
+
+  let low = 0
+  let high = blockCount
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2)
+    const rect = getRect(middle)
+    if (viewportTop < rect.top + rect.height) {
+      high = middle
+    } else {
+      low = middle + 1
+    }
+  }
+
+  if (low === blockCount) {
+    return { index: blockCount - 1, ratio: 1 }
+  }
+
+  const block = getRect(low)
+  if (viewportTop <= block.top || block.height <= 0) {
+    return { index: low, ratio: 0 }
+  }
+  return { index: low, ratio: (viewportTop - block.top) / block.height }
+}
+
 /** Scroll offset that puts the viewport top at `ratio` inside the block. */
 export function computeResumeScrollTop({
   scrollTop,
@@ -285,13 +333,10 @@ export function createResumePosition({
 
     const blocks = Array.from(blockContainer.children)
     const viewportTop = scrollContainer.getBoundingClientRect().top
-    const computed = computeResumeAnchor(
-      viewportTop,
-      blocks.map(block => {
-        const rect = block.getBoundingClientRect()
-        return { top: rect.top, height: rect.height }
-      }),
-    )
+    const computed = computeResumeAnchorFromRects(viewportTop, blocks.length, index => {
+      const rect = blocks[index].getBoundingClientRect()
+      return { top: rect.top, height: rect.height }
+    })
     if (!computed) {
       return null
     }

--- a/third_party/muya/src/history/index.ts
+++ b/third_party/muya/src/history/index.ts
@@ -133,7 +133,6 @@ class History {
                 op: Nullable<JSONOpList>;
                 source: string;
                 prevDoc: TState[];
-                doc: TState[];
             }) => {
                 if (this._ignoreChange)
                     return;

--- a/third_party/muya/src/inlineRenderer/__tests__/referenceDefinitionCache.spec.ts
+++ b/third_party/muya/src/inlineRenderer/__tests__/referenceDefinitionCache.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+
+import type { Muya } from '../../muya';
+import type { TState } from '../../state/types';
+import * as json1 from 'ot-json1';
+import { describe, expect, it, vi } from 'vitest';
+import JSONState from '../../state';
+import InlineRenderer from '..';
+
+function makeRenderer(blocks: TState[]) {
+    const muya = {
+        options: {
+            footnote: false,
+            isGitlabCompatibilityEnabled: false,
+            trimUnnecessaryCodeBlockEmptyLines: false,
+            frontMatter: false,
+            math: false,
+            listIndentation: 1,
+        },
+        eventCenter: { emit: () => {} },
+    } as unknown as Muya;
+    const jsonState = new JSONState(muya, blocks);
+    Object.assign(muya, { editor: { jsonState } });
+    const renderer = new InlineRenderer(muya);
+
+    return { jsonState, renderer };
+}
+
+function collect(renderer: InlineRenderer) {
+    // Exercise the cache directly so token rendering does not obscure state reads.
+    // @ts-expect-error -- intentional coverage of the private collection boundary.
+    renderer._collectReferenceDefinitions();
+}
+
+describe('reference definition collection cache', () => {
+    it('scans document state once per revision', () => {
+        const { jsonState, renderer } = makeRenderer([
+            { name: 'paragraph', text: '[ref]: https://first.example' },
+            { name: 'paragraph', text: '[label][ref]' },
+        ]);
+        const getState = vi.spyOn(jsonState, 'getState');
+
+        collect(renderer);
+        collect(renderer);
+
+        expect(getState).toHaveBeenCalledTimes(1);
+        expect(renderer.labels.get('ref')?.href).toBe('https://first.example');
+    });
+
+    it('recollects after document replacement and applied edits', () => {
+        const { jsonState, renderer } = makeRenderer([
+            { name: 'paragraph', text: '[ref]: https://first.example' },
+        ]);
+        const initialRevision = jsonState.revision;
+
+        collect(renderer);
+        jsonState.setContent([
+            { name: 'paragraph', text: '[ref]: https://second.example' },
+        ]);
+        expect(jsonState.revision).toBe(initialRevision + 1);
+
+        const getState = vi.spyOn(jsonState, 'getState');
+        collect(renderer);
+        collect(renderer);
+        expect(getState).toHaveBeenCalledTimes(1);
+        expect(renderer.labels.get('ref')?.href).toBe('https://second.example');
+
+        jsonState.dispatch(
+            json1.replaceOp(
+                [0, 'text'],
+                '[ref]: https://second.example',
+                '[ref]: https://third.example',
+            ),
+        );
+        expect(jsonState.revision).toBe(initialRevision + 2);
+
+        getState.mockClear();
+        collect(renderer);
+        collect(renderer);
+        expect(getState).toHaveBeenCalledTimes(1);
+        expect(renderer.labels.get('ref')?.href).toBe('https://third.example');
+    });
+});

--- a/third_party/muya/src/inlineRenderer/index.ts
+++ b/third_party/muya/src/inlineRenderer/index.ts
@@ -14,6 +14,7 @@ const debug = logger('inlineRenderer:');
 class InlineRenderer {
     public labels: Labels = new Map();
     public renderer: Renderer;
+    private _labelsRevision = -1;
 
     constructor(public muya: Muya) {
         this.renderer = new Renderer(muya, this);
@@ -75,7 +76,11 @@ class InlineRenderer {
     }
 
     private _collectReferenceDefinitions() {
-        const state = this.muya.editor.jsonState.getState();
+        const { jsonState } = this.muya.editor;
+        if (this._labelsRevision === jsonState.revision)
+            return;
+
+        const state = jsonState.getState();
         const labels = new Map();
 
         const travel = (sts: TState[]) => {
@@ -96,6 +101,7 @@ class InlineRenderer {
         travel(state);
 
         this.labels = labels;
+        this._labelsRevision = jsonState.revision;
     }
 
     getLabelInfo(blockOrState: ParagraphContent | IParagraphState) {

--- a/third_party/muya/src/search/__tests__/search.spec.ts
+++ b/third_party/muya/src/search/__tests__/search.spec.ts
@@ -3,6 +3,7 @@
 import type Content from '../../block/base/content';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya } from '../../muya';
+import { MAX_FULL_SEARCH_HIGHLIGHTS } from '../index';
 
 // Coverage for the Search module (src/search/index.ts) — the find/replace
 // engine the desktop "Find in document" / "Find and replace" surfaces drive.
@@ -91,6 +92,27 @@ describe('search.search()', () => {
         expect(highlightCount(muya)).toBe(0);
         expect(selectionCount(muya)).toBe(0);
     });
+
+    it('keeps an exact large result set but renders only its active match', () => {
+        const markdown = Array.from(
+            { length: MAX_FULL_SEARCH_HIGHLIGHTS + 1 },
+            (_, index) => `x result ${index}`,
+        ).join('\n\n');
+        const muya = bootMuya(markdown);
+        placeCursorOnFirstBlock(muya);
+
+        const search = muya.editor.searchModule;
+        search.search('x');
+
+        expect(search.matches.length).toBe(MAX_FULL_SEARCH_HIGHLIGHTS + 1);
+        expect(highlightCount(muya)).toBe(1);
+        expect(selectionCount(muya)).toBe(0);
+
+        search.find('next');
+        expect(search.index).toBe(1);
+        expect(highlightCount(muya)).toBe(1);
+        expect(selectionCount(muya)).toBe(0);
+    });
 });
 
 describe('search.search() — selectHighlight restores the editor cursor', () => {
@@ -145,6 +167,24 @@ describe('search.find() — cursor navigation across matches', () => {
         // previous from index 0 wraps backward to the last match (2).
         search.find('previous');
         expect(search.index).toBe(2);
+        expect(highlightCount(muya)).toBe(1);
+        expect(selectionCount(muya)).toBe(2);
+    });
+
+    it('redraws only the blocks whose active match changed', () => {
+        const muya = bootMuya('x first\n\nx second\n\nx third\n');
+        placeCursorOnFirstBlock(muya);
+
+        const search = muya.editor.searchModule;
+        search.search('x');
+        const blocks = search.matches.map(match => match.block);
+        const updateSpies = blocks.map(block => vi.spyOn(block, 'update'));
+
+        search.find('next');
+
+        expect(updateSpies[0]).toHaveBeenCalledTimes(1);
+        expect(updateSpies[1]).toHaveBeenCalledTimes(1);
+        expect(updateSpies[2]).not.toHaveBeenCalled();
         expect(highlightCount(muya)).toBe(1);
         expect(selectionCount(muya)).toBe(2);
     });

--- a/third_party/muya/src/search/__tests__/search.spec.ts
+++ b/third_party/muya/src/search/__tests__/search.spec.ts
@@ -141,6 +141,19 @@ describe('search.search() — selectHighlight restores the editor cursor', () =>
 });
 
 describe('search.find() — cursor navigation across matches', () => {
+    it('recovers when the configured highlight index is outside the result set', () => {
+        const muya = bootMuya('x and x and x\n');
+        placeCursorOnFirstBlock(muya);
+
+        const search = muya.editor.searchModule;
+        search.search('x', { highlightIndex: 100 });
+
+        expect(search.index).toBe(0);
+        expect(() => search.find('next')).not.toThrow();
+        expect(search.index).toBe(1);
+        expect(highlightCount(muya)).toBe(1);
+    });
+
     it('wraps forward 0 -> 1 -> 2 -> 0 and backward 0 -> 2, moving the active mu-highlight', () => {
         const muya = bootMuya('x and x and x\n');
         placeCursorOnFirstBlock(muya);

--- a/third_party/muya/src/search/index.ts
+++ b/third_party/muya/src/search/index.ts
@@ -14,6 +14,7 @@ export const MAX_FULL_SEARCH_HIGHLIGHTS = 100;
 
 export class Search {
     private _value: string = '';
+    private _matchesByBlock = new Map<Content, IMatch[]>();
     public matches: IMatch[] = [];
     public index: number = -1;
 
@@ -31,6 +32,7 @@ export class Search {
     // stale matches don't reference the previous document's blocks (#1932).
     reset() {
         this._value = '';
+        this._matchesByBlock.clear();
         this.matches = [];
         this.index = -1;
     }
@@ -75,13 +77,13 @@ export class Search {
     private _updateMatchBlocks(blocks: ReadonlySet<Content>) {
         const { matches, index } = this;
         const activeOnly = matches.length > MAX_FULL_SEARCH_HIGHLIGHTS;
+        const activeMatch = matches[index];
 
         for (const block of blocks) {
             const highlights: IHighlight[] = [];
-            for (let matchIndex = 0; matchIndex < matches.length; matchIndex++) {
-                const match = matches[matchIndex];
-                const active = matchIndex === index;
-                if (match.block === block && (!activeOnly || active)) {
+            for (const match of this._matchesByBlock.get(block) ?? []) {
+                const active = match === activeMatch;
+                if (!activeOnly || active) {
                     highlights.push({
                         start: match.start,
                         end: match.end,
@@ -177,9 +179,12 @@ export class Search {
         if (index >= len)
             index = 0;
 
-        const previousBlock = matches[this.index].block;
+        const previousBlock = matches[this.index]?.block;
         this.index = index;
-        this._updateMatchBlocks(new Set([previousBlock, matches[index].block]));
+        const changedBlocks = new Set<Content>([matches[index].block]);
+        if (previousBlock)
+            changedBlocks.add(previousBlock);
+        this._updateMatchBlocks(changedBlocks);
 
         return this;
     }
@@ -226,8 +231,8 @@ export class Search {
             });
         }
 
-        if (highlightIndex !== -1) {
-            // If set the highlight index, then highlight the highlighIndex
+        if (highlightIndex >= 0 && highlightIndex < matches.length) {
+            // If set a valid highlight index, highlight that match.
             index = highlightIndex;
         }
         else if (matches.length) {
@@ -235,7 +240,21 @@ export class Search {
             index = 0;
         }
 
-        Object.assign(this, { _value: value, matches, index });
+        const matchesByBlock = new Map<Content, IMatch[]>();
+        for (const match of matches) {
+            const blockMatches = matchesByBlock.get(match.block);
+            if (blockMatches)
+                blockMatches.push(match);
+            else
+                matchesByBlock.set(match.block, [match]);
+        }
+
+        Object.assign(this, {
+            _value: value,
+            _matchesByBlock: matchesByBlock,
+            matches,
+            index,
+        });
 
         this._updateMatches();
 

--- a/third_party/muya/src/search/index.ts
+++ b/third_party/muya/src/search/index.ts
@@ -6,6 +6,12 @@ import type { IMatch } from './types';
 import { DEFAULT_SEARCH_OPTIONS } from '../config';
 import { buildRegexValue, matchString } from '../utils/search';
 
+// Re-rendering inline DOM is substantially more expensive than collecting
+// matches on Android WebView. Above this bound, keep the exact result set and
+// navigation but render only the active match instead of blocking on hundreds
+// or thousands of background highlights.
+export const MAX_FULL_SEARCH_HIGHLIGHTS = 100;
+
 export class Search {
     private _value: string = '';
     public matches: IMatch[] = [];
@@ -33,11 +39,14 @@ export class Search {
         const { matches, index } = this;
         let i;
         const len = matches.length;
+        const activeOnly = len > MAX_FULL_SEARCH_HIGHLIGHTS;
         const matchesMap = new Map<Content, IHighlight[]>();
 
         for (i = 0; i < len; i++) {
             const { block, start, end } = matches[i];
             const active = i === index;
+            if (activeOnly && !active)
+                continue;
             const highlight: IHighlight = { start, end, active };
             const highlights = matchesMap.get(block);
 
@@ -59,6 +68,35 @@ export class Search {
                 block.blurHandler();
 
             if (isActive && !isClear)
+                block.focusHandler();
+        }
+    }
+
+    private _updateMatchBlocks(blocks: ReadonlySet<Content>) {
+        const { matches, index } = this;
+        const activeOnly = matches.length > MAX_FULL_SEARCH_HIGHLIGHTS;
+
+        for (const block of blocks) {
+            const highlights: IHighlight[] = [];
+            for (let matchIndex = 0; matchIndex < matches.length; matchIndex++) {
+                const match = matches[matchIndex];
+                const active = matchIndex === index;
+                if (match.block === block && (!activeOnly || active)) {
+                    highlights.push({
+                        start: match.start,
+                        end: match.end,
+                        active,
+                    });
+                }
+            }
+
+            const isActive = highlights.some(highlight => highlight.active);
+            block.update(undefined, highlights);
+
+            if (block.parent?.active && !isActive)
+                block.blurHandler();
+
+            if (isActive)
                 block.focusHandler();
         }
     }
@@ -139,10 +177,9 @@ export class Search {
         if (index >= len)
             index = 0;
 
+        const previousBlock = matches[this.index].block;
         this.index = index;
-
-        this._updateMatches(true);
-        this._updateMatches();
+        this._updateMatchBlocks(new Set([previousBlock, matches[index].block]));
 
         return this;
     }

--- a/third_party/muya/src/state/__tests__/cloneStateTree.spec.ts
+++ b/third_party/muya/src/state/__tests__/cloneStateTree.spec.ts
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest';
+import type { TState } from '../types';
+import { cloneStateTree } from '../cloneState';
+import { Muya } from '../../muya';
+
+describe('cloneStateTree', () => {
+    it('deeply isolates state children and metadata without structuredClone', () => {
+        const source: TState[] = [
+            {
+                name: 'order-list',
+                meta: { start: 1, loose: false, delimiter: '.' },
+                children: [
+                    {
+                        name: 'list-item',
+                        meta: { orderMarker: '1.' },
+                        children: [{ name: 'paragraph', text: 'first' }],
+                    },
+                ],
+            },
+            {
+                name: 'task-list',
+                meta: { marker: '-', loose: false },
+                children: [
+                    {
+                        name: 'task-list-item',
+                        meta: { checked: false },
+                        children: [{ name: 'paragraph', text: 'task' }],
+                    },
+                ],
+            },
+        ];
+        const structuredCloneSpy = vi.spyOn(globalThis, 'structuredClone');
+
+        const cloned = cloneStateTree(source);
+
+        expect(cloned).toEqual(source);
+        expect(cloned).not.toBe(source);
+        const clonedOrder = cloned[0] as Extract<TState, { name: 'order-list' }>;
+        const sourceOrder = source[0] as Extract<TState, { name: 'order-list' }>;
+        const clonedTask = cloned[1] as Extract<TState, { name: 'task-list' }>;
+        const sourceTask = source[1] as Extract<TState, { name: 'task-list' }>;
+        expect(clonedOrder.meta).not.toBe(sourceOrder.meta);
+        expect(clonedOrder.children).not.toBe(sourceOrder.children);
+        expect(clonedOrder.children[0].meta).not.toBe(sourceOrder.children[0].meta);
+        expect(clonedTask.children[0].meta).not.toBe(sourceTask.children[0].meta);
+
+        clonedOrder.meta.start = 9;
+        clonedOrder.children[0].meta!.orderMarker = '9)';
+        clonedOrder.children[0].children[0] = { name: 'paragraph', text: 'changed' };
+        clonedTask.children[0].meta.checked = true;
+
+        expect(sourceOrder.meta.start).toBe(1);
+        expect(sourceOrder.children[0].meta?.orderMarker).toBe('1.');
+        expect(sourceOrder.children[0].children[0]).toEqual({ name: 'paragraph', text: 'first' });
+        expect(sourceTask.children[0].meta.checked).toBe(false);
+        expect(structuredCloneSpy).not.toHaveBeenCalled();
+    });
+
+    it('keeps Muya.getState defensive after callers mutate a returned tree', () => {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const muya = new Muya(host, { markdown: '1. first\n2. second\n' } as ConstructorParameters<typeof Muya>[1]);
+        muya.init();
+        const before = muya.getState();
+        const returned = muya.getState();
+        const list = returned[0] as Extract<TState, { name: 'order-list' }>;
+
+        list.meta.start = 99;
+        list.children[0].meta = { orderMarker: '99)' };
+        list.children[0].children[0] = { name: 'paragraph', text: 'mutated' };
+
+        expect(muya.getState()).toEqual(before);
+        muya.destroy();
+        muya.domNode.remove();
+    });
+});

--- a/third_party/muya/src/state/__tests__/flushPendingOps.spec.ts
+++ b/third_party/muya/src/state/__tests__/flushPendingOps.spec.ts
@@ -66,6 +66,22 @@ describe('muya.flush() — make pending edits durable synchronously (#2938)', ()
         expect(changes).toBe(1);
     });
 
+    it('does not attach a redundant post-edit state snapshot', () => {
+        const muya = boot('hello\n');
+        const leaf = muya.editor.scrollPage!.firstContentInDescendant() as Content;
+        let change: Record<string, unknown> | null = null;
+
+        muya.eventCenter.on('json-change', (payload: Record<string, unknown>) => {
+            change = payload;
+        });
+
+        leaf.text = 'hello world';
+        muya.flush();
+
+        expect(change).toHaveProperty('prevDoc');
+        expect(change).not.toHaveProperty('doc');
+    });
+
     it('flushing before setContent persists the outgoing edit (no loss, no double-flush)', async () => {
         const muya = boot('hello\n');
         const leaf = muya.editor.scrollPage!.firstContentInDescendant() as Content;

--- a/third_party/muya/src/state/cloneState.ts
+++ b/third_party/muya/src/state/cloneState.ts
@@ -1,0 +1,28 @@
+import type { TState } from './types';
+
+/**
+ * Clone Muya's bounded document-state schema without the high fixed cost of
+ * structuredClone on Android WebView. State metadata is one level of scalar
+ * fields; nested document data exists only in `children` arrays.
+ */
+export function cloneStateTree(states: readonly TState[]): TState[] {
+    return states.map((state) => {
+        if ('children' in state) {
+            const children = cloneStateTree(state.children);
+            if ('meta' in state && state.meta) {
+                return {
+                    ...state,
+                    meta: { ...state.meta },
+                    children,
+                } as TState;
+            }
+            return { ...state, children } as TState;
+        }
+
+        if ('meta' in state) {
+            return { ...state, meta: { ...state.meta } } as TState;
+        }
+
+        return { ...state };
+    });
+}

--- a/third_party/muya/src/state/index.ts
+++ b/third_party/muya/src/state/index.ts
@@ -217,14 +217,11 @@ class JSONState {
     dispatch(op: JSONOp, source = 'user' /* user, api */) {
         const prevDoc = this.getState();
         this._apply(op);
-        // TODO: remove doc in future
-        const doc = this.getState();
         debug.log(JSON.stringify(op));
         this._muya.eventCenter.emit('json-change', {
             op,
             source,
             prevDoc,
-            doc,
         });
     }
 
@@ -289,8 +286,6 @@ class JSONState {
         );
         const prevDoc = this.getState();
         this._apply(op);
-        // TODO: remove doc in future
-        const doc = this.getState();
         // Clear before emitting: a listener that edits synchronously then starts
         // a fresh batch instead of mutating the one being flushed.
         this._operationCache = [];
@@ -302,7 +297,6 @@ class JSONState {
             op,
             source: 'user',
             prevDoc,
-            doc,
         });
     }
 }

--- a/third_party/muya/src/state/index.ts
+++ b/third_party/muya/src/state/index.ts
@@ -3,9 +3,9 @@ import type { Muya } from '../muya';
 import type { TDiff } from '../utils';
 import type { TState } from './types';
 import * as json1 from 'ot-json1';
-import { deepClone } from '../utils';
 import logger from '../utils/logger';
 import { getTOC } from './getTOC';
+import { cloneStateTree } from './cloneState';
 
 import { MarkdownToState } from './markdownToState';
 import StateToMarkdown from './stateToMarkdown';
@@ -52,6 +52,8 @@ class JSONState {
 
     private _state: TState[] = [];
 
+    private _revision = 0;
+
     constructor(private _muya: Muya, stateOrMarkdown: TState[] | string) {
         this.setContent(stateOrMarkdown);
     }
@@ -63,6 +65,7 @@ class JSONState {
         if (op === null)
             return;
         this._state = asState(json1.type.apply(asDoc(this._state), op));
+        this._revision += 1;
     }
 
     setContent(content: TState[] | string) {
@@ -80,6 +83,12 @@ class JSONState {
             this._setState(content);
         else
             this._setMarkdown(content);
+
+        this._revision += 1;
+    }
+
+    get revision() {
+        return this._revision;
     }
 
     private _setState(state: TState[]) {
@@ -130,7 +139,7 @@ class JSONState {
     } {
         const prevState = this.getState();
         const nextState
-            = typeof content === 'string' ? this.markdownToState(content) : deepClone(content);
+            = typeof content === 'string' ? this.markdownToState(content) : cloneStateTree(content);
 
         const components: JSONOpList[] = [];
         const max = Math.max(prevState.length, nextState.length);
@@ -220,7 +229,7 @@ class JSONState {
     }
 
     getState(): TState[] {
-        return deepClone(this._state);
+        return cloneStateTree(this._state);
     }
 
     getMarkdown() {


### PR DESCRIPTION
## Summary

- debounce search input and redraw only the blocks whose active match changed
- keep exact search counts and navigation above 100 matches while rendering only the active highlight
- reduce resume-position layout reads from O(n) to O(log n)
- replace slow Android WebView `structuredClone` state snapshots with a schema-specific defensive clone
- cache reference-definition scans by JSON-state revision, removing the measured initialization O(n²) path
- add a reproducible API 34 large-document probe and benchmark report

## Real-device results

| Case | Before | After |
| --- | ---: | ---: |
| 1,000-section editor open | ~26.8s | 1.58s |
| 1,000-match search | ~6.4s | 0.20s |
| Next match | ~12.5s | 9ms |
| 5,000-section editor open | ~60.7s | 13.26s |
| 10,000-section editor open | >120s timeout | 45.73s |

The final 10,000-section run also measured outline at 3.19s, dense search at 1.54s, next-match navigation at 34ms, and resume persistence at 442ms.

## Verification

- `pnpm test` (529 passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --dir third_party/muya run test:app-gate` (1,421 passed)
- `./gradlew :app:testDebugUnitTest`
- search, outline, and resume Playwright coverage passed in the full mobile E2E run
- API 34 matrix completed at 250, 1,000, 5,000, and 10,000 sections

## Notes

The remaining 10,000-section editor-open cost is dominated by Markdown parsing and creation of 30,001 blocks, not the optimized interaction paths. Full profiles and boundaries are documented in `refs/large-document-performance-2026-07-14.md`.