### PR TITLE
Add signed Android release pipeline

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,161 @@
+name: Android Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: android-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  signed-apk:
+    name: Build signed APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup
+
+      - name: Install JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '22'
+          cache: gradle
+
+      - name: Validate release secrets
+        shell: bash
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            ANDROID_RELEASE_KEYSTORE_BASE64 \
+            ANDROID_RELEASE_STORE_PASSWORD \
+            ANDROID_RELEASE_KEY_ALIAS \
+            ANDROID_RELEASE_KEY_PASSWORD
+          do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::$name is not configured"
+              missing=1
+            fi
+          done
+          [[ "$missing" -eq 0 ]]
+
+      - name: Validate release version
+        shell: bash
+        run: |
+          set -euo pipefail
+          app_version="$(node -p "require('./package.json').version")"
+          if [[ "$GITHUB_REF_TYPE" == 'tag' && "$GITHUB_REF_NAME" != "v$app_version" ]]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match app version v$app_version"
+            exit 1
+          fi
+          echo "APP_VERSION=$app_version" >> "$GITHUB_ENV"
+
+      - name: Run release source gates
+        run: |
+          pnpm lint
+          pnpm test
+          pnpm build
+
+      - name: Sync Capacitor Android assets
+        run: pnpm exec cap sync android
+
+      - name: Decode release keystore
+        shell: bash
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$ANDROID_RELEASE_KEYSTORE_BASE64" \
+            | base64 --decode \
+            > "$RUNNER_TEMP/marktext-release.jks"
+          chmod 600 "$RUNNER_TEMP/marktext-release.jks"
+
+      - name: Build signed release APK
+        env:
+          ANDROID_RELEASE_KEYSTORE_FILE: ${{ runner.temp }}/marktext-release.jks
+          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+        run: |
+          chmod +x android/gradlew
+          ./android/gradlew -p android testDebugUnitTest assembleRelease --no-daemon
+
+      - name: Verify signature and prepare artifacts
+        id: artifact
+        shell: bash
+        env:
+          EXPECTED_CERT_SHA256: 6ec922525bce1803428b80f0e2577d18246b2290b4f3bb16150fa707d1819c67
+        run: |
+          set -euo pipefail
+          source_apk='android/app/build/outputs/apk/release/app-release.apk'
+          apk_name="marktext-android-v${APP_VERSION}.apk"
+          artifact_dir='release-artifacts'
+          mkdir -p "$artifact_dir"
+          cp "$source_apk" "$artifact_dir/$apk_name"
+
+          apksigner="$(find "$ANDROID_HOME/build-tools" -type f -name apksigner | sort -V | tail -n 1)"
+          if [[ -z "$apksigner" ]]; then
+            echo '::error::apksigner was not found in ANDROID_HOME'
+            exit 1
+          fi
+
+          signer_output="$("$apksigner" verify --verbose --print-certs "$artifact_dir/$apk_name")"
+          printf '%s\n' "$signer_output"
+          actual_cert_sha256="$(printf '%s\n' "$signer_output" \
+            | sed -n -E 's/^(Signer #[0-9]+|V[0-9.]+ Signer):? certificate SHA-256 digest: //p' \
+            | head -n 1 \
+            | tr '[:upper:]' '[:lower:]')"
+          if [[ "$actual_cert_sha256" != "$EXPECTED_CERT_SHA256" ]]; then
+            echo "::error::Release certificate mismatch: $actual_cert_sha256"
+            exit 1
+          fi
+
+          (
+            cd "$artifact_dir"
+            sha256sum "$apk_name" > "$apk_name.sha256"
+          )
+          echo "apk_name=$apk_name" >> "$GITHUB_OUTPUT"
+
+      - name: Upload signed APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: marktext-android-v${{ env.APP_VERSION }}
+          path: release-artifacts/
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Create or update draft GitHub Release
+        if: github.ref_type == 'tag'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          apk_path="release-artifacts/${{ steps.artifact.outputs.apk_name }}"
+          checksum_path="$apk_path.sha256"
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" "$apk_path" "$checksum_path" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              "$apk_path" \
+              "$checksum_path" \
+              --verify-tag \
+              --draft \
+              --generate-notes \
+              --title "MarkText $GITHUB_REF_NAME"
+          fi

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ pnpm android:open     # open it in Android Studio, then run on a device or emula
 ```
 
 Other scripts (`test`, `lint`, `typecheck`, `build`) are in `package.json`.
+Release maintainers should follow [`docs/RELEASING.md`](docs/RELEASING.md).
 
 > [!TIP]
 > The Markdown editor core is a vendored, **modified** copy of `@muyajs/core` (Muya)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,19 @@
 apply plugin: 'com.android.application'
 
+def releaseSigningEnvironment = [
+    storeFile: 'ANDROID_RELEASE_KEYSTORE_FILE',
+    storePassword: 'ANDROID_RELEASE_STORE_PASSWORD',
+    keyAlias: 'ANDROID_RELEASE_KEY_ALIAS',
+    keyPassword: 'ANDROID_RELEASE_KEY_PASSWORD'
+]
+def releaseSigningValues = releaseSigningEnvironment.collectEntries { key, variableName ->
+    [(key): System.getenv(variableName)]
+}
+def missingReleaseSigningVariables = releaseSigningValues.findAll { key, value ->
+    value == null || value.trim().isEmpty()
+}.keySet()
+def releaseSigningConfigured = missingReleaseSigningVariables.isEmpty()
+
 android {
     namespace = "io.github.renakoni.marktextandroid"
     compileSdk = rootProject.ext.compileSdkVersion
@@ -16,11 +30,43 @@ android {
             ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    signingConfigs {
+        if (releaseSigningConfigured) {
+            release {
+                storeFile file(releaseSigningValues.storeFile)
+                storePassword releaseSigningValues.storePassword
+                keyAlias releaseSigningValues.keyAlias
+                keyPassword releaseSigningValues.keyPassword
+            }
+        }
+    }
     buildTypes {
         release {
+            if (releaseSigningConfigured) {
+                signingConfig signingConfigs.release
+            }
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+}
+
+def requireReleaseSigning = tasks.register('requireReleaseSigning') {
+    doLast {
+        if (!releaseSigningConfigured) {
+            def names = missingReleaseSigningVariables.collect { key -> releaseSigningEnvironment[key] }
+            throw new GradleException("Release signing is incomplete. Missing environment variables: ${names.join(', ')}")
+        }
+
+        if (!file(releaseSigningValues.storeFile).isFile()) {
+            throw new GradleException("Release keystore not found: ${releaseSigningValues.storeFile}")
+        }
+    }
+}
+
+tasks.configureEach { task ->
+    if (task.name in ['assembleRelease', 'bundleRelease', 'packageRelease']) {
+        task.dependsOn requireReleaseSigning
     }
 }
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,60 @@
+# Releasing MarkText for Android
+
+The first distribution channel is GitHub Releases. Release APKs must keep the
+application id `io.github.renakoni.marktextandroid` and must always be signed by
+the same release certificate.
+
+## Key custody
+
+- Keep the release keystore outside the repository.
+- Keep its password and alias in a password manager.
+- Maintain at least two encrypted, independently restorable keystore backups.
+- Never print, commit, attach, or upload the raw keystore except as an encrypted
+  GitHub Actions secret.
+
+Official release certificate SHA-256:
+
+```text
+6E:C9:22:52:5B:CE:18:03:42:8B:80:F0:E2:57:7D:18:24:6B:22:90:B4:F3:BB:16:15:0F:A7:07:D1:81:9C:67
+```
+
+The release workflow rejects APKs signed by any other certificate.
+
+## Repository secrets
+
+Configure these in GitHub repository settings under Actions secrets:
+
+```text
+ANDROID_RELEASE_KEYSTORE_BASE64
+ANDROID_RELEASE_STORE_PASSWORD
+ANDROID_RELEASE_KEY_ALIAS
+ANDROID_RELEASE_KEY_PASSWORD
+```
+
+On Windows, copy the keystore's Base64 form without printing it:
+
+```powershell
+[Convert]::ToBase64String(
+  [IO.File]::ReadAllBytes('E:\marktext-signing\marktext-release.jks')
+) | Set-Clipboard
+```
+
+Use `marktext-release` for the alias. The store and key password may be the same
+high-entropy password. Clear the clipboard after each secret is entered.
+
+## Release sequence
+
+1. Increment Android `versionCode`.
+2. Set the same semantic version in `android/app/build.gradle`, `package.json`,
+   and `src/lib/appInfo.ts`.
+3. Merge the release candidate after normal pull-request checks pass.
+4. Run the Android Release workflow manually to obtain a signed candidate APK.
+5. Verify clean install and same-key upgrade on devices without losing app data.
+6. Create and push the matching tag, for example `v0.1.0`.
+7. The tag workflow verifies the version, signature, and certificate, then
+   creates a draft GitHub Release containing the APK and SHA-256 checksum.
+8. Inspect the draft notes and assets, then publish the Release manually.
+
+The in-app update checker reads GitHub's latest published release. APK
+installation remains an Android user-confirmed action. AAB delivery is deferred
+until Google Play is selected as a distribution channel.

--- a/src/lib/releaseIdentityContract.test.ts
+++ b/src/lib/releaseIdentityContract.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, test } from 'vitest'
+import { APP_INFO } from './appInfo'
+
+function requireMatch(source: string, pattern: RegExp, label: string) {
+  const match = source.match(pattern)
+  expect(match, `${label} was not found`).not.toBeNull()
+  return match?.[1]
+}
+
+describe('release identity contract', () => {
+  const packageJson = JSON.parse(
+    readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+  ) as { version?: unknown }
+  const appGradle = readFileSync(new URL('../../android/app/build.gradle', import.meta.url), 'utf8')
+
+  test('keeps web and Android versions aligned', () => {
+    const androidVersion = requireMatch(appGradle, /versionName\s+["']([^"']+)["']/, 'versionName')
+    const androidVersionCode = requireMatch(appGradle, /versionCode\s+(\d+)/, 'versionCode')
+
+    expect(packageJson.version).toBe(APP_INFO.version)
+    expect(androidVersion).toBe(APP_INFO.version)
+    expect(Number(androidVersionCode)).toBeGreaterThan(0)
+  })
+
+  test('requires release tags to match the app version', () => {
+    if (process.env.GITHUB_REF_TYPE !== 'tag') {
+      return
+    }
+
+    expect(process.env.GITHUB_REF_NAME).toBe(`v${APP_INFO.version}`)
+  })
+})


### PR DESCRIPTION
## What

- load Android release signing only from environment variables and fail release packaging when signing is incomplete
- add a manual/tag Android Release workflow that builds, verifies, fingerprints, checksums, and uploads a signed APK
- lock the official release certificate fingerprint and app/tag version parity
- document key custody, repository secrets, and the repeatable GitHub Releases sequence

## Security

No keystore or password is committed. The certificate SHA-256 is public metadata and the workflow rejects any different signing certificate.

## Verification

- pnpm test (74 files / 566 tests)
- pnpm typecheck`n- tracked project ESLint gate
- pnpm build`n- pnpm exec cap sync android`n- 	estDebugUnitTest`n- ssembleDebug`n- unsigned ssembleRelease rejected with the expected missing-variable error
- disposable-key ssembleRelease succeeded and pksigner verify --verbose --print-certs confirmed one v2 signer
- matching and mismatched release-tag contract paths verified