### PR TITLE
Keep the caret visible after Enter and other structural edits

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -42,6 +42,7 @@ import { createDocumentOutline, waitForViewportSettle } from './features/editor/
 import { createDocumentSearch } from './features/editor/documentSearch'
 import { createSelectionToolbarLongPress } from './features/editor/selectionToolbarLongPress'
 import type { SelectionToolbarCommandId } from './features/editor/selectionToolbar'
+import { createCaretFollow } from './features/editor/caretFollow'
 import { createResumePosition } from './features/editor/resumePosition'
 import {
   readStoredResumePosition,
@@ -486,6 +487,13 @@ const {
   saveAndroidDocument: () => saveAndroidDocument(),
 })
 
+// Deferred lookup: the editor session below owns the editor instance; the
+// follow handler only dereferences it per selection-change event.
+const caretFollow = createCaretFollow({
+  getEditor: () => getEditor(),
+  logger: editorLog,
+})
+
 const {
   editorReady,
   editorFailed,
@@ -513,6 +521,7 @@ const {
   createMuyaEditor,
   destroyMuyaEditor,
   syncMarkdown: nextStatus => syncMarkdown(nextStatus),
+  onEditorSelectionChange: caretFollow.onEditorSelectionChange,
   onEditorFocus: () => {
     status.value =
       documentState.value.autosaveTarget === 'android-document' &&

--- a/src/features/editor/caretFollow.test.ts
+++ b/src/features/editor/caretFollow.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import { computeCaretFollowScrollDelta, createCaretFollow } from './caretFollow'
+
+describe('computeCaretFollowScrollDelta', () => {
+  const CONTAINER = { containerTop: 80, containerHeight: 400 }
+
+  it('returns 0 when the caret sits inside the comfortable band', () => {
+    expect(
+      computeCaretFollowScrollDelta({ caretTop: 280, caretBottom: 300, ...CONTAINER }),
+    ).toBe(0)
+  })
+
+  it('scrolls down when the caret drops into the bottom margin', () => {
+    // Caret bottom 20px above the container bottom edge (band ends at 300).
+    expect(
+      computeCaretFollowScrollDelta({ caretTop: 440, caretBottom: 460, ...CONTAINER }),
+    ).toBe(80)
+  })
+
+  it('scrolls down when the caret is fully below the container', () => {
+    expect(
+      computeCaretFollowScrollDelta({ caretTop: 520, caretBottom: 540, ...CONTAINER }),
+    ).toBe(160)
+  })
+
+  it('scrolls up when the caret rises into the top margin', () => {
+    // Caret top 40px below the container top edge (band starts at 100).
+    expect(
+      computeCaretFollowScrollDelta({ caretTop: 120, caretBottom: 140, ...CONTAINER }),
+    ).toBe(-60)
+  })
+
+  it('scrolls up when the caret is fully above the container', () => {
+    expect(
+      computeCaretFollowScrollDelta({ caretTop: 0, caretBottom: 20, ...CONTAINER }),
+    ).toBe(-180)
+  })
+
+  it('clamps the margin on short viewports so the band never collapses', () => {
+    // 160px visible height (landscape + keyboard): margin becomes 40, not 100.
+    expect(
+      computeCaretFollowScrollDelta({
+        caretTop: 80,
+        caretBottom: 96,
+        containerTop: 0,
+        containerHeight: 160,
+      }),
+    ).toBe(0)
+    expect(
+      computeCaretFollowScrollDelta({
+        caretTop: 130,
+        caretBottom: 150,
+        containerTop: 0,
+        containerHeight: 160,
+      }),
+    ).toBe(30)
+  })
+
+  it('ignores a container that has no height yet', () => {
+    expect(
+      computeCaretFollowScrollDelta({
+        caretTop: 10,
+        caretBottom: 20,
+        containerTop: 0,
+        containerHeight: 0,
+      }),
+    ).toBe(0)
+  })
+})
+
+function buildEditorDom() {
+  const container = document.createElement('div')
+  const editorRoot = document.createElement('div')
+  const focusable = document.createElement('div')
+  focusable.tabIndex = -1
+  editorRoot.appendChild(focusable)
+  container.appendChild(editorRoot)
+  document.body.appendChild(container)
+
+  container.getBoundingClientRect = () =>
+    ({ top: 0, bottom: 400, left: 0, right: 360, width: 360, height: 400 }) as DOMRect
+  Object.defineProperty(container, 'clientHeight', { value: 400 })
+
+  return { container, editorRoot, focusable }
+}
+
+describe('createCaretFollow', () => {
+  it('scrolls the editor parent when a collapsed caret leaves the visible band', () => {
+    const { container, editorRoot, focusable } = buildEditorDom()
+    focusable.focus()
+
+    const follow = createCaretFollow({ getEditor: () => ({ domNode: editorRoot }) })
+    follow.onEditorSelectionChange({
+      isCollapsed: true,
+      cursorCoords: { top: 380, bottom: 396 },
+    })
+
+    expect(container.scrollTop).toBe(96)
+    container.remove()
+  })
+
+  it('does nothing while the editor does not own focus', () => {
+    const { container, editorRoot } = buildEditorDom()
+
+    const follow = createCaretFollow({ getEditor: () => ({ domNode: editorRoot }) })
+    follow.onEditorSelectionChange({
+      isCollapsed: true,
+      cursorCoords: { top: 380, bottom: 396 },
+    })
+
+    expect(container.scrollTop).toBe(0)
+    container.remove()
+  })
+
+  it('leaves non-collapsed selections alone for native handle drags', () => {
+    const { container, editorRoot, focusable } = buildEditorDom()
+    focusable.focus()
+
+    const follow = createCaretFollow({ getEditor: () => ({ domNode: editorRoot }) })
+    follow.onEditorSelectionChange({
+      isCollapsed: false,
+      cursorCoords: { top: 380, bottom: 396 },
+    })
+
+    expect(container.scrollTop).toBe(0)
+    container.remove()
+  })
+
+  it('skips silently when no caret rect is recoverable', () => {
+    const { container, editorRoot, focusable } = buildEditorDom()
+    focusable.focus()
+    window.getSelection()?.removeAllRanges()
+
+    const follow = createCaretFollow({ getEditor: () => ({ domNode: editorRoot }) })
+    follow.onEditorSelectionChange({ isCollapsed: true, cursorCoords: null })
+
+    expect(container.scrollTop).toBe(0)
+    container.remove()
+  })
+})

--- a/src/features/editor/caretFollow.ts
+++ b/src/features/editor/caretFollow.ts
@@ -1,0 +1,138 @@
+// Keeps the caret visible after Muya-driven edits (Enter, undo/redo, toolbar
+// commands). The WebView scrolls the caret into view on its own only for
+// native contenteditable input; structural edits rebuild DOM and re-apply the
+// selection programmatically, which never triggers that native follow, so a
+// caret at the bottom edge silently leaves the viewport. Muya deliberately
+// leaves scroll-follow to its shell — its `selection-change` event carries a
+// viewport-relative caret rect (`cursorCoords`) for exactly this purpose, and
+// desktop MarkText implements the same follow there (upstream #628/#3329).
+//
+// Android constraints this module adds over the desktop handler:
+// - container-relative math (the scroll container sits below the app header);
+// - collapsed carets only, so native selection-handle drags are untouched;
+// - only while the editor owns focus, so editor init and resume-position
+//   restores never fight over scrollTop;
+// - margins clamped for short viewports (landscape plus soft keyboard).
+
+interface CaretFollowEditor {
+  domNode: HTMLElement
+}
+
+interface CaretFollowLogger {
+  debug(message: string, context?: Record<string, unknown>): void
+}
+
+export interface CreateCaretFollowOptions {
+  getEditor: () => CaretFollowEditor | null
+  logger?: CaretFollowLogger
+}
+
+// Desktop keeps the caret at least 100px clear of the container edges.
+const CARET_FOLLOW_MARGIN_PX = 100
+
+export interface CaretFollowInput {
+  caretTop: number
+  caretBottom: number
+  containerTop: number
+  containerHeight: number
+}
+
+/**
+ * How far the container must scroll (positive = down) so the caret sits inside
+ * the comfortable band. Zero when the caret is already within it.
+ */
+export function computeCaretFollowScrollDelta({
+  caretTop,
+  caretBottom,
+  containerTop,
+  containerHeight,
+}: CaretFollowInput): number {
+  if (containerHeight <= 0) {
+    return 0
+  }
+
+  // On a short visible area (landscape with the soft keyboard up) the fixed
+  // desktop margins would overlap; keep the band at least half the viewport.
+  const margin = Math.min(CARET_FOLLOW_MARGIN_PX, Math.floor(containerHeight / 4))
+  const top = caretTop - containerTop
+  const bottom = caretBottom - containerTop
+
+  if (bottom > containerHeight - margin) {
+    return bottom - (containerHeight - margin)
+  }
+
+  if (top < margin) {
+    return top - margin
+  }
+
+  return 0
+}
+
+// Muya's `cursorCoords` is null when a collapsed caret has no client rect
+// (empty paragraph text nodes) — recover the rect the way the desktop shell
+// does, by falling back to the caret's nearest element.
+function readCaretRect(): { top: number; bottom: number } | null {
+  const selection = window.getSelection()
+  if (!selection || selection.rangeCount === 0) {
+    return null
+  }
+
+  const range = selection.getRangeAt(0).cloneRange()
+  let rects: DOMRectList | null = range.getClientRects()
+  if (rects.length === 0) {
+    const node = range.startContainer
+    const element = node instanceof Element ? node : node.parentElement
+    rects = element ? element.getClientRects() : null
+  }
+
+  if (!rects || rects.length === 0) {
+    return null
+  }
+
+  const rect = rects[rects.length - 1]
+  return { top: rect.top, bottom: rect.bottom }
+}
+
+interface SelectionChangePayload {
+  isCollapsed?: boolean
+  cursorCoords?: { top: number; bottom: number } | null
+}
+
+export function createCaretFollow(options: CreateCaretFollowOptions) {
+  function onEditorSelectionChange(...args: unknown[]) {
+    const editor = options.getEditor()
+    const container = editor?.domNode.parentElement
+    if (!editor || !container) {
+      return
+    }
+
+    const active = document.activeElement
+    if (!(active instanceof HTMLElement) || !editor.domNode.contains(active)) {
+      return
+    }
+
+    const payload = args[0] as SelectionChangePayload | undefined
+    if (payload?.isCollapsed !== true) {
+      return
+    }
+
+    const rect = payload.cursorCoords ?? readCaretRect()
+    if (!rect) {
+      return
+    }
+
+    const delta = computeCaretFollowScrollDelta({
+      caretTop: rect.top,
+      caretBottom: rect.bottom,
+      containerTop: container.getBoundingClientRect().top,
+      containerHeight: container.clientHeight,
+    })
+
+    if (delta !== 0) {
+      container.scrollTop += delta
+      options.logger?.debug('caret follow scrolled', { delta })
+    }
+  }
+
+  return { onEditorSelectionChange }
+}

--- a/src/features/editor/editorRuntime.ts
+++ b/src/features/editor/editorRuntime.ts
@@ -23,6 +23,7 @@ export interface CreateMuyaEditorOptions {
   markdown: string
   onContentChange: (...args: unknown[]) => void
   onJsonChange: (...args: unknown[]) => void
+  onSelectionChange?: (...args: unknown[]) => void
   onFocus: (...args: unknown[]) => void
   onBlur: (...args: unknown[]) => void
   appLocale?: string
@@ -148,6 +149,7 @@ export async function createMuyaEditor({
   markdown,
   onContentChange,
   onJsonChange,
+  onSelectionChange,
   onFocus,
   onBlur,
   appLocale,
@@ -184,6 +186,9 @@ export async function createMuyaEditor({
     }
     editor.on('content-change', onContentChange)
     editor.on('json-change', onJsonChange)
+    if (onSelectionChange) {
+      editor.on('selection-change', onSelectionChange)
+    }
     editor.on('focus', onFocus)
     editor.on('blur', onBlur)
 

--- a/src/features/editor/editorSession.ts
+++ b/src/features/editor/editorSession.ts
@@ -50,6 +50,7 @@ export interface EditorSessionOptions {
   destroyMuyaEditor: (editor: MuyaEditor | null) => void
   // Editor-content handlers owned by App (status + autosave coordination).
   syncMarkdown: (nextStatus?: unknown) => void
+  onEditorSelectionChange?: (...args: unknown[]) => void
   onEditorFocus: () => void
   onEditorBlur: () => void
   // Collaborators owned by App or sibling factories.
@@ -179,6 +180,7 @@ export function createEditorSession(options: EditorSessionOptions): EditorSessio
         markdown: initialMarkdown,
         onContentChange: options.syncMarkdown,
         onJsonChange: options.syncMarkdown,
+        onSelectionChange: options.onEditorSelectionChange,
         onFocus: options.onEditorFocus,
         onBlur: handleEditorBlur,
         appLocale: options.locale.value,

--- a/tests/e2e/mobile-editor-caret-follow.spec.ts
+++ b/tests/e2e/mobile-editor-caret-follow.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test, type Page } from '@playwright/test'
+import { openLocalDraft } from './helpers/drafts'
+
+test.describe.configure({ timeout: 60000 })
+
+// Pressing Enter rebuilds the paragraph DOM and re-applies the selection
+// programmatically, so the WebView's native caret-follow (which covers typed
+// characters) never fires. The caretFollow module must keep the collapsed
+// caret inside the shell viewport after every structural edit; without it the
+// caret walks off the bottom edge line by line.
+
+const MARKDOWN = `# Caret Follow
+
+${Array.from({ length: 40 }, (_, index) => `Line ${index + 1}`).join('\n\n')}
+`
+
+interface CaretMetrics {
+  caretBottom: number
+  shellBottom: number
+  scrollTop: number
+}
+
+function readCaretMetrics(page: Page): Promise<CaretMetrics | null> {
+  return page.evaluate(() => {
+    const shell = document.querySelector<HTMLElement>('.editor-host-shell')
+    const selection = window.getSelection()
+    if (!shell || !selection || selection.rangeCount === 0) {
+      return null
+    }
+
+    const range = selection.getRangeAt(0).cloneRange()
+    const rects = range.getClientRects()
+    let rect: DOMRect | undefined = rects.length > 0 ? rects[rects.length - 1] : undefined
+    if (!rect) {
+      const node = range.startContainer
+      const element = node instanceof Element ? node : node.parentElement
+      rect = element?.getBoundingClientRect()
+    }
+
+    if (!rect) {
+      return null
+    }
+
+    return {
+      caretBottom: rect.bottom,
+      shellBottom: shell.getBoundingClientRect().bottom,
+      scrollTop: shell.scrollTop,
+    }
+  })
+}
+
+test('keeps the caret visible while Enter appends lines at the bottom', async ({ page }) => {
+  await openLocalDraft(page, {
+    id: 'caret-follow-draft',
+    markdown: MARKDOWN,
+    title: /Caret Follow/,
+  })
+
+  // Scroll to the end and put the caret into the last line.
+  await page.evaluate(() => {
+    const shell = document.querySelector<HTMLElement>('.editor-host-shell')!
+    shell.scrollTop = shell.scrollHeight
+  })
+  const lastParagraph = page.locator('.mu-editor p.mu-paragraph').last()
+  await lastParagraph.click()
+
+  const initial = await readCaretMetrics(page)
+  expect(initial).not.toBeNull()
+
+  // Enough presses to walk well past the shell height even with generous
+  // editor bottom padding; the invariant must hold after every single one.
+  for (let press = 0; press < 30; press += 1) {
+    await page.keyboard.press('Enter')
+    const metrics = await readCaretMetrics(page)
+    expect(metrics, `caret metrics after Enter #${press + 1}`).not.toBeNull()
+    expect(
+      metrics!.caretBottom,
+      `caret left the viewport after Enter #${press + 1}`,
+    ).toBeLessThanOrEqual(metrics!.shellBottom + 1)
+  }
+
+  const final = await readCaretMetrics(page)
+  expect(final!.scrollTop).toBeGreaterThan(initial!.scrollTop)
+})


### PR DESCRIPTION
## Problem

With the caret on the last visible line, pressing Enter wraps to a new line but the viewport does not scroll — the caret silently leaves the screen (severity: high, reported from device testing on the published v0.1.0). Typing a character does bring the caret back into view, which made the behavior feel inconsistent.

## Evidence chain

- The WebView scrolls the caret into view natively only for real contenteditable input. Muya handles Enter (and undo/redo, toolbar commands) by `preventDefault` + rebuilding the block DOM + re-applying the selection programmatically, which never triggers that native follow.
- Muya deliberately leaves scroll-follow to its shell: its `selection-change` event carries a viewport-relative caret rect (`cursorCoords`, `third_party/muya/src/selection/TextSelection.ts:266`), documented in `selectionChange.spec.ts` as the value "the desktop typewriter scroll reads".
- Desktop MarkText implements exactly this follow in its shell (`editor.vue` selection-change handler, upstream fixes #628/#3329: scroll down when the caret is within 100px of the container bottom, scroll up when it rises above the top band). The Android shell had no equivalent — only `resumePosition` touches `scrollTop`, and only on document open.

## Fix

New `src/features/editor/caretFollow.ts`, wired through `editorRuntime`/`editorSession` as an optional `selection-change` subscriber (same callback pipeline as the existing content/focus events). It mirrors the desktop margins with Android-specific constraints:

- container-relative math (`.editor-host-shell` sits below the app header);
- collapsed carets only, so native selection-handle drags are untouched;
- only while the editor owns focus, so editor init and resume-position restores never fight over `scrollTop`;
- margins clamped to a quarter of the visible height for short viewports (landscape + soft keyboard);
- when Muya reports `cursorCoords: null` (empty-paragraph carets can have no client rect), the rect is recovered from the caret's nearest element, the same fallback the desktop shell uses.

Scrolling up to read stays undisturbed: reading scroll changes no selection, so no event fires; the caret is re-revealed only by actual edits.

## Verification

- `pnpm typecheck` passed.
- Unit tests: `caretFollow.test.ts` (11 tests) covers the scroll-delta band math (down/up/inside/short-viewport clamp/zero-height) and the handler gating (focus required, non-collapsed ignored, missing rect skipped). Full editor-feature unit suite: 24 files / 199 tests passed.
- Focused ESLint on all touched files passed with zero warnings.
- New e2e `mobile-editor-caret-follow.spec.ts`: opens a 40-line draft, places the caret in the last line, presses Enter 30 times and asserts after every press that the caret stays inside the shell viewport, then that the container actually scrolled. **Failure path proven**: with the App.vue wiring temporarily disabled, the test fails at Enter #5 with "caret left the viewport" — matching the reported repro; re-enabled, it passes.