### PR TITLE
Add issue templates and link the release badge

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Report a problem with the MarkText for Android app
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Please search [existing issues](https://github.com/Renakoni/marktext-android/issues) first — a 👍 on a match helps more than a duplicate.
+
+        This is an **unofficial Android port**; report app issues here, not to upstream MarkText.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: What went wrong, and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open a `.md` file from '…'
+        2. Tap '…'
+        3. See the problem
+    validations:
+      required: true
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Settings → About, or the APK file name.
+      placeholder: "0.1.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: install-source
+    attributes:
+      label: How did you install it?
+      options:
+        - APK from GitHub Releases
+        - Built from source
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: android-version
+    attributes:
+      label: Android version
+      placeholder: "Android 14"
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: Device (make and model)
+      placeholder: "Xiaomi 14 / Pixel 7 / Galaxy S23"
+    validations:
+      required: true
+  - type: input
+    id: webview
+    attributes:
+      label: Android System WebView version
+      description: The editor runs in the system WebView, so this often matters. Settings → Apps → Android System WebView (or Chrome).
+      placeholder: "126.0.6478.122"
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area (optional)
+      description: Where does it happen?
+      options:
+        - Editing / formatting
+        - Opening, saving, or sharing files
+        - Import / open-with / share intents
+        - PDF export
+        - Themes / settings
+        - Startup / crash
+        - Other
+    validations:
+      required: false
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshots, screen recording, or logs
+      description: A screen recording is ideal for UI or editing bugs. You can export logs from Settings → Advanced → Export logs. Please don't paste private document contents.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Build & usage (README)
+    url: https://github.com/Renakoni/marktext-android#readme
+    about: Features, build-from-source, and current project status.
+  - name: Upstream MarkText (desktop / Muya core)
+    url: https://github.com/marktext/marktext
+    about: This is an unofficial Android port. For the desktop editor or the Muya editor core itself, use the upstream project.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest an idea or improvement
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Search [existing issues](https://github.com/Renakoni/marktext-android/issues) first to avoid duplicates.
+
+        This app aims to stay a quiet, focused mobile Markdown editor — small in scope by choice.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: The use case or frustration behind the idea.
+      placeholder: "When I'm writing on my phone, I want … so that …"
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What should the app do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   &nbsp;
   <img src="https://img.shields.io/badge/Android-7.0%2B-4c8492?style=flat-square&logo=android&logoColor=white" alt="Android 7.0+">
   &nbsp;
-  <img src="https://img.shields.io/badge/Status-pre--release%200.1.0-c98a4b?style=flat-square" alt="Pre-release 0.1.0">
+  <a href="https://github.com/Renakoni/marktext-android/releases/latest"><img src="https://img.shields.io/github/v/release/Renakoni/marktext-android?style=flat-square&color=c98a4b&label=release" alt="Latest release"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Repository housekeeping — no app-code changes.

- **Issue templates** — adds `.github/ISSUE_TEMPLATE/` with an Android-adapted **bug report** (app version, install source, Android version, device, System WebView version, feature area, logs) and a **feature request** form, plus a `config.yml` that disables blank issues and links to the README and upstream MarkText. Adapted for the Android APK rather than copied from upstream. The existing `PULL_REQUEST_TEMPLATE.md` is already Android-focused and is left as-is.
- **README release badge** — the status badge now links to the latest GitHub release and shows the live release version.

## Test plan

- [x] Issue-form YAML hand-checked (no local `yaml` module to lint against); GitHub renders the forms after merge.
- [x] Badge `<a>` wrapping verified in the README source.

## Notes for reviewers

No native or runtime code touched; `main` is protected, so this goes through a PR to satisfy the required checks.