### PR TITLE
Expose the GitHub release link when an update is available

### DIFF
--- a/src/features/settings/components/AboutSettings.vue
+++ b/src/features/settings/components/AboutSettings.vue
@@ -16,6 +16,14 @@ const updateStatus = computed(() => {
   return updateResult.value ? getUpdateStatus(updateResult.value) : undefined
 })
 
+const availableReleaseUrl = computed(() => {
+  if (checkingUpdates.value || updateResult.value?.status !== 'available') {
+    return null
+  }
+
+  return updateResult.value.releaseUrl ?? APP_INFO.releasesUrl
+})
+
 function getUpdateStatus(result: AppUpdateCheckResult) {
   if (result.status === 'available' && result.latestVersion) {
     return t('about.update.available', { version: result.latestVersion })
@@ -109,6 +117,33 @@ async function checkUpdates() {
           <span v-if="updateStatus" class="about-row-value">{{ updateStatus }}</span>
         </span>
       </button>
+
+      <a
+        v-if="availableReleaseUrl"
+        class="about-row is-link"
+        :href="availableReleaseUrl"
+        target="_blank"
+        rel="noreferrer"
+        data-testid="settings-open-release"
+      >
+        <span class="about-row-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false">
+            <path d="M12 4v10" />
+            <path d="M8 10l4 4 4-4" />
+            <path d="M5 19h14" />
+          </svg>
+        </span>
+        <span class="about-row-main">
+          <span class="about-row-label">{{ t('about.update.openRelease') }}</span>
+        </span>
+        <span class="about-row-trailing" aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false">
+            <path d="M8 8h8v8" />
+            <path d="M16 8l-9 9" />
+            <path d="M7 7h-1a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2v-1" />
+          </svg>
+        </span>
+      </a>
 
       <a
         class="about-row is-link"

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -607,4 +607,5 @@ export const de = {
   'about.update.noReleases': 'Noch keine veröffentlichten Releases',
   'about.update.badRelease': 'Das neueste Release enthielt keine Version',
   'about.update.unavailable': 'GitHub-Releases konnten nicht erreicht werden',
+  'about.update.openRelease': 'GitHub-Release öffnen',
 } satisfies Record<I18nKey, string>

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -601,6 +601,7 @@ export const en = {
   'about.update.noReleases': 'No published releases yet',
   'about.update.badRelease': 'Latest release did not include a version',
   'about.update.unavailable': 'Could not reach GitHub releases',
+  'about.update.openRelease': 'Open GitHub release',
 }
 
 export type I18nKey = keyof typeof en

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -607,4 +607,5 @@ export const es = {
   'about.update.noReleases': 'Aún no hay versiones publicadas',
   'about.update.badRelease': 'La última versión no incluyó un número de versión',
   'about.update.unavailable': 'No se pudo acceder a las versiones de GitHub',
+  'about.update.openRelease': 'Abrir la versión en GitHub',
 } satisfies Record<I18nKey, string>

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -607,4 +607,5 @@ export const fr = {
   'about.update.noReleases': 'Aucune version publiée pour l’instant',
   'about.update.badRelease': 'La dernière version ne comportait pas de numéro de version',
   'about.update.unavailable': 'Impossible de joindre les versions GitHub',
+  'about.update.openRelease': 'Ouvrir la version sur GitHub',
 } satisfies Record<I18nKey, string>

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -607,4 +607,5 @@ export const ja = {
   'about.update.noReleases': 'まだ公開されたリリースはありません',
   'about.update.badRelease': '最新リリースにバージョンが含まれていません',
   'about.update.unavailable': 'GitHub のリリースに接続できませんでした',
+  'about.update.openRelease': 'GitHub のリリースを開く',
 } satisfies Record<I18nKey, string>

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -607,4 +607,5 @@ export const ko = {
   'about.update.noReleases': '아직 게시된 릴리스가 없습니다',
   'about.update.badRelease': '최신 릴리스에 버전이 포함되지 않았습니다',
   'about.update.unavailable': 'GitHub 릴리스에 연결할 수 없습니다',
+  'about.update.openRelease': 'GitHub 릴리스 열기',
 } satisfies Record<I18nKey, string>

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -607,4 +607,5 @@ export const pt = {
   'about.update.noReleases': 'Nenhuma versão publicada ainda',
   'about.update.badRelease': 'A versão mais recente não incluiu um número de versão',
   'about.update.unavailable': 'Não foi possível acessar as versões no GitHub',
+  'about.update.openRelease': 'Abrir a versão no GitHub',
 } satisfies Record<I18nKey, string>

--- a/src/lib/locales/tr.ts
+++ b/src/lib/locales/tr.ts
@@ -607,4 +607,5 @@ export const tr = {
   'about.update.noReleases': 'Henüz yayımlanmış sürüm yok',
   'about.update.badRelease': 'En son sürüm bir sürüm numarası içermiyordu',
   'about.update.unavailable': 'GitHub sürümlerine ulaşılamadı',
+  'about.update.openRelease': 'GitHub sürümünü aç',
 } satisfies Record<I18nKey, string>

--- a/src/lib/locales/zh-CN.ts
+++ b/src/lib/locales/zh-CN.ts
@@ -598,4 +598,5 @@ export const zhCN = {
   'about.update.noReleases': '暂无发布版本',
   'about.update.badRelease': '最新发布未包含版本号',
   'about.update.unavailable': '无法连接 GitHub Releases',
+  'about.update.openRelease': '打开 GitHub 发布页',
 } satisfies Record<I18nKey, string>

--- a/src/lib/locales/zh-TW.ts
+++ b/src/lib/locales/zh-TW.ts
@@ -607,4 +607,5 @@ export const zhTW = {
   'about.update.noReleases': '尚無發行版本',
   'about.update.badRelease': '最新發行版本未包含版本號',
   'about.update.unavailable': '無法連線至 GitHub 發行版',
+  'about.update.openRelease': '開啟 GitHub 發行頁',
 } satisfies Record<I18nKey, string>

--- a/tests/e2e/mobile-home-navigation.spec.ts
+++ b/tests/e2e/mobile-home-navigation.spec.ts
@@ -290,9 +290,16 @@ test('switches between document home and the settings about screen', async ({ pa
   await expect(page.getByTestId('settings-reference-muya')).toHaveCount(0)
   await expect(page.getByTestId('settings-about-notices')).toHaveCount(0)
 
+  await expect(page.getByTestId('settings-open-release')).toHaveCount(0)
+
   await page.getByTestId('settings-check-updates').click()
   await expect(page.getByTestId('settings-check-updates')).toContainText(
     'Update available: v1.0.0',
+  )
+  await expect(page.getByTestId('settings-open-release')).toContainText('Open GitHub release')
+  await expect(page.getByTestId('settings-open-release')).toHaveAttribute(
+    'href',
+    'https://github.com/Renakoni/marktext-android/releases/tag/v1.0.0',
   )
 
   await page.getByTestId('settings-detail-back').click()


### PR DESCRIPTION
## Summary

The update checker already returned the GitHub Release URL (`releaseUrl` in `appUpdates.ts`), but `AboutSettings.vue` only rendered a status line, so a user who saw "Update available: vX.Y.Z" had no direct path to the release. This change adds an explicit **Open GitHub release** row that appears only when a newer version is detected.

- The row reuses the existing About-page link pattern (`about-row is-link`, `target="_blank"`), which is the same mechanism as the shipped GitHub repository link, so Capacitor opens it in the external browser and APK installation remains an Android user-confirmed action.
- The link is hidden while a check is running and for `current`/`unavailable` results, keeping the surface quiet by default.
- `releaseUrl` falls back to `APP_INFO.releasesUrl` if the API response lacked `html_url` (the type allows null).
- Adds the `about.update.openRelease` string to all ten locales; the TypeScript key contract and locale parity tests enforce coverage.

Closes the "Make update checks actionable" item from the post-release queue.

## Verification

- `pnpm typecheck` passed.
- Focused unit tests passed: `localeContract.test.ts`, `appUpdates.test.ts`, `i18n.test.ts` (3 files / 36 tests).
- Focused ESLint on the changed files passed with zero warnings.
- Focused Playwright run of `mobile-home-navigation.spec.ts` ("settings about screen") passed; the test now asserts the release link is absent before the check and points at the mocked release URL after an update is detected.