### PR TITLE
Keep theme mode segments on screen for long locale labels

### DIFF
--- a/src/features/settings/components/SettingsChoiceRow.vue
+++ b/src/features/settings/components/SettingsChoiceRow.vue
@@ -42,6 +42,9 @@ defineEmits<{
 .settings-choice-row {
   position: relative;
   display: grid;
+  /* Cap the implicit track at the available width so the options track can
+     never be sized by its single-line max-content and push past the screen. */
+  grid-template-columns: minmax(0, 1fr);
   gap: 10px;
   width: 100%;
   min-width: 0;
@@ -65,21 +68,30 @@ defineEmits<{
   overflow-wrap: anywhere;
 }
 
-/* Segmented control: sunken track, the active segment floats as a thumb. */
+/* Segmented control: sunken track, the active segment floats as a thumb.
+   Segments size from their label and wrap onto a second track line when the
+   localized labels outgrow the row (for example German "Benutzerdefiniert"
+   with four options on a phone), instead of pushing past the screen edge. */
 .settings-choice-options {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 2px;
   width: 100%;
+  min-width: 0;
   padding: 2px;
   border-radius: var(--radius-sm);
   background: var(--surface-sunken);
 }
 
 .settings-choice-option {
-  min-width: 0;
+  flex: 1 0 auto;
+  min-width: 72px;
+  max-width: 100%;
   min-height: 36px;
   padding: 0 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   border: 0;
   border-radius: 8px;
   background: transparent;

--- a/src/features/settings/components/SettingsChoiceRow.vue
+++ b/src/features/settings/components/SettingsChoiceRow.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
 interface SettingsChoiceOption {
   id: string
   label: string
   testId: string
 }
 
-defineProps<{
+const props = defineProps<{
   label?: string
   ariaLabel?: string
   modelValue: string
@@ -16,12 +18,75 @@ defineProps<{
 defineEmits<{
   'update:modelValue': [value: string]
 }>()
+
+// Whether the localized labels fit on one segmented line is a property of the
+// rendered text, not the viewport, so CSS alone cannot decide it. Measure the
+// single-line overflow and stack the segments into a two-column grid when the
+// row cannot hold them — a balanced grid keeps every segment button-shaped
+// instead of leaving one label stretched across a full-width bar.
+const optionsElement = ref<HTMLElement | null>(null)
+const stacked = ref(false)
+// The width the single-line layout needs, captured when it overflows; a later
+// resize wider than this lets the control return to one line.
+let singleLineWidth = 0
+let resizeObserver: ResizeObserver | null = null
+
+function measure() {
+  const element = optionsElement.value
+  if (!element) {
+    return
+  }
+
+  if (!stacked.value) {
+    if (element.scrollWidth > element.clientWidth) {
+      singleLineWidth = element.scrollWidth
+      stacked.value = true
+    }
+  } else if (element.clientWidth >= singleLineWidth) {
+    stacked.value = false
+  }
+}
+
+function remeasureFromSingleLine() {
+  stacked.value = false
+  singleLineWidth = 0
+  requestAnimationFrame(measure)
+}
+
+watch(
+  () => props.options.map(option => option.label).join('\n'),
+  remeasureFromSingleLine,
+)
+
+onMounted(() => {
+  measure()
+  if (typeof ResizeObserver !== 'undefined' && optionsElement.value) {
+    // Deferring keeps the layout mutation out of the observer's delivery
+    // cycle; stacking synchronously here triggers the browser's
+    // "ResizeObserver loop completed with undelivered notifications" error.
+    resizeObserver = new ResizeObserver(() => requestAnimationFrame(measure))
+    resizeObserver.observe(optionsElement.value)
+  }
+  // Web-font swaps change label widths without resizing the container.
+  document.fonts?.ready.then(measure)
+})
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+  resizeObserver = null
+})
 </script>
 
 <template>
   <div class="settings-choice-row" :class="{ 'is-label-hidden': !label }" :data-testid="testId">
     <span v-if="label" class="settings-choice-label">{{ label }}</span>
-    <div class="settings-choice-options" role="group" :aria-label="ariaLabel ?? label">
+    <div
+      ref="optionsElement"
+      class="settings-choice-options"
+      :class="{ 'is-stacked': stacked }"
+      role="group"
+      :aria-label="ariaLabel ?? label"
+    >
       <button
         v-for="option in options"
         :key="option.id"
@@ -69,18 +134,23 @@ defineEmits<{
 }
 
 /* Segmented control: sunken track, the active segment floats as a thumb.
-   Segments size from their label and wrap onto a second track line when the
-   localized labels outgrow the row (for example German "Benutzerdefiniert"
-   with four options on a phone), instead of pushing past the screen edge. */
+   Overflow stays clipped for the frame before `measure()` stacks the control. */
 .settings-choice-options {
   display: flex;
-  flex-wrap: wrap;
   gap: 2px;
   width: 100%;
   min-width: 0;
   padding: 2px;
   border-radius: var(--radius-sm);
   background: var(--surface-sunken);
+  overflow: hidden;
+}
+
+/* Two balanced columns once the localized labels outgrow the single line
+   (for example German "Benutzerdefiniert" with four options on a phone). */
+.settings-choice-options.is-stacked {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .settings-choice-option {
@@ -89,9 +159,6 @@ defineEmits<{
   max-width: 100%;
   min-height: 36px;
   padding: 0 10px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   border: 0;
   border-radius: 8px;
   background: transparent;
@@ -100,6 +167,9 @@ defineEmits<{
   font-size: 13.5px;
   font-weight: 500;
   letter-spacing: -0.004em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   touch-action: manipulation;
   transition:
     background-color var(--dur-standard) var(--ease-out),

--- a/tests/e2e/mobile-appearance-settings.spec.ts
+++ b/tests/e2e/mobile-appearance-settings.spec.ts
@@ -41,6 +41,39 @@ test('uses the selected language in a newly created editor session', async ({ pa
   await expect(page.locator('[hint]').first()).toHaveAttribute('hint', /输入程序语言标识/)
 })
 
+test('keeps the theme mode segments on screen with long locale labels', async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => {
+    localStorage.clear()
+    // German has the longest mode label ("Benutzerdefiniert"); it used to push
+    // the segmented control past the right screen edge.
+    localStorage.setItem('marktext-for-android:locale', 'de')
+  })
+  await page.reload()
+
+  await openAppearanceSettings(page)
+  const modeControl = page.getByTestId('settings-appearance-theme-mode')
+  await expect(modeControl).toBeVisible()
+
+  const viewport = page.viewportSize()!
+  const controlBox = await modeControl.boundingBox()
+  expect(controlBox).not.toBeNull()
+  expect(controlBox!.x + controlBox!.width).toBeLessThanOrEqual(viewport.width + 0.5)
+
+  for (const option of ['system', 'light', 'dark', 'custom']) {
+    const segment = page.getByTestId(`settings-appearance-theme-mode-option-${option}`)
+    const box = await segment.boundingBox()
+    expect(box, `segment ${option}`).not.toBeNull()
+    expect(box!.x, `segment ${option} left edge`).toBeGreaterThanOrEqual(0)
+    expect(box!.x + box!.width, `segment ${option} right edge`).toBeLessThanOrEqual(
+      viewport.width + 0.5,
+    )
+    // The label must be fully rendered, not ellipsized inside the segment.
+    const clipped = await segment.evaluate(element => element.scrollWidth > element.clientWidth)
+    expect(clipped, `segment ${option} label clipped`).toBe(false)
+  }
+})
+
 test('applies Appearance text settings without rewriting existing draft Markdown', async ({ page }) => {
   const markdown = '# Appearance Probe\r\n\r\n- [ ] untouched\r\n'
   const now = '2026-07-03T08:00:00.000Z'

--- a/tests/e2e/mobile-appearance-settings.spec.ts
+++ b/tests/e2e/mobile-appearance-settings.spec.ts
@@ -55,23 +55,39 @@ test('keeps the theme mode segments on screen with long locale labels', async ({
   const modeControl = page.getByTestId('settings-appearance-theme-mode')
   await expect(modeControl).toBeVisible()
 
-  const viewport = page.viewportSize()!
-  const controlBox = await modeControl.boundingBox()
-  expect(controlBox).not.toBeNull()
-  expect(controlBox!.x + controlBox!.width).toBeLessThanOrEqual(viewport.width + 0.5)
+  const expectSegmentsOnScreen = async () => {
+    const viewport = page.viewportSize()!
+    const controlBox = await modeControl.boundingBox()
+    expect(controlBox).not.toBeNull()
+    expect(controlBox!.x + controlBox!.width).toBeLessThanOrEqual(viewport.width + 0.5)
 
-  for (const option of ['system', 'light', 'dark', 'custom']) {
-    const segment = page.getByTestId(`settings-appearance-theme-mode-option-${option}`)
-    const box = await segment.boundingBox()
-    expect(box, `segment ${option}`).not.toBeNull()
-    expect(box!.x, `segment ${option} left edge`).toBeGreaterThanOrEqual(0)
-    expect(box!.x + box!.width, `segment ${option} right edge`).toBeLessThanOrEqual(
-      viewport.width + 0.5,
-    )
-    // The label must be fully rendered, not ellipsized inside the segment.
-    const clipped = await segment.evaluate(element => element.scrollWidth > element.clientWidth)
-    expect(clipped, `segment ${option} label clipped`).toBe(false)
+    for (const option of ['system', 'light', 'dark', 'custom']) {
+      const segment = page.getByTestId(`settings-appearance-theme-mode-option-${option}`)
+      const box = await segment.boundingBox()
+      expect(box, `segment ${option}`).not.toBeNull()
+      expect(box!.x, `segment ${option} left edge`).toBeGreaterThanOrEqual(0)
+      expect(box!.x + box!.width, `segment ${option} right edge`).toBeLessThanOrEqual(
+        viewport.width + 0.5,
+      )
+      // The label must be fully rendered, not ellipsized inside the segment.
+      const clipped = await segment.evaluate(element => element.scrollWidth > element.clientWidth)
+      expect(clipped, `segment ${option} label clipped`).toBe(false)
+    }
   }
+
+  await expectSegmentsOnScreen()
+
+  // On a narrower phone the segments stack into two balanced columns; every
+  // label must still be fully on screen and unclipped.
+  await page.setViewportSize({ width: 360, height: 800 })
+  await expect
+    .poll(() =>
+      modeControl
+        .locator('.settings-choice-options')
+        .evaluate(element => element.classList.contains('is-stacked')),
+    )
+    .toBe(true)
+  await expectSegmentsOnScreen()
 })
 
 test('applies Appearance text settings without rewriting existing draft Markdown', async ({ page }) => {


### PR DESCRIPTION
## Problem

In Settings → Appearance with German or French locale, the theme mode segmented control (System / Hell / Dunkel / Benutzerdefiniert) overflowed past the right screen edge (reported with device screenshots; priority medium).

## Root cause

`SettingsChoiceRow.vue` sized the segments with `grid-template-columns: repeat(auto-fit, minmax(72px, 1fr))` inside an unconstrained implicit grid track, so four equal columns were sized by the longest localized label ("Benutzerdefiniert", ~17 characters) and the whole track grew past the viewport.

## Fix

Whether the labels fit on one line is a property of the rendered text, not the viewport, so a fixed breakpoint cannot decide it. The control now:

- lays segments out on a single flex line sized by their labels (English and, on ~412px phones, German/French all still fit on one line);
- measures single-line overflow in the component (ResizeObserver, deferred to `requestAnimationFrame` to avoid the observer-loop error) and, when the labels genuinely cannot fit, stacks the four segments into a **two-column balanced grid** — every segment keeps its button shape instead of one label stretching into a full-width bar (the first wrap-based iteration looked wrong, see the commit history);
- re-measures when the labels change (locale switch) and when web fonts finish loading, and returns to one line when the container grows wide enough;
- keeps an ellipsis guard for pathological labels and clips the pre-measurement frame so nothing ever paints past the screen edge.

The parent row also caps its implicit grid track at `minmax(0, 1fr)` so the options container can never be sized by its max-content again.

## Verification

- `pnpm typecheck` and focused ESLint (zero warnings) passed.
- Settings unit suite: 6 files / 39 tests passed.
- New e2e in `mobile-appearance-settings.spec.ts`: German locale, asserts all four segments sit inside the viewport and no label is ellipsized at the default width, then resizes to 360px, waits for the stacked two-column mode, and re-asserts. Full appearance spec: 3/3 passed. **Failure path proven**: with the fix stashed, the test fails with "segment custom label clipped".
- Visual pass over the dev build: German 412px (single line, full label), German 360px (2×2 balanced grid), English 360px (single line, unchanged).