### PR TITLE
Drive the launch splash through the SplashScreen API

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
@@ -34,13 +34,34 @@ public class MainActivity extends BridgeActivity {
         new WeakReference<>(null);
     private final ArrayDeque<String> selectionActionModeEvents = new ArrayDeque<>();
 
+    private volatile boolean webContentReady = false;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // Drive the Android 12+ splash (and its compat backport) ourselves so the
+        // launch shows the app icon on the splash colour and hands off to the app
+        // theme cleanly. Must run before super.onCreate().
+        androidx.core.splashscreen.SplashScreen splashScreen =
+            androidx.core.splashscreen.SplashScreen.installSplashScreen(this);
+
         registerPlugin(AndroidDocumentsPlugin.class);
         registerPlugin(NativeLoggerPlugin.class);
         registerPlugin(AndroidAppInfoPlugin.class);
         registerPlugin(AndroidSelectionPlugin.class);
         super.onCreate(savedInstanceState);
+
+        // Keep the splash up until the web layer has loaded, so the wait reads as
+        // the icon holding rather than a blank frame while the bundle initializes.
+        splashScreen.setKeepOnScreenCondition(() -> !webContentReady);
+        getBridge().addWebViewListener(new com.getcapacitor.WebViewListener() {
+            @Override
+            public void onPageLoaded(android.webkit.WebView webView) {
+                webContentReady = true;
+            }
+        });
+        // Safety net: never hold the splash longer than a few seconds, whatever
+        // happens to the page load.
+        new android.os.Handler(getMainLooper()).postDelayed(() -> webContentReady = true, 4000L);
     }
 
     @Override

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/MainActivity.java
@@ -53,15 +53,19 @@ public class MainActivity extends BridgeActivity {
         // Keep the splash up until the web layer has loaded, so the wait reads as
         // the icon holding rather than a blank frame while the bundle initializes.
         splashScreen.setKeepOnScreenCondition(() -> !webContentReady);
-        getBridge().addWebViewListener(new com.getcapacitor.WebViewListener() {
-            @Override
-            public void onPageLoaded(android.webkit.WebView webView) {
-                webContentReady = true;
-            }
-        });
-        // Safety net: never hold the splash longer than a few seconds, whatever
-        // happens to the page load.
+        // Register the timeout first, so the splash is always released even when
+        // the bridge never came up: a missing or broken WebView provider makes
+        // BridgeActivity show its fallback page and leaves getBridge() null.
         new android.os.Handler(getMainLooper()).postDelayed(() -> webContentReady = true, 4000L);
+        com.getcapacitor.Bridge bridge = getBridge();
+        if (bridge != null) {
+            bridge.addWebViewListener(new com.getcapacitor.WebViewListener() {
+                @Override
+                public void onPageLoaded(android.webkit.WebView webView) {
+                    webContentReady = true;
+                }
+            });
+        }
     }
 
     @Override

--- a/android/app/src/main/res/drawable/ic_splash_logo.xml
+++ b/android/app/src/main/res/drawable/ic_splash_logo.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Splash icon: the launcher mark flattened to a single muted grey (its alpha
+  silhouette, tinted), so the launch reads as a quiet monochrome mark rather than
+  the full-colour app icon. Inset to sit inside the splash icon's safe zone.
+-->
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:inset="15%">
+    <bitmap
+        android:src="@mipmap/ic_launcher_foreground"
+        android:tint="@color/splash_icon_tint"
+        android:gravity="center" />
+</inset>

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splash_background">#1A1A1A</color>
+</resources>

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="splash_background">#1A1A1A</color>
+    <color name="splash_icon_tint">#CDD1D7</color>
 </resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Launch background; the night variant lives in values-night/colors.xml. -->
+    <color name="splash_background">#F7F8FA</color>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -2,4 +2,6 @@
 <resources>
     <!-- Launch background; the night variant lives in values-night/colors.xml. -->
     <color name="splash_background">#F7F8FA</color>
+    <!-- Muted grey splash mark; light-mode uses a darker grey for contrast. -->
+    <color name="splash_icon_tint">#5F6368</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -12,11 +12,15 @@
     <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
-        <item name="android:background">@null</item>
+        <!-- Solid launch-coloured window so the frame before the web layer paints
+             is the splash colour, never a black flash. -->
+        <item name="android:background">@color/splash_background</item>
     </style>
 
 
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
-        <item name="android:background">@drawable/splash</item>
+        <item name="windowSplashScreenBackground">@color/splash_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground_inset</item>
+        <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -12,8 +12,8 @@
     <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
-        <!-- Solid launch-coloured window so the frame before the web layer paints
-             is the splash colour, never a black flash. -->
+        <!-- The activity root view's background, so the frame before the web layer
+             paints shows the splash colour instead of a black flash. -->
         <item name="android:background">@color/splash_background</item>
     </style>
 

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -20,7 +20,7 @@
 
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/splash_background</item>
-        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground_inset</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_logo</item>
         <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
     </style>
 </resources>


### PR DESCRIPTION
## What

Replaces the black flash on cold start with a proper Android 12+ splash. This is **step 1** of the splash work — no custom icon animation yet.

- Install and drive `androidx.core:core-splashscreen` from `MainActivity` (it was never installed), and keep the splash on screen until the web layer reports `onPageLoaded` — with a 4s safety net — so the wait reads as the icon holding rather than a blank frame while the bundle initializes.
- Configure the launch theme with `windowSplashScreenBackground`, `windowSplashScreenAnimatedIcon` (the padded launcher mark), and `postSplashScreenTheme`. The old `android:background=@drawable/splash` was ignored on Android 12+.
- Add a DayNight `splash_background` colour (light `#F7F8FA` / dark `#1A1A1A`), and give the post-splash app theme a solid window background of that colour instead of `@null`, so no frame is ever black.

## Verification

Cold-start screen recording on a Xiaomi 14 (Android 14, dark mode): home → dark splash with the mark held during load → app, with no black frame at any point. `assembleDebug` is green.