### PR TITLE
Port upstream 4931: keep emoji deletion on code-point boundaries

### DIFF
--- a/tests/e2e/mobile-emoji-deletion.spec.ts
+++ b/tests/e2e/mobile-emoji-deletion.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test, type Page } from '@playwright/test'
+import { openLocalDraft } from './helpers/drafts'
+
+test.describe.configure({ timeout: 60000 })
+
+// Upstream marktext#4931 (issue #4926): emoji are stored as UTF-16 surrogate
+// pairs, and a deletion at the offset between the two units left a lone
+// surrogate in the document. ot-text-unicode cannot encode a lone surrogate,
+// so the next text operation threw "Invalid offset - splits unicode bytes"
+// and crashed the renderer. Mobile hits this harder than desktop: soft
+// keyboards make emoji input and Backspace far more common.
+
+const EMOJI = '\u{1F642}'
+const MIXED_TEXT = `${EMOJI}(微笑)\u{1F600}(大笑)`
+const TEXT_AFTER_FIRST_EMOJI = MIXED_TEXT.slice(EMOJI.length)
+const DELETE_KEYS = ['Backspace', 'Delete'] as const
+
+function paragraph(page: Page) {
+  return page.locator('.mu-editor p.mu-paragraph').first()
+}
+
+function collectPageErrors(page: Page) {
+  const errors: Error[] = []
+  page.on('pageerror', error => errors.push(error))
+  return errors
+}
+
+async function openDraftWithText(page: Page, markdown: string, title: RegExp) {
+  await openLocalDraft(page, { id: 'emoji-deletion-draft', markdown, title })
+  await paragraph(page).click()
+}
+
+/**
+ * Rest the collapsed DOM caret at `unitOffset` UTF-16 units into the first
+ * text node containing `needle`, then let Muya adopt the selection the way a
+ * user tap would.
+ */
+async function placeCaret(page: Page, needle: string, unitOffset: number) {
+  const placed = await page.evaluate(
+    ({ needle, unitOffset }) => {
+      const target = document.querySelector('.mu-editor p.mu-paragraph')
+      if (!target) {
+        return false
+      }
+
+      const walker = document.createTreeWalker(target, NodeFilter.SHOW_TEXT)
+      let textNode = walker.nextNode()
+      while (textNode instanceof Text && !textNode.data.includes(needle)) {
+        textNode = walker.nextNode()
+      }
+      if (!(textNode instanceof Text)) {
+        return false
+      }
+
+      const offset = textNode.data.indexOf(needle) + unitOffset
+      const range = document.createRange()
+      range.setStart(textNode, offset)
+      range.collapse(true)
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      document.dispatchEvent(new Event('selectionchange'))
+      return true
+    },
+    { needle, unitOffset },
+  )
+  expect(placed).toBe(true)
+}
+
+for (const key of DELETE_KEYS) {
+  test(`${key} inside an emoji removes the whole code point without corruption`, async ({
+    page,
+  }) => {
+    const errors = collectPageErrors(page)
+    await openDraftWithText(page, MIXED_TEXT, /微笑/)
+
+    // Offset 1 is between the emoji's two UTF-16 code units.
+    await placeCaret(page, EMOJI, 1)
+    await page.keyboard.press(key)
+    await expect(paragraph(page)).toHaveText(TEXT_AFTER_FIRST_EMOJI)
+
+    // A follow-up edit must still apply cleanly — a lone surrogate would make
+    // this (not the deletion itself) throw inside the ot layer.
+    await placeCaret(page, '(', 0)
+    await page.keyboard.type('x')
+    await expect(paragraph(page)).toHaveText(`x${TEXT_AFTER_FIRST_EMOJI}`)
+    expect(errors).toEqual([])
+  })
+}
+
+test('Backspace removes a trailing emoji as one code point', async ({ page }) => {
+  const errors = collectPageErrors(page)
+  await openDraftWithText(page, `abc${EMOJI}`, /abc/)
+
+  await placeCaret(page, 'abc', `abc${EMOJI}`.length)
+  await page.keyboard.press('Backspace')
+  await expect(paragraph(page)).toHaveText('abc')
+
+  await page.keyboard.type('x')
+  await expect(paragraph(page)).toHaveText('abcx')
+  expect(errors).toEqual([])
+})

--- a/third_party/muya/src/block/base/__tests__/formatBackspace.spec.ts
+++ b/third_party/muya/src/block/base/__tests__/formatBackspace.spec.ts
@@ -70,6 +70,15 @@ function pressBackspace(content: Format): Event {
     return event;
 }
 
+function pressBackspaceThroughKeydown(content: Format): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', {
+        key: 'Backspace',
+        cancelable: true,
+    });
+    content.keydownHandler(event);
+    return event;
+}
+
 describe('format.backspaceHandler — closing-marker boundary (muya#113)', () => {
     it('just-outside the closing `**`: removes one marker char, no doubled markers', () => {
         // Caret at offset 14, immediately after the whole `**strong**` close.
@@ -214,6 +223,33 @@ describe('format.backspaceHandler — plain-text boundaries (no markers involved
         const event = pressBackspace(content);
 
         expect(content.text).toBe('oo **strong**');
+        expect(content.getCursor()!.start.offset).toBe(0);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('caret after a trailing astral character: removes the whole code point', () => {
+        const content = caretInFirstBlock(bootMuya('abc\u{1F642}\n'), 5);
+        const event = pressBackspace(content);
+
+        expect(content.text).toBe('abc');
+        expect(content.getCursor()!.start.offset).toBe(3);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('caret inside a trailing astral character: snaps then removes the whole code point', () => {
+        const content = caretInFirstBlock(bootMuya('abc\u{1F642}\n'), 4);
+        const event = pressBackspaceThroughKeydown(content);
+
+        expect(content.text).toBe('abc');
+        expect(content.getCursor()!.start.offset).toBe(3);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('caret after a leading astral character: removes the whole code point', () => {
+        const content = caretInFirstBlock(bootMuya('\u{1F642}abc\n'), 2);
+        const event = pressBackspace(content);
+
+        expect(content.text).toBe('abc');
         expect(content.getCursor()!.start.offset).toBe(0);
         expect(event.defaultPrevented).toBe(true);
     });

--- a/third_party/muya/src/block/base/content.ts
+++ b/third_party/muya/src/block/base/content.ts
@@ -732,6 +732,32 @@ class Content extends TreeNode {
         return true;
     }
 
+    private _snapDeletionCursorToCodePointBoundary(event: KeyboardEvent) {
+        if (event.key !== EVENT_KEYS.Backspace && event.key !== EVENT_KEYS.Delete)
+            return;
+
+        const cursor = this.getCursor();
+        if (!cursor?.isCollapsed)
+            return;
+
+        const offset = cursor.start.offset;
+        const previous = this.text.charCodeAt(offset - 1);
+        const next = this.text.charCodeAt(offset);
+        const splitsSurrogatePair
+            = previous >= 0xD800
+                && previous <= 0xDBFF
+                && next >= 0xDC00
+                && next <= 0xDFFF;
+
+        // Native deletion at this invalid UTF-16 boundary leaves a lone
+        // surrogate that text-unicode cannot encode (#4926).
+        if (splitsSurrogatePair) {
+            const safeOffset
+                = event.key === EVENT_KEYS.Backspace ? offset + 1 : offset - 1;
+            this.setCursor(safeOffset, safeOffset);
+        }
+    }
+
     keydownHandler = (event: Event) => {
         if (!isKeyboardEvent(event))
             return;
@@ -741,6 +767,8 @@ class Content extends TreeNode {
 
         if (this._wrapSelectionWithAutoPair(event))
             return;
+
+        this._snapDeletionCursorToCodePointBoundary(event);
 
         switch (event.key) {
             case EVENT_KEYS.Backspace:

--- a/third_party/muya/src/block/base/format.ts
+++ b/third_party/muya/src/block/base/format.ts
@@ -42,6 +42,23 @@ interface IOffsetWithDelta extends IOffset {
 
 const debug = logger('block.format:');
 
+function firstCodePointLength(text: string) {
+    const codePoint = text.codePointAt(0);
+    return codePoint !== undefined && codePoint > 0xFFFF ? 2 : 1;
+}
+
+function lastCodePointLength(text: string) {
+    const last = text.length - 1;
+    const lastUnit = text.charCodeAt(last);
+    const previousUnit = text.charCodeAt(last - 1);
+    return lastUnit >= 0xDC00
+        && lastUnit <= 0xDFFF
+        && previousUnit >= 0xD800
+        && previousUnit <= 0xDBFF
+        ? 2
+        : 1;
+}
+
 function isEmojiToken(token: Token): token is CodeEmojiMathToken {
     return token.type === 'emoji';
 }
@@ -1337,7 +1354,7 @@ class Format extends Content {
         // `contenteditable=false` inline image; resolve the real offset from the
         // DOM so the scan can match the image token like any other caret.
         const offset = this._caretOffsetOnInlineImage() ?? start.offset;
-        const { needRender, imageToken, referenceImageToken }
+        const { needRender, imageToken, referenceImageToken, offsetDelta }
             = this._scanBackspaceTokens(tokens, offset);
 
         if (referenceImageToken) {
@@ -1353,8 +1370,8 @@ class Format extends Content {
             event.preventDefault();
             this.text = generator(tokens);
 
-            start.offset--;
-            end.offset--;
+            start.offset -= offsetDelta;
+            end.offset -= offsetDelta;
             this.setCursor(start.offset, end.offset, true);
         }
 
@@ -1381,6 +1398,7 @@ class Format extends Content {
         needRender: boolean;
         imageToken: Token | null;
         referenceImageToken: Token | null;
+        offsetDelta: number;
     } {
         for (const token of tokens) {
             // An inline image followed by other content: the caret lands on the
@@ -1390,25 +1408,28 @@ class Format extends Content {
                 = token.type === 'image'
                     || (token.type === 'html_tag' && token.tag === 'img');
             if (token.range.end === offset && isImageToken)
-                return { needRender: false, imageToken: token, referenceImageToken: null };
+                return { needRender: false, imageToken: token, referenceImageToken: null, offsetDelta: 0 };
 
             // A reference image (`![alt][ref]`) is editable marked text, so it has
             // no inline-image wrapper to select. Delete the whole token at once.
             if (token.range.end === offset && token.type === 'reference_image')
-                return { needRender: false, imageToken: null, referenceImageToken: token };
+                return { needRender: false, imageToken: null, referenceImageToken: token, offsetDelta: 0 };
 
             // handle delete the second marker(et:*、$) in inline syntax.(Firefox compatible)
             // Fix: https://github.com/marktext/muya/issues/113
             // for example: foo **strong**|
             if (token.range.end === offset) {
-                token.raw = token.raw.substring(0, token.raw.length - 1);
-                return { needRender: true, imageToken: null, referenceImageToken: null };
+                const removedLength = lastCodePointLength(token.raw);
+                token.raw = token.raw.substring(0, token.raw.length - removedLength);
+                return { needRender: true, imageToken: null, referenceImageToken: null, offsetDelta: removedLength };
             }
 
-            // If preToken is a syntax token, the the cursor is at offset 1, need to set the cursor manually.(Firefox compatible)
-            // // Fix: https://github.com/marktext/muya/issues/113
+            // When the caret is just after a token's first code point, remove
+            // that code point and place the cursor manually (Firefox parity).
+            // Fix: https://github.com/marktext/muya/issues/113
             // for example: foo **strong**w|
-            if (token.range.start + 1 === offset) {
+            const removedLength = firstCodePointLength(token.raw);
+            if (token.range.start + removedLength === offset) {
                 // An EMPTY inline marker pair in plain text — the whole token
                 // is the two paired chars (`*|*`, `~|~`, e.g. right after
                 // toolbar-inserted `**|**` lost its first pair): defer to the
@@ -1424,15 +1445,15 @@ class Format extends Content {
                     && token.raw.length === 2
                     && BRACKET_HASH[token.raw[0]] === token.raw[1]
                 ) {
-                    return { needRender: false, imageToken: null, referenceImageToken: null };
+                    return { needRender: false, imageToken: null, referenceImageToken: null, offsetDelta: 0 };
                 }
 
-                token.raw = token.raw.substring(1);
-                return { needRender: true, imageToken: null, referenceImageToken: null };
+                token.raw = token.raw.substring(removedLength);
+                return { needRender: true, imageToken: null, referenceImageToken: null, offsetDelta: removedLength };
             }
         }
 
-        return { needRender: false, imageToken: null, referenceImageToken: null };
+        return { needRender: false, imageToken: null, referenceImageToken: null, offsetDelta: 0 };
     }
 
     // Resolve the real caret offset when the collapsed caret is parked on a


### PR DESCRIPTION
## Summary

Port of [marktext/marktext#4935's sibling fix marktext#4931](https://github.com/marktext/marktext/pull/4931) (issue marktext#4926, authored upstream by this repo's owner) into the vendored Muya tree. Emoji are UTF-16 surrogate pairs; a deletion at the offset between the two units left a lone surrogate, which `ot-text-unicode` cannot encode — the next text operation threw `Invalid offset - splits unicode bytes` and crashed the renderer. Mobile hits this harder than desktop: soft keyboards make emoji input and Backspace far more frequent.

## Changes (adapted onto our vendored tree)

- `third_party/muya/src/block/base/content.ts` — `_snapDeletionCursorToCodePointBoundary`: before Backspace/Delete runs, a collapsed caret sitting between a surrogate pair is snapped to the adjacent valid boundary (Backspace past the pair, Delete before it), so the whole emoji is removed as one code point.
- `third_party/muya/src/block/base/format.ts` — `_scanBackspaceTokens` now trims a whole leading/trailing **code point** (not one code unit) from inline tokens and reports the removed length; `backspaceHandler` adjusts the cursor by that delta. Adapted around our local empty-marker-pair guard (`*|*` defers to `deleteAutoPair`), which upstream does not have — the guard's behavior is unchanged because `firstCodePointLength` is 1 for bracket characters.
- Upstream's three Muya unit tests ported into `formatBackspace.spec.ts`; upstream's Electron E2E replaced with a Playwright equivalent (`tests/e2e/mobile-emoji-deletion.spec.ts`) covering Backspace/Delete inside a pasted-style emoji and a trailing emoji, asserting the exact resulting text, that a follow-up edit still applies cleanly (which is what catches the deferred ot corruption), and zero page errors.

`node_modules/@muyajs/core` was synced per the vendor contract.

## Verification

- Focused Muya spec: 17/17; full `block/base` directory: 18 files / 153 tests; **full Muya app gate: 211 files / 1426 tests** — all passed.
- `pnpm typecheck` and focused ESLint passed.
- New e2e: 3/3 passed. **Failure path proven**: with `node_modules` reverted to main's Muya files, the spec reproduces the exact upstream crash in our WebView stack — `Invalid offset - splits unicode bytes` at `strPosToUni → makeInvertible → invertWithDoc` (the history-inversion path upstream #4892 reports) — and fails; restored, it passes.

## Notes

- Upstream PR is still open; if upstream review changes the final implementation we accept the divergence (Android product first).
- The snap direction (Backspace → after the pair, Delete → before it) means both keys remove the whole emoji the caret was inside, matching upstream and the platform convention.