### PR TITLE
Install Muya dependencies in Android release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -65,6 +65,9 @@ jobs:
           fi
           echo "APP_VERSION=$app_version" >> "$GITHUB_ENV"
 
+      - name: Install Muya dependencies
+        run: pnpm --dir third_party/muya install
+
       - name: Run release source gates
         run: |
           pnpm lint


### PR DESCRIPTION
## Summary

- install the vendored Muya package's independent dev dependencies before the release source gates
- mirror the dependency setup already used by the Web Quality Muya job

## Cause

The first manual Android Release run failed before signing because the clean runner had no third_party/muya/node_modules, so test:muya could not load its Vite plugins.

## Verification

- pnpm --dir third_party/muya install
- pnpm test:muya: 211 files and 1423 tests passed
- git diff --check