### PR TITLE
Port upstream 4942: drive the token walk with a linear walker

### DIFF
--- a/third_party/muya/src/utils/marked/__tests__/walkTokensLinear.spec.ts
+++ b/third_party/muya/src/utils/marked/__tests__/walkTokensLinear.spec.ts
@@ -1,0 +1,65 @@
+import { Marked } from 'marked';
+import { describe, expect, it } from 'vitest';
+import { lexBlock } from '../lexBlock';
+
+// lexBlock walks tokens with a local linear driver instead of
+// `Marked.walkTokens`, whose per-token result concat is O(tokens²)
+// (marktext#4887). The drivers must keep visiting the same tokens.
+
+const NESTED = [
+    '# Heading with **bold**',
+    '',
+    '> quote with a [link](https://example.com)',
+    '',
+    '- item one\n- item two\n  - nested `code`',
+    '',
+    '| a | b |\n| - | - |\n| **c** | d |',
+    '',
+    'Paragraph with *em* text.',
+].join('\n');
+
+function visitedTypes(markdown: string): string[] {
+    const seen: string[] = [];
+    const m = new Marked();
+    const tokens = new m.Lexer(m.defaults).blockTokens(markdown);
+    m.walkTokens(tokens, token => void seen.push(token.type));
+    return seen.sort();
+}
+
+describe('lexBlock token walk', () => {
+    it('visits the same token set as Marked.walkTokens', () => {
+        const seen: string[] = [];
+        // lexBlock runs its walker internally; re-walk its output with the
+        // reference driver to compare coverage on identical token trees.
+        const tokens = lexBlock(NESTED, {
+            footnote: false,
+            isGitlabCompatibilityEnabled: true,
+            frontMatter: false,
+            math: false,
+        });
+        const m = new Marked();
+        m.walkTokens(tokens as never, token => void seen.push(token.type));
+
+        expect(seen.sort()).toEqual(visitedTypes(NESTED));
+        expect(seen).toContain('table');
+        expect(seen).toContain('list_item');
+    });
+
+    it('applies muya token augmentation to nested tokens', () => {
+        const tokens = lexBlock(
+            '> # quoted heading\n\n- item\n\n  ```js\n  x\n  ```\n',
+            {
+                footnote: false,
+                isGitlabCompatibilityEnabled: true,
+                frontMatter: false,
+                math: false,
+            },
+        );
+        const json = JSON.stringify(tokens);
+        // Both augmentations live on tokens that are only reachable through
+        // child arrays (blockquote > heading, list item > fenced code); a
+        // walker that misses child arrays would leave them untouched.
+        expect(json).toContain('"headingStyle":"atx"');
+        expect(json).toContain('"codeBlockStyle":"fenced"');
+    });
+});

--- a/third_party/muya/src/utils/marked/lexBlock.ts
+++ b/third_party/muya/src/utils/marked/lexBlock.ts
@@ -8,6 +8,42 @@ import fm from './frontMatter';
 import { DEFAULT_OPTIONS } from './options';
 import walkTokens from './walkTokens';
 
+/**
+ * Depth-first token walk with the same visit order as `Marked.walkTokens`,
+ * minus its return-value accumulation: marked's driver `concat`s every
+ * callback result into one array, which clones that array once per token —
+ * O(tokens²) on large documents (the dominant parse cost in marktext#4887;
+ * our callbacks return nothing, so the accumulation is pure waste).
+ */
+function walkTokensLinear(
+    tokens: Token[],
+    callback: (token: Token) => void,
+): void {
+    for (const token of tokens) {
+        callback(token);
+
+        switch (token.type) {
+            case 'table': {
+                for (const cell of token.header)
+                    walkTokensLinear(cell.tokens, callback);
+                for (const row of token.rows) {
+                    for (const cell of row)
+                        walkTokensLinear(cell.tokens, callback);
+                }
+                break;
+            }
+            case 'list': {
+                walkTokensLinear(token.items, callback);
+                break;
+            }
+            default: {
+                if ('tokens' in token && token.tokens)
+                    walkTokensLinear(token.tokens, callback);
+            }
+        }
+    }
+}
+
 export function lexBlock(
     src: string,
     options: ILexOption = DEFAULT_OPTIONS,
@@ -46,7 +82,7 @@ export function lexBlock(
     // are picked up; the no-arg constructor would fall back to global defaults.
     tokens.push(...new m.Lexer(m.defaults).blockTokens(src));
     tokens = compatibleTaskList(tokens as Token[]);
-    m.walkTokens(tokens as Token[], walkTokens(options));
+    walkTokensLinear(tokens as Token[], walkTokens(options));
 
     // After walkTokens / compatibleTaskList run, marked's Heading/List/ListItem
     // tokens have been augmented with muya-specific fields (headingStyle,


### PR DESCRIPTION
Ports the remaining piece of upstream [marktext#4942](https://github.com/marktext/marktext/pull/4942) (the algorithmic half of the marktext#4887 large-file freeze fix).

## Why only this piece

The vendored Muya already carries the rest of #4942 from the earlier large-file investigation: `cloneStateTree` (schema-specific clone replacing `structuredClone`), the revision-keyed reference-definition cache in `InlineRenderer`, and a `json-change` payload with no eager `doc` clone at all (more aggressive than upstream's lazy getter — nothing in this app reads it). The one piece still missing was the token-walk driver, and it is the dominant remaining parse cost.

## What changes

`lexBlock` drove muya's token augmentation through `Marked.walkTokens`, whose driver `concat`s every callback result into one accumulator array — cloning that array once per token, O(tokens²) on large documents. Our callbacks return nothing, so the accumulation is pure waste. A local depth-first walker with the same visit order (tables' header/row cells, list items, generic child `tokens`) replaces it.

This is the same hotspot the on-device profile pointed at (~19.7 s inside `walkTokens` for a ~2 MB document on Android).

Timing on the same synthetic shape used upstream (Node, this machine; on-device is strictly slower):

| document | `Marked.walkTokens` alone | full `lexBlock` with the linear walker |
|---:|---:|---:|
| 835 KB (8k sections: heading + paragraph + list) | 18.9 s | **0.117 s** |

## Verification

- New `walkTokensLinear.spec.ts` (ported from upstream): identical visit coverage vs `Marked.walkTokens` on nested constructs (table cells, nested lists, blockquote children), and augmentation (`headingStyle`, `codeBlockStyle`) reaching tokens only visible through child arrays.
- Muya app-gate suite: **1445/1445**.
- Root unit tests (incl. the vendor-sync contract): **577/577**; `node_modules/@muyajs/core` resynced.
- `pnpm typecheck`, `pnpm lint` (tracked code), `pnpm build` all clean.
