### PR TITLE
Trim repetitive lines from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,8 +7,6 @@ body:
     attributes:
       value: |
         Thanks for the report. Please search [existing issues](https://github.com/Renakoni/marktext-android/issues) first — a 👍 on a match helps more than a duplicate.
-
-        This is an **unofficial Android port**; report app issues here, not to upstream MarkText.
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,8 +7,6 @@ body:
     attributes:
       value: |
         Search [existing issues](https://github.com/Renakoni/marktext-android/issues) first to avoid duplicates.
-
-        This app aims to stay a quiet, focused mobile Markdown editor — small in scope by choice.
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
Follow-up to #133. Removes two lines that repeat context already stated elsewhere:

- **bug_report.yml** — drops the "unofficial Android port; report app issues here, not upstream" line (the unofficial-port status is already in the README).
- **feature_request.yml** — drops the "stay a quiet, focused mobile Markdown editor" scope line.

Net change is 4 line deletions; no field or behaviour changes.