### PR TITLE
Update docs for the v0.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,12 @@ Customization runs deep here, right down to the bars you touch while writing:
 ## Project status
 
 > [!IMPORTANT]
-> A mature debug/beta build — **not yet a signed public release**. The editor and
-> its document-safety features are stable and well-tested; what remains is the
-> release pipeline (app signing, published builds, and on-device verification).
-> For now, the way to try it is to build from source.
+> The first signed public release, **v0.1.0**, is available. Its APK is built by
+> the repository's release workflow, pinned to the official release certificate,
+> and has passed clean-install and same-key upgrade checks on Android 14.
 
-Signed builds will appear on the
-[Releases](https://github.com/Renakoni/marktext-android/releases) page when ready.
+Download signed builds from the
+[Releases](https://github.com/Renakoni/marktext-android/releases/latest) page.
 
 ## Build from source
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -55,6 +55,20 @@ high-entropy password. Clear the clipboard after each secret is entered.
    creates a draft GitHub Release containing the APK and SHA-256 checksum.
 8. Inspect the draft notes and assets, then publish the Release manually.
 
+## First release record
+
+`v0.1.0` was published on July 15, 2026 from commit `0cca3ed`. The tag workflow
+produced `marktext-android-v0.1.0.apk` and its SHA-256 file. The published APK:
+
+- is 7,849,488 bytes;
+- has SHA-256 `E506604D62377DD448FBA67F0B60F0CE110BC9A27FDFA60D47686953A141E2EB`;
+- passed APK Signature Scheme v2 and release-certificate verification; and
+- passed clean install, same-key replacement, cold launch, and draft-retention
+  checks on an Android 14 physical device.
+
+Runtime coverage at the declared minimum API 24 was not completed for this
+release and remains part of the compatibility matrix for future updates.
+
 The in-app update checker reads GitHub's latest published release. APK
 installation remains an Android user-confirmed action. AAB delivery is deferred
 until Google Play is selected as a distribution channel.


### PR DESCRIPTION
## Summary

- update the restrained README status block now that v0.1.0 is publicly available
- record the first signed release artifact, certificate verification, device checks, and remaining API 24 coverage gap in the maintainer runbook

## Verification

- git diff --check
- Graphify product graph refreshed at main@669446e: 2,073 nodes / 4,327 edges / 187 communities
- graph query reaches the first-release record, release identity contract, update service, and release sequence