### PR TITLE
Import non-persistable incoming documents as local drafts

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -203,6 +203,7 @@ const SHARE_TEMPORARY_ACCESS_MESSAGE =
 const RENAME_TEMPORARY_ACCESS_MESSAGE =
   'Renamed, but Android only kept temporary access. Reopen it from Android to add it back to Recents.'
 const SHARED_TEXT_IMPORTED_MESSAGE = 'Imported shared text as a local draft.'
+const INCOMING_FILE_IMPORTED_MESSAGE = 'Imported this file as a local draft.'
 const ANDROID_SAVE_RECOVERY_MESSAGE = 'Save failed. A local recovery draft was kept.'
 const ANDROID_EXIT_RECOVERY_MESSAGE = 'Unsaved changes were kept as a recovery draft.'
 const ANDROID_EXIT_DISCARD_MESSAGE = 'Unsaved changes were discarded.'
@@ -1270,22 +1271,15 @@ function rememberAndroidDocument(document: OpenedAndroidDocument) {
 
 async function openAndroidDocumentResult(
   document: OpenedAndroidDocument,
-  options: { source?: AndroidDocumentOpenSource; remember?: boolean } = {},
+  options: { source?: AndroidDocumentOpenSource } = {},
 ) {
   const openResult = createAndroidDocumentOpenResult(document, {
     source: options.source,
-    remember: options.remember,
-    openWithTemporaryAccessMessage: OPEN_WITH_TEMPORARY_ACCESS_MESSAGE,
-    shareTemporaryAccessMessage: SHARE_TEMPORARY_ACCESS_MESSAGE,
     logger: androidDocumentLog,
   })
 
   homeNotice.value = openResult.homeNotice
-  if (openResult.rememberDocument) {
-    rememberAndroidDocument(openResult.rememberDocument)
-  } else {
-    protectAndroidDocumentImportedImages(document)
-  }
+  rememberAndroidDocument(openResult.rememberDocument)
   promptLocalDraftSaveOnExit.value = openResult.promptLocalDraftSaveOnExit
   currentAndroidDocumentCanWrite.value = openResult.currentAndroidDocumentCanWrite
   documentState.value = openResult.documentState
@@ -1751,6 +1745,9 @@ const incomingDocuments = createIncomingDocumentOrchestration({
   promptLocalDraftSaveOnExit,
   currentAndroidDocumentCanWrite,
   sharedTextImportedMessage: SHARED_TEXT_IMPORTED_MESSAGE,
+  incomingFileImportedMessage: INCOMING_FILE_IMPORTED_MESSAGE,
+  openWithTemporaryAccessMessage: OPEN_WITH_TEMPORARY_ACCESS_MESSAGE,
+  shareTemporaryAccessMessage: SHARE_TEMPORARY_ACCESS_MESSAGE,
   hasEditor,
   openEditor,
   releaseEditorFocusAfterOpen,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1754,6 +1754,7 @@ const incomingDocuments = createIncomingDocumentOrchestration({
   closeEditorMenu,
   closeEditorToolbar,
   openAndroidDocumentResult,
+  protectIncomingDocumentImages: protectAndroidDocumentImportedImages,
   saveAndroidDocument,
   saveDraft,
   syncDocumentFromEditor,

--- a/src/features/android-documents/androidDocumentOpenWorkflow.test.ts
+++ b/src/features/android-documents/androidDocumentOpenWorkflow.test.ts
@@ -176,10 +176,65 @@ describe('androidDocumentOpenWorkflow', () => {
     )
 
     expect(result).toMatchObject({
+      localDraft: null,
       homeNotice: 'Opened temporarily from Android',
       promptLocalDraftSaveOnExit: true,
       statusAfterOpen: 'Opened temporarily',
     })
+  })
+
+  it('never reuses a stored draft while local drafts are disabled', () => {
+    // Stored drafts stay loaded when persistence is off; reusing one's id
+    // would let this session's Discard delete it from storage.
+    const existingDraft = {
+      id: 'draft-incoming',
+      markdown: '# Incoming\n\nfrom another app',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+      lastSavedAt: '2026-07-01T00:00:00.000Z',
+      displayName: 'Incoming.md',
+    }
+
+    const result = createImportedIncomingDocumentOpenResult(
+      {
+        sourceUri: 'content://provider/incoming.md',
+        displayName: 'Incoming.md',
+        markdown: '# Incoming\n\nfrom another app',
+      },
+      {
+        existingDrafts: [existingDraft],
+        canPersistLocalDrafts: false,
+        incomingFileImportedMessage: 'Imported this file as a local draft.',
+        temporaryAccessMessage: 'Opened temporarily from Android',
+      },
+    )
+
+    expect(result.documentState.id).not.toBe('draft-incoming')
+    expect(result.localDraft).toBeNull()
+  })
+
+  it('opens an empty incoming file as a named session without claiming an import', () => {
+    const result = createImportedIncomingDocumentOpenResult(
+      {
+        sourceUri: 'content://provider/empty.md',
+        displayName: 'Empty.md',
+        markdown: '   \n\n  ',
+      },
+      {
+        existingDrafts: [],
+        canPersistLocalDrafts: true,
+        incomingFileImportedMessage: 'Imported this file as a local draft.',
+        temporaryAccessMessage: 'open-with temporary',
+      },
+    )
+
+    // Empty drafts are dropped by the store, so nothing durable exists yet;
+    // the session keeps the name and becomes durable once content is typed.
+    expect(result.localDraft).toBeNull()
+    expect(result.statusAfterOpen).toBe('Ready')
+    expect(result.homeNotice).toBeNull()
+    expect(result.documentState.displayName).toBe('Empty.md')
+    expect(result.documentState.autosaveTarget).toBe('local-draft')
   })
 
   it('creates a local draft session result for shared text', () => {

--- a/src/features/android-documents/androidDocumentOpenWorkflow.test.ts
+++ b/src/features/android-documents/androidDocumentOpenWorkflow.test.ts
@@ -4,6 +4,7 @@ import {
   createAndroidDocumentOpenResult,
   createAndroidOpenWithDocumentEventAction,
   createAndroidShareDocumentEventAction,
+  createImportedIncomingDocumentOpenResult,
   createSharedTextDocumentOpenResult,
   getIncomingDocumentPreservationAction,
   openAndroidMarkdownDocumentWorkflow,
@@ -39,8 +40,6 @@ describe('androidDocumentOpenWorkflow', () => {
   it('creates an opened Android document session result for durable documents', () => {
     const result = createAndroidDocumentOpenResult(openedDocument, {
       source: 'picker',
-      openWithTemporaryAccessMessage: 'open-with temporary',
-      shareTemporaryAccessMessage: 'share temporary',
     })
 
     expect(result).toMatchObject({
@@ -59,24 +58,126 @@ describe('androidDocumentOpenWorkflow', () => {
     })
   })
 
-  it('marks temporary open-with documents as non-recent and opened temporarily', () => {
-    const temporaryDocument = {
-      ...openedDocument,
-      persisted: false,
-      canWrite: false,
+  it('imports a non-persistable incoming document as a named local draft', () => {
+    const result = createImportedIncomingDocumentOpenResult(
+      {
+        sourceUri: 'content://provider/incoming.md',
+        displayName: 'Incoming.md',
+        markdown: '# Incoming\r\n\r\nfrom another app',
+      },
+      {
+        existingDrafts: [],
+        canPersistLocalDrafts: true,
+        incomingFileImportedMessage: 'Imported this file as a local draft.',
+        temporaryAccessMessage: 'open-with temporary',
+        now: () => '2026-07-02T00:00:00.000Z',
+      },
+    )
+
+    expect(result).toMatchObject({
+      markdown: '# Incoming\n\nfrom another app',
+      homeNotice: null,
+      promptLocalDraftSaveOnExit: true,
+      currentAndroidDocumentCanWrite: false,
+      statusAfterOpen: 'Imported this file as a local draft.',
+      documentState: {
+        autosaveTarget: 'local-draft',
+        displayName: 'Incoming.md',
+        sourceUri: null,
+        updatedAt: '2026-07-02T00:00:00.000Z',
+      },
+    })
+    expect(result.localDraft).toEqual({
+      id: result.documentState.id,
+      markdown: '# Incoming\n\nfrom another app',
+      createdAt: '2026-07-02T00:00:00.000Z',
+      updatedAt: '2026-07-02T00:00:00.000Z',
+      lastSavedAt: '2026-07-02T00:00:00.000Z',
+      displayName: 'Incoming.md',
+    })
+  })
+
+  it('reuses the existing draft when the same unchanged file is opened again', () => {
+    const existingDraft = {
+      id: 'draft-incoming',
+      markdown: '# Incoming\n\nfrom another app',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+      lastSavedAt: '2026-07-01T00:00:00.000Z',
+      displayName: 'Incoming.md',
     }
 
-    const result = createAndroidDocumentOpenResult(temporaryDocument, {
-      source: 'open-with',
-      remember: false,
-      openWithTemporaryAccessMessage: 'Opened temporarily from Android',
-      shareTemporaryAccessMessage: 'share temporary',
+    const result = createImportedIncomingDocumentOpenResult(
+      {
+        sourceUri: 'content://provider/incoming.md',
+        displayName: 'Incoming.md',
+        markdown: '# Incoming\r\n\r\nfrom another app',
+      },
+      {
+        existingDrafts: [existingDraft],
+        canPersistLocalDrafts: true,
+        incomingFileImportedMessage: 'Imported this file as a local draft.',
+        temporaryAccessMessage: 'open-with temporary',
+        now: () => '2026-07-02T00:00:00.000Z',
+      },
+    )
+
+    expect(result.documentState.id).toBe('draft-incoming')
+    expect(result.localDraft).toMatchObject({
+      id: 'draft-incoming',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-02T00:00:00.000Z',
+      displayName: 'Incoming.md',
     })
+  })
+
+  it('imports a changed file with the same name as a new draft', () => {
+    const existingDraft = {
+      id: 'draft-incoming',
+      markdown: '# Incoming\n\nedited inside the app',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+      lastSavedAt: '2026-07-01T00:00:00.000Z',
+      displayName: 'Incoming.md',
+    }
+
+    const result = createImportedIncomingDocumentOpenResult(
+      {
+        sourceUri: 'content://provider/incoming.md',
+        displayName: 'Incoming.md',
+        markdown: '# Incoming\n\nfrom another app',
+      },
+      {
+        existingDrafts: [existingDraft],
+        canPersistLocalDrafts: true,
+        incomingFileImportedMessage: 'Imported this file as a local draft.',
+        temporaryAccessMessage: 'open-with temporary',
+        now: () => '2026-07-02T00:00:00.000Z',
+      },
+    )
+
+    expect(result.documentState.id).not.toBe('draft-incoming')
+    expect(result.localDraft.markdown).toBe('# Incoming\n\nfrom another app')
+  })
+
+  it('keeps the temporary-access messaging when local drafts are disabled', () => {
+    const result = createImportedIncomingDocumentOpenResult(
+      {
+        sourceUri: 'content://provider/incoming.md',
+        displayName: 'Incoming.md',
+        markdown: '# Incoming\n\nfrom another app',
+      },
+      {
+        existingDrafts: [],
+        canPersistLocalDrafts: false,
+        incomingFileImportedMessage: 'Imported this file as a local draft.',
+        temporaryAccessMessage: 'Opened temporarily from Android',
+      },
+    )
 
     expect(result).toMatchObject({
       homeNotice: 'Opened temporarily from Android',
-      rememberDocument: null,
-      currentAndroidDocumentCanWrite: false,
+      promptLocalDraftSaveOnExit: true,
       statusAfterOpen: 'Opened temporarily',
     })
   })

--- a/src/features/android-documents/androidDocumentOpenWorkflow.test.ts
+++ b/src/features/android-documents/androidDocumentOpenWorkflow.test.ts
@@ -157,7 +157,7 @@ describe('androidDocumentOpenWorkflow', () => {
     )
 
     expect(result.documentState.id).not.toBe('draft-incoming')
-    expect(result.localDraft.markdown).toBe('# Incoming\n\nfrom another app')
+    expect(result.localDraft?.markdown).toBe('# Incoming\n\nfrom another app')
   })
 
   it('keeps the temporary-access messaging when local drafts are disabled', () => {

--- a/src/features/android-documents/androidDocumentOpenWorkflow.ts
+++ b/src/features/android-documents/androidDocumentOpenWorkflow.ts
@@ -58,7 +58,8 @@ export interface CreatedAndroidDocumentOpenResult {
 export interface CreatedImportedIncomingDocumentOpenResult {
   markdown: string
   documentState: ReturnType<typeof createUntitledDocument>
-  localDraft: LocalDraftRecord
+  /** Null when the file has no content: empty drafts are never persisted. */
+  localDraft: LocalDraftRecord | null
   homeNotice: string | null
   promptLocalDraftSaveOnExit: true
   currentAndroidDocumentCanWrite: false
@@ -173,6 +174,13 @@ export function createAndroidDocumentOpenResult(
  * reuses the existing draft (matched by name plus normalized content) instead
  * of multiplying copies; a changed file becomes a new draft so neither
  * version is silently lost.
+ *
+ * Two cases never claim an import: with local drafts disabled the session
+ * gets a fresh id (stored drafts stay loaded in memory, and reusing one
+ * would let this session's Discard delete it) and keeps the temporary-access
+ * messaging; an empty file has nothing the draft store would retain (empty
+ * drafts are dropped by design), so it opens as a plain named session that
+ * only becomes durable once content exists.
  */
 export function createImportedIncomingDocumentOpenResult(
   document: Pick<OpenedAndroidDocument, 'sourceUri' | 'displayName' | 'markdown'>,
@@ -192,17 +200,26 @@ export function createImportedIncomingDocumentOpenResult(
     autosaveTarget: 'local-draft',
     now: openedAt,
   })
+  const hasContent = importedDocument.markdown.trim().length > 0
+  const willPersistDraft = canPersistLocalDrafts && hasContent
 
-  const existingDraft = existingDrafts.find(
-    draft =>
-      draft.displayName === document.displayName &&
-      draft.markdown === importedDocument.markdown,
-  )
+  const existingDraft = willPersistDraft
+    ? existingDrafts.find(
+        draft =>
+          draft.displayName === document.displayName &&
+          draft.markdown === importedDocument.markdown,
+      )
+    : undefined
   const documentState = existingDraft
     ? createDocumentStateFromLocalDraft({ ...existingDraft, updatedAt: openedAt })
     : importedDocument
 
-  if (canPersistLocalDrafts) {
+  if (!canPersistLocalDrafts) {
+    logger?.warn('opened incoming Android document without durable retention', {
+      displayName: document.displayName,
+      sourceUri: document.sourceUri,
+    })
+  } else if (hasContent) {
     logger?.info('imported incoming Android document as a local draft', {
       displayName: document.displayName,
       sourceUri: document.sourceUri,
@@ -210,7 +227,7 @@ export function createImportedIncomingDocumentOpenResult(
       characters: document.markdown.length,
     })
   } else {
-    logger?.warn('opened incoming Android document without durable retention', {
+    logger?.info('opened empty incoming Android document without a draft entry', {
       displayName: document.displayName,
       sourceUri: document.sourceUri,
     })
@@ -219,18 +236,24 @@ export function createImportedIncomingDocumentOpenResult(
   return {
     markdown: documentState.markdown,
     documentState,
-    localDraft: {
-      id: documentState.id,
-      markdown: documentState.markdown,
-      createdAt: documentState.createdAt,
-      updatedAt: openedAt,
-      lastSavedAt: documentState.lastSavedAt,
-      displayName: document.displayName,
-    },
+    localDraft: willPersistDraft
+      ? {
+          id: documentState.id,
+          markdown: documentState.markdown,
+          createdAt: documentState.createdAt,
+          updatedAt: openedAt,
+          lastSavedAt: documentState.lastSavedAt,
+          displayName: document.displayName,
+        }
+      : null,
     homeNotice: canPersistLocalDrafts ? null : temporaryAccessMessage,
     promptLocalDraftSaveOnExit: true,
     currentAndroidDocumentCanWrite: false,
-    statusAfterOpen: canPersistLocalDrafts ? incomingFileImportedMessage : 'Opened temporarily',
+    statusAfterOpen: !canPersistLocalDrafts
+      ? 'Opened temporarily'
+      : hasContent
+        ? incomingFileImportedMessage
+        : 'Ready',
   }
 }
 

--- a/src/features/android-documents/androidDocumentOpenWorkflow.ts
+++ b/src/features/android-documents/androidDocumentOpenWorkflow.ts
@@ -1,5 +1,8 @@
 import { createUntitledDocument, type AutosaveTarget } from '../../lib/documentState'
-import { createDocumentStateFromAndroidDocument } from '../document-session/documentSessionState'
+import {
+  createDocumentStateFromAndroidDocument,
+  createDocumentStateFromLocalDraft,
+} from '../document-session/documentSessionState'
 import type {
   AndroidOpenWithDocumentEvent,
   AndroidShareDocumentEvent,
@@ -24,9 +27,6 @@ interface WorkflowLogger {
 
 interface CreateAndroidDocumentOpenResultOptions {
   source?: AndroidDocumentOpenSource
-  remember?: boolean
-  openWithTemporaryAccessMessage: string
-  shareTemporaryAccessMessage: string
   logger?: WorkflowLogger
 }
 
@@ -36,14 +36,33 @@ interface CreateSharedTextDocumentOpenResultOptions {
   logger?: WorkflowLogger
 }
 
+interface CreateImportedIncomingDocumentOpenResultOptions {
+  existingDrafts: LocalDraftRecord[]
+  canPersistLocalDrafts: boolean
+  incomingFileImportedMessage: string
+  temporaryAccessMessage: string
+  now?: () => string
+  logger?: WorkflowLogger
+}
+
 export interface CreatedAndroidDocumentOpenResult {
   markdown: string
   documentState: ReturnType<typeof createDocumentStateFromAndroidDocument>
-  homeNotice: string | null
-  rememberDocument: OpenedAndroidDocument | null
+  homeNotice: null
+  rememberDocument: OpenedAndroidDocument
   promptLocalDraftSaveOnExit: false
   currentAndroidDocumentCanWrite: boolean
-  statusAfterOpen: 'Opened temporarily' | 'Read only' | 'Saved'
+  statusAfterOpen: 'Read only' | 'Saved'
+}
+
+export interface CreatedImportedIncomingDocumentOpenResult {
+  markdown: string
+  documentState: ReturnType<typeof createUntitledDocument>
+  localDraft: LocalDraftRecord
+  homeNotice: string | null
+  promptLocalDraftSaveOnExit: true
+  currentAndroidDocumentCanWrite: false
+  statusAfterOpen: string
 }
 
 export interface CreatedSharedTextDocumentOpenResult {
@@ -123,31 +142,8 @@ interface IncomingDocumentPreservationActionOptions {
 
 export function createAndroidDocumentOpenResult(
   document: OpenedAndroidDocument,
-  {
-    source = 'picker',
-    remember = true,
-    openWithTemporaryAccessMessage,
-    shareTemporaryAccessMessage,
-    logger,
-  }: CreateAndroidDocumentOpenResultOptions,
+  { source = 'picker', logger }: CreateAndroidDocumentOpenResultOptions = {},
 ): CreatedAndroidDocumentOpenResult {
-  const temporaryAccessMessage =
-    source === 'open-with'
-      ? openWithTemporaryAccessMessage
-      : source === 'share'
-        ? shareTemporaryAccessMessage
-        : null
-  const openedTemporarily = Boolean(temporaryAccessMessage && !document.persisted)
-  const shouldRemember = remember
-
-  if (!shouldRemember) {
-    logger?.warn('opened Android document without durable recent access', {
-      displayName: document.displayName,
-      sourceUri: document.sourceUri,
-      source,
-    })
-  }
-
   logger?.info('open Android document in editor', {
     displayName: document.displayName,
     sourceUri: document.sourceUri,
@@ -160,11 +156,81 @@ export function createAndroidDocumentOpenResult(
   return {
     markdown: document.markdown,
     documentState: createDocumentStateFromAndroidDocument(document),
-    homeNotice: openedTemporarily ? temporaryAccessMessage : null,
-    rememberDocument: shouldRemember ? document : null,
+    homeNotice: null,
+    rememberDocument: document,
     promptLocalDraftSaveOnExit: false,
     currentAndroidDocumentCanWrite: document.canWrite,
-    statusAfterOpen: openedTemporarily ? 'Opened temporarily' : document.canWrite ? 'Saved' : 'Read only',
+    statusAfterOpen: document.canWrite ? 'Saved' : 'Read only',
+  }
+}
+
+/**
+ * A non-persistable incoming document (open-with or shared file) arrives on a
+ * one-shot Android grant: the URI dies with the task and can never be
+ * reopened. The only durable record is the content itself, so it is imported
+ * as a named local draft — that is what puts the document in the history and
+ * keeps edits safe after the app exits. Reopening the same unchanged file
+ * reuses the existing draft (matched by name plus normalized content) instead
+ * of multiplying copies; a changed file becomes a new draft so neither
+ * version is silently lost.
+ */
+export function createImportedIncomingDocumentOpenResult(
+  document: Pick<OpenedAndroidDocument, 'sourceUri' | 'displayName' | 'markdown'>,
+  {
+    existingDrafts,
+    canPersistLocalDrafts,
+    incomingFileImportedMessage,
+    temporaryAccessMessage,
+    now = () => new Date().toISOString(),
+    logger,
+  }: CreateImportedIncomingDocumentOpenResultOptions,
+): CreatedImportedIncomingDocumentOpenResult {
+  const openedAt = now()
+  const importedDocument = createUntitledDocument({
+    markdown: document.markdown,
+    displayName: document.displayName,
+    autosaveTarget: 'local-draft',
+    now: openedAt,
+  })
+
+  const existingDraft = existingDrafts.find(
+    draft =>
+      draft.displayName === document.displayName &&
+      draft.markdown === importedDocument.markdown,
+  )
+  const documentState = existingDraft
+    ? createDocumentStateFromLocalDraft({ ...existingDraft, updatedAt: openedAt })
+    : importedDocument
+
+  if (canPersistLocalDrafts) {
+    logger?.info('imported incoming Android document as a local draft', {
+      displayName: document.displayName,
+      sourceUri: document.sourceUri,
+      reusedDraft: Boolean(existingDraft),
+      characters: document.markdown.length,
+    })
+  } else {
+    logger?.warn('opened incoming Android document without durable retention', {
+      displayName: document.displayName,
+      sourceUri: document.sourceUri,
+    })
+  }
+
+  return {
+    markdown: documentState.markdown,
+    documentState,
+    localDraft: {
+      id: documentState.id,
+      markdown: documentState.markdown,
+      createdAt: documentState.createdAt,
+      updatedAt: openedAt,
+      lastSavedAt: documentState.lastSavedAt,
+      displayName: document.displayName,
+    },
+    homeNotice: canPersistLocalDrafts ? null : temporaryAccessMessage,
+    promptLocalDraftSaveOnExit: true,
+    currentAndroidDocumentCanWrite: false,
+    statusAfterOpen: canPersistLocalDrafts ? incomingFileImportedMessage : 'Opened temporarily',
   }
 }
 

--- a/src/features/android-documents/incomingDocumentOrchestration.test.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.test.ts
@@ -46,6 +46,7 @@ function createOrchestration(overrides: {
   draftSaved?: boolean
   recoveryKept?: boolean
   canPersistDrafts?: boolean
+  localDrafts?: LocalDraftRecord[]
 } = {}) {
   const options = {
     currentScreen: ref<AppScreen>(overrides.currentScreen ?? 'home'),
@@ -53,7 +54,7 @@ function createOrchestration(overrides: {
       overrides.documentState
       ?? createUntitledDocument({ markdown: '', autosaveTarget: 'local-draft' }),
     ),
-    localDrafts: ref<LocalDraftRecord[]>([]),
+    localDrafts: ref<LocalDraftRecord[]>(overrides.localDrafts ?? []),
     homeNotice: ref<string | null>(null),
     status: ref('Ready'),
     draftExitPromptOpen: ref(true),
@@ -70,6 +71,7 @@ function createOrchestration(overrides: {
     closeEditorMenu: vi.fn(),
     closeEditorToolbar: vi.fn(),
     openAndroidDocumentResult: vi.fn().mockResolvedValue(undefined),
+    protectIncomingDocumentImages: vi.fn(),
     saveAndroidDocument: vi.fn().mockResolvedValue(overrides.saveResult ?? true),
     saveDraft: vi.fn(() => overrides.draftSaved ?? true),
     syncDocumentFromEditor: vi.fn(),
@@ -448,6 +450,65 @@ describe('incomingDocumentOrchestration', () => {
     expect(options.openEditor).toHaveBeenCalledWith('# Incoming')
     expect(options.homeNotice.value).toBe('open-with temporary access')
     expect(options.status.value).toBe('Opened temporarily')
+  })
+
+  it('never adopts a stored draft id while local drafts are disabled', async () => {
+    // Stored drafts stay loaded in memory when persistence is off; adopting
+    // one's id would let this session's Discard delete it from storage.
+    const storedDraft = {
+      id: 'stored-draft',
+      markdown: '# Incoming',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+      lastSavedAt: '2026-07-01T00:00:00.000Z',
+      displayName: 'incoming.md',
+    }
+    const { orchestration, options } = createOrchestration({
+      canPersistDrafts: false,
+      localDrafts: [storedDraft],
+    })
+    const temporaryDocument = { ...incomingDocument, persisted: false, canWrite: false }
+
+    await orchestration.handleOpenWithDocumentEvent({ document: temporaryDocument, error: null })
+
+    expect(options.documentState.value.id).not.toBe('stored-draft')
+    expect(options.persistLocalDrafts).not.toHaveBeenCalled()
+  })
+
+  it('protects imported images referenced by non-persistable incoming documents', async () => {
+    const { orchestration, options } = createOrchestration()
+    const temporaryDocument = { ...incomingDocument, persisted: false, canWrite: false }
+
+    await orchestration.handleOpenWithDocumentEvent({ document: temporaryDocument, error: null })
+    expect(options.protectIncomingDocumentImages).toHaveBeenCalledWith(temporaryDocument)
+
+    await orchestration.handleShareDocumentEvent({
+      document: {
+        ...sharedTextDocument,
+        sourceUri: 'content://test/shared.md',
+        displayName: 'Shared Stream.md',
+        shareKind: 'stream',
+      },
+      error: null,
+    })
+    expect(options.protectIncomingDocumentImages).toHaveBeenCalledTimes(2)
+  })
+
+  it('opens an empty incoming file without persisting or claiming an import', async () => {
+    const { orchestration, options } = createOrchestration()
+    const emptyDocument = {
+      ...incomingDocument,
+      persisted: false,
+      canWrite: false,
+      markdown: '   \n\n',
+    }
+
+    await orchestration.handleOpenWithDocumentEvent({ document: emptyDocument, error: null })
+
+    expect(options.persistLocalDrafts).not.toHaveBeenCalled()
+    expect(options.status.value).toBe('Ready')
+    expect(options.documentState.value.displayName).toBe('incoming.md')
+    expect(options.openEditor).toHaveBeenCalled()
   })
 
   it('imports shared text as a local draft and opens it', async () => {

--- a/src/features/android-documents/incomingDocumentOrchestration.test.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.test.ts
@@ -61,6 +61,9 @@ function createOrchestration(overrides: {
     promptLocalDraftSaveOnExit: ref(false),
     currentAndroidDocumentCanWrite: ref(true),
     sharedTextImportedMessage: 'Imported shared text as a local draft.',
+    incomingFileImportedMessage: 'Imported this file as a local draft.',
+    openWithTemporaryAccessMessage: 'open-with temporary access',
+    shareTemporaryAccessMessage: 'share temporary access',
     hasEditor: () => overrides.hasEditor ?? false,
     openEditor: vi.fn().mockResolvedValue(undefined),
     releaseEditorFocusAfterOpen: vi.fn(),
@@ -111,7 +114,6 @@ describe('incomingDocumentOrchestration', () => {
     expect(options.closeEditorToolbar).toHaveBeenCalled()
     expect(options.openAndroidDocumentResult).toHaveBeenCalledWith(incomingDocument, {
       source: 'open-with',
-      remember: true,
     })
   })
 
@@ -259,7 +261,6 @@ describe('incomingDocumentOrchestration', () => {
     expect(options.closeEditorMenu).toHaveBeenCalled()
     expect(options.openAndroidDocumentResult).toHaveBeenCalledWith(incomingDocument, {
       source: 'open-with',
-      remember: true,
     })
   })
 
@@ -369,22 +370,84 @@ describe('incomingDocumentOrchestration', () => {
     expect(options.openAndroidDocumentResult).toHaveBeenCalledTimes(2)
     expect(options.openAndroidDocumentResult).toHaveBeenLastCalledWith(secondDocument, {
       source: 'open-with',
-      remember: true,
     })
   })
 
-  it('routes a shared Markdown file through the shared open path', async () => {
+  it('opens a persisted shared Markdown file through the durable open path', async () => {
     const { orchestration, options } = createOrchestration()
 
     await orchestration.handleShareDocumentEvent({
-      document: { ...sharedTextDocument, sourceUri: 'content://test/shared.md', shareKind: 'stream' },
+      document: {
+        ...sharedTextDocument,
+        sourceUri: 'content://test/shared.md',
+        shareKind: 'stream',
+        persisted: true,
+      },
       error: null,
     })
 
     expect(options.openAndroidDocumentResult).toHaveBeenCalledWith(
       expect.objectContaining({ sourceUri: 'content://test/shared.md' }),
-      { source: 'share', remember: false },
+      { source: 'share' },
     )
+    expect(options.persistLocalDrafts).not.toHaveBeenCalled()
+  })
+
+  it('imports a non-persistable shared Markdown file as a named local draft', async () => {
+    const { orchestration, options } = createOrchestration()
+
+    await orchestration.handleShareDocumentEvent({
+      document: {
+        ...sharedTextDocument,
+        sourceUri: 'content://test/shared.md',
+        displayName: 'Shared Stream.md',
+        shareKind: 'stream',
+      },
+      error: null,
+    })
+
+    expect(options.openAndroidDocumentResult).not.toHaveBeenCalled()
+    expect(options.persistLocalDrafts).toHaveBeenCalledTimes(1)
+    const [drafts] = options.persistLocalDrafts.mock.calls[0]
+    expect(drafts[0]).toMatchObject({
+      markdown: '# Shared note',
+      displayName: 'Shared Stream.md',
+    })
+    expect(options.documentState.value.autosaveTarget).toBe('local-draft')
+    expect(options.promptLocalDraftSaveOnExit.value).toBe(true)
+    expect(options.openEditor).toHaveBeenCalledWith('# Shared note')
+    expect(options.status.value).toBe('Imported this file as a local draft.')
+  })
+
+  it('imports a non-persistable open-with document as a named local draft', async () => {
+    const { orchestration, options } = createOrchestration({ currentScreen: 'home' })
+    const temporaryDocument = { ...incomingDocument, persisted: false, canWrite: false }
+
+    await orchestration.handleOpenWithDocumentEvent({ document: temporaryDocument, error: null })
+
+    expect(options.openAndroidDocumentResult).not.toHaveBeenCalled()
+    expect(options.persistLocalDrafts).toHaveBeenCalledTimes(1)
+    const [drafts] = options.persistLocalDrafts.mock.calls[0]
+    expect(drafts[0]).toMatchObject({
+      markdown: '# Incoming',
+      displayName: 'incoming.md',
+    })
+    expect(options.currentAndroidDocumentCanWrite.value).toBe(false)
+    expect(options.openEditor).toHaveBeenCalledWith('# Incoming')
+    expect(options.status.value).toBe('Imported this file as a local draft.')
+    expect(options.releaseEditorFocusAfterOpen).toHaveBeenCalled()
+  })
+
+  it('keeps the temporary-access notice for open-with when local drafts are disabled', async () => {
+    const { orchestration, options } = createOrchestration({ canPersistDrafts: false })
+    const temporaryDocument = { ...incomingDocument, persisted: false, canWrite: false }
+
+    await orchestration.handleOpenWithDocumentEvent({ document: temporaryDocument, error: null })
+
+    expect(options.persistLocalDrafts).not.toHaveBeenCalled()
+    expect(options.openEditor).toHaveBeenCalledWith('# Incoming')
+    expect(options.homeNotice.value).toBe('open-with temporary access')
+    expect(options.status.value).toBe('Opened temporarily')
   })
 
   it('imports shared text as a local draft and opens it', async () => {

--- a/src/features/android-documents/incomingDocumentOrchestration.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.ts
@@ -68,6 +68,11 @@ export interface IncomingDocumentOrchestrationOptions {
     document: OpenedAndroidDocument,
     options?: { source?: AndroidDocumentOpenSource },
   ) => Promise<void>
+  // Marks imported images referenced by the incoming Markdown as protected
+  // from cleanup: the external file keeps referencing them even after the
+  // imported draft is deleted, so the protection registry — not the draft —
+  // is what keeps them alive.
+  protectIncomingDocumentImages: (document: OpenedAndroidDocument) => void
   saveAndroidDocument: (options?: SaveAndroidDocumentOptions) => Promise<boolean>
   saveDraft: () => boolean
   syncDocumentFromEditor: (markDirty: boolean, flushPending: boolean) => void
@@ -137,7 +142,8 @@ export function createIncomingDocumentOrchestration(
       logger: options.documentLogger,
     })
 
-    if (options.canPersistLocalDrafts()) {
+    options.protectIncomingDocumentImages(document)
+    if (openResult.localDraft && options.canPersistLocalDrafts()) {
       options.persistLocalDrafts(upsertLocalDraft(options.localDrafts.value, openResult.localDraft))
     }
     options.homeNotice.value = openResult.homeNotice

--- a/src/features/android-documents/incomingDocumentOrchestration.ts
+++ b/src/features/android-documents/incomingDocumentOrchestration.ts
@@ -6,6 +6,7 @@ import {
 import {
   createAndroidOpenWithDocumentEventAction,
   createAndroidShareDocumentEventAction,
+  createImportedIncomingDocumentOpenResult,
   createSharedTextDocumentOpenResult,
   getIncomingDocumentPreservationAction,
   shouldKeepAndroidRecoveryAfterPreserveFailure,
@@ -54,6 +55,9 @@ export interface IncomingDocumentOrchestrationOptions {
   promptLocalDraftSaveOnExit: Ref<boolean>
   currentAndroidDocumentCanWrite: Ref<boolean>
   sharedTextImportedMessage: string
+  incomingFileImportedMessage: string
+  openWithTemporaryAccessMessage: string
+  shareTemporaryAccessMessage: string
   // Collaborators that stay in App: shared open/save paths and editor chrome.
   hasEditor: () => boolean
   openEditor: (markdown: string) => Promise<void>
@@ -62,7 +66,7 @@ export interface IncomingDocumentOrchestrationOptions {
   closeEditorToolbar: () => void
   openAndroidDocumentResult: (
     document: OpenedAndroidDocument,
-    options?: { source?: AndroidDocumentOpenSource, remember?: boolean },
+    options?: { source?: AndroidDocumentOpenSource },
   ) => Promise<void>
   saveAndroidDocument: (options?: SaveAndroidDocumentOptions) => Promise<boolean>
   saveDraft: () => boolean
@@ -100,6 +104,36 @@ export function createIncomingDocumentOrchestration(
   async function openSharedTextDocument(document: SharedAndroidDocument) {
     const openResult = createSharedTextDocumentOpenResult(document, {
       sharedTextImportedMessage: options.sharedTextImportedMessage,
+      logger: options.documentLogger,
+    })
+
+    if (options.canPersistLocalDrafts()) {
+      options.persistLocalDrafts(upsertLocalDraft(options.localDrafts.value, openResult.localDraft))
+    }
+    options.homeNotice.value = openResult.homeNotice
+    options.promptLocalDraftSaveOnExit.value = openResult.promptLocalDraftSaveOnExit
+    options.currentAndroidDocumentCanWrite.value = openResult.currentAndroidDocumentCanWrite
+    options.documentState.value = openResult.documentState
+    await options.openEditor(openResult.markdown)
+    options.status.value = openResult.statusAfterOpen
+    options.releaseEditorFocusAfterOpen()
+  }
+
+  // Non-persistable incoming files land here: the one-shot grant cannot be
+  // remembered, so the content is imported as a named local draft — that is
+  // the durable history entry the URI can never be.
+  async function openImportedIncomingDocument(
+    document: OpenedAndroidDocument,
+    source: Extract<AndroidDocumentOpenSource, 'open-with' | 'share'>,
+  ) {
+    const openResult = createImportedIncomingDocumentOpenResult(document, {
+      existingDrafts: options.localDrafts.value,
+      canPersistLocalDrafts: options.canPersistLocalDrafts(),
+      incomingFileImportedMessage: options.incomingFileImportedMessage,
+      temporaryAccessMessage:
+        source === 'open-with'
+          ? options.openWithTemporaryAccessMessage
+          : options.shareTemporaryAccessMessage,
       logger: options.documentLogger,
     })
 
@@ -261,10 +295,11 @@ export function createIncomingDocumentOrchestration(
     await scheduleIncomingTransaction(() =>
       runIncomingTransaction(action.document.displayName, async () => {
         closeEditorChromeForIncomingOpen()
-        await options.openAndroidDocumentResult(action.document, {
-          source: action.source,
-          remember: action.remember,
-        })
+        if (action.remember) {
+          await options.openAndroidDocumentResult(action.document, { source: action.source })
+        } else {
+          await openImportedIncomingDocument(action.document, action.source)
+        }
       }),
     )
   }
@@ -285,10 +320,11 @@ export function createIncomingDocumentOrchestration(
       await scheduleIncomingTransaction(() =>
         runIncomingTransaction(action.document.displayName, async () => {
           closeEditorChromeForIncomingOpen()
-          await options.openAndroidDocumentResult(action.document, {
-            source: action.source,
-            remember: action.remember,
-          })
+          if (action.remember) {
+            await options.openAndroidDocumentResult(action.document, { source: action.source })
+          } else {
+            await openImportedIncomingDocument(action.document, action.source)
+          }
         }),
       )
       return

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -72,6 +72,7 @@ const KNOWN_TEXT_MESSAGE_KEYS = {
   'Opened from Android share with temporary access. Save a copy to keep editing later.':
     'app.notice.shareTemporaryAccess',
   'Imported shared text as a local draft.': 'app.notice.sharedTextImported',
+  'Imported this file as a local draft.': 'app.notice.incomingFileImported',
   'Save failed. A local recovery draft was kept.': 'app.notice.androidSaveRecovery',
   'Unsaved changes were kept as a recovery draft.': 'app.notice.androidExitRecovery',
   'Unsaved changes were discarded.': 'app.notice.androidExitDiscard',

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -70,6 +70,7 @@ export const de = {
   'app.notice.renameTemporaryAccess':
     'Umbenannt, aber Android hat nur temporären Zugriff behalten. Öffne es erneut über Android, um es wieder zu „Zuletzt verwendet“ hinzuzufügen.',
   'app.notice.sharedTextImported': 'Geteilten Text als lokalen Entwurf importiert.',
+  'app.notice.incomingFileImported': 'Diese Datei als lokalen Entwurf importiert.',
   'app.notice.androidSaveRecovery': 'Speichern fehlgeschlagen. Ein lokaler Wiederherstellungsentwurf wurde behalten.',
   'app.notice.androidExitRecovery': 'Ungespeicherte Änderungen wurden als Wiederherstellungsentwurf behalten.',
   'app.notice.androidExitDiscard': 'Ungespeicherte Änderungen wurden verworfen.',

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -67,6 +67,7 @@ export const en = {
   'app.notice.renameTemporaryAccess':
     'Renamed, but Android only kept temporary access. Reopen it from Android to add it back to Recents.',
   'app.notice.sharedTextImported': 'Imported shared text as a local draft.',
+  'app.notice.incomingFileImported': 'Imported this file as a local draft.',
   'app.notice.androidSaveRecovery': 'Save failed. A local recovery draft was kept.',
   'app.notice.androidExitRecovery': 'Unsaved changes were kept as a recovery draft.',
   'app.notice.androidExitDiscard': 'Unsaved changes were discarded.',

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -70,6 +70,7 @@ export const es = {
   'app.notice.renameTemporaryAccess':
     'Renombrado, pero Android solo mantuvo acceso temporal. Vuelve a abrirlo desde Android para añadirlo de nuevo a Recientes.',
   'app.notice.sharedTextImported': 'Se importó el texto compartido como borrador local.',
+  'app.notice.incomingFileImported': 'Se importó este archivo como borrador local.',
   'app.notice.androidSaveRecovery': 'Falló el guardado. Se conservó un borrador de recuperación local.',
   'app.notice.androidExitRecovery': 'Los cambios sin guardar se conservaron como borrador de recuperación.',
   'app.notice.androidExitDiscard': 'Se descartaron los cambios sin guardar.',

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -70,6 +70,7 @@ export const fr = {
   'app.notice.renameTemporaryAccess':
     'Renommé, mais Android n’a conservé qu’un accès temporaire. Rouvrez-le depuis Android pour le rajouter aux Documents récents.',
   'app.notice.sharedTextImported': 'Texte partagé importé comme brouillon local.',
+  'app.notice.incomingFileImported': 'Fichier importé comme brouillon local.',
   'app.notice.androidSaveRecovery': 'Échec de l’enregistrement. Un brouillon de récupération local a été conservé.',
   'app.notice.androidExitRecovery': 'Les modifications non enregistrées ont été conservées comme brouillon de récupération.',
   'app.notice.androidExitDiscard': 'Les modifications non enregistrées ont été abandonnées.',

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -70,6 +70,7 @@ export const ja = {
   'app.notice.renameTemporaryAccess':
     '名前を変更しましたが、Android は一時アクセスのみを許可しました。最近の項目に戻すには Android から開き直してください。',
   'app.notice.sharedTextImported': '共有されたテキストをローカル下書きとして取り込みました。',
+  'app.notice.incomingFileImported': 'このファイルをローカル下書きとして取り込みました。',
   'app.notice.androidSaveRecovery': '保存に失敗しました。復元用下書きをローカルに残しました。',
   'app.notice.androidExitRecovery': '未保存の変更を復元用下書きとして残しました。',
   'app.notice.androidExitDiscard': '未保存の変更を破棄しました。',

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -70,6 +70,7 @@ export const ko = {
   'app.notice.renameTemporaryAccess':
     '이름을 바꿨지만 Android가 임시 접근만 유지했습니다. 최근 문서에 다시 추가하려면 Android에서 다시 여세요.',
   'app.notice.sharedTextImported': '공유된 텍스트를 로컬 초안으로 가져왔습니다.',
+  'app.notice.incomingFileImported': '이 파일을 로컬 초안으로 가져왔습니다.',
   'app.notice.androidSaveRecovery': '저장에 실패했습니다. 로컬 복구 초안을 유지했습니다.',
   'app.notice.androidExitRecovery': '저장하지 않은 변경 사항을 복구 초안으로 유지했습니다.',
   'app.notice.androidExitDiscard': '저장하지 않은 변경 사항을 폐기했습니다.',

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -70,6 +70,7 @@ export const pt = {
   'app.notice.renameTemporaryAccess':
     'Renomeado, mas o Android manteve apenas acesso temporário. Reabra pelo Android para adicioná-lo de volta aos Recentes.',
   'app.notice.sharedTextImported': 'Texto compartilhado importado como rascunho local.',
+  'app.notice.incomingFileImported': 'Este arquivo foi importado como rascunho local.',
   'app.notice.androidSaveRecovery': 'Falha ao salvar. Um rascunho de recuperação local foi mantido.',
   'app.notice.androidExitRecovery': 'As alterações não salvas foram mantidas como rascunho de recuperação.',
   'app.notice.androidExitDiscard': 'As alterações não salvas foram descartadas.',

--- a/src/lib/locales/tr.ts
+++ b/src/lib/locales/tr.ts
@@ -70,6 +70,7 @@ export const tr = {
   'app.notice.renameTemporaryAccess':
     'Yeniden adlandırıldı, ancak Android yalnızca geçici erişim verdi. Son kullanılanlara geri eklemek için Android’den yeniden açın.',
   'app.notice.sharedTextImported': 'Paylaşılan metin yerel taslak olarak içe aktarıldı.',
+  'app.notice.incomingFileImported': 'Bu dosya yerel taslak olarak içe aktarıldı.',
   'app.notice.androidSaveRecovery': 'Kaydetme başarısız. Yerel bir kurtarma taslağı korundu.',
   'app.notice.androidExitRecovery': 'Kaydedilmemiş değişiklikler kurtarma taslağı olarak korundu.',
   'app.notice.androidExitDiscard': 'Kaydedilmemiş değişiklikler atıldı.',

--- a/src/lib/locales/zh-CN.ts
+++ b/src/lib/locales/zh-CN.ts
@@ -68,6 +68,7 @@ export const zhCN = {
   'app.notice.renameTemporaryAccess':
     '已重命名，但 Android 只授予了临时访问权限。请从 Android 重新打开，才能重新加入最近文档。',
   'app.notice.sharedTextImported': '已将分享文本导入为本地草稿。',
+  'app.notice.incomingFileImported': '已将此文件导入为本地草稿。',
   'app.notice.androidSaveRecovery': '保存失败。已保留本地恢复草稿。',
   'app.notice.androidExitRecovery': '未保存的更改已保留为恢复草稿。',
   'app.notice.androidExitDiscard': '已丢弃未保存的更改。',

--- a/src/lib/locales/zh-TW.ts
+++ b/src/lib/locales/zh-TW.ts
@@ -70,6 +70,7 @@ export const zhTW = {
   'app.notice.renameTemporaryAccess':
     '已重新命名，但 Android 僅保留暫時存取權。請從 Android 重新開啟，以將其重新加入最近文件。',
   'app.notice.sharedTextImported': '已將分享的文字匯入為本機草稿。',
+  'app.notice.incomingFileImported': '已將此檔案匯入為本機草稿。',
   'app.notice.androidSaveRecovery': '儲存失敗。已保留本機修復草稿。',
   'app.notice.androidExitRecovery': '未儲存的變更已保留為修復草稿。',
   'app.notice.androidExitDiscard': '未儲存的變更已捨棄。',

--- a/tests/e2e/mobile-android-document-lifecycle.spec.ts
+++ b/tests/e2e/mobile-android-document-lifecycle.spec.ts
@@ -177,13 +177,17 @@ test('opens a warm Android open-with document after preserving the current draft
   })
 
   await expect(page.getByTestId('editor-host')).toContainText('Open With Warm')
-  await expect(page.getByText('Opened temporarily')).toBeVisible()
+  await expect(page.getByText('Imported this file as a local draft.')).toBeVisible()
 
   const storage = await page.evaluate(() => ({
     drafts: localStorage.getItem('marktext-for-android:drafts') ?? '',
     recentDocuments: localStorage.getItem('marktext-for-android:recent-documents') ?? '',
   }))
   expect(storage.drafts).toContain('Draft Before Open With')
+  // The one-shot grant cannot be remembered, so the file itself is imported
+  // as a named local draft — that is its durable history entry.
+  expect(storage.drafts).toContain('Open With Warm.md')
+  expect(storage.drafts).toContain('opened while app was alive')
   expect(storage.recentDocuments).not.toContain('content://test/open-with-warm-transient')
 })
 
@@ -336,7 +340,7 @@ test('offers save-copy when leaving a dirty read-only Android document', async (
   expect(storage.recentDocuments).toContain('Read Only Exit copy.md')
 })
 
-test('keeps temporary open-with edits as a recovery draft when leaving', async ({ page }) => {
+test('keeps temporary open-with edits in the imported draft when leaving', async ({ page }) => {
   await installAndroidAppMock(page, undefined, {
     pendingOpenWithEvent: {
       document: {
@@ -355,24 +359,27 @@ test('keeps temporary open-with edits as a recovery draft when leaving', async (
   await page.goto('/')
 
   await expectEditorReady(page)
-  await expect(page.getByText('Opened temporarily')).toBeVisible()
+  await expect(page.getByText('Imported this file as a local draft.')).toBeVisible()
   await page.getByTestId('editor-host').click()
   await page.keyboard.press('End')
   await page.keyboard.press('Enter')
   await page.keyboard.type('temporary open-with edit')
 
+  // The session IS the imported draft, so edits are already durable; leaving
+  // offers to save a device copy instead of the Android recovery prompt.
   await page.getByTestId('back-button').click()
-  await expect(page.getByTestId('android-exit-prompt')).toBeVisible()
-  await page.getByTestId('prompt-keep-recovery-button').click()
+  await expect(page.getByTestId('prompt-keep-draft-button')).toBeVisible()
+  await page.getByTestId('prompt-keep-draft-button').click()
 
   await expect(page.getByRole('heading', { name: 'MarkText' })).toBeVisible()
-  await expect(page.getByText('Unsaved changes were kept as a recovery draft.')).toBeVisible()
+  await expect(page.getByText('Temporary Exit').first()).toBeVisible()
 
   const storage = await page.evaluate(() => ({
     drafts: localStorage.getItem('marktext-for-android:drafts') ?? '',
     recentDocuments: localStorage.getItem('marktext-for-android:recent-documents') ?? '',
   }))
-  expect(storage.drafts).toContain('android-recovery:content://test/open-with-temporary-exit')
+  expect(storage.drafts).toContain('Temporary Exit.md')
   expect(storage.drafts).toContain('temporary open-with edit')
+  expect(storage.drafts).not.toContain('android-recovery:')
   expect(storage.recentDocuments).not.toContain('content://test/open-with-temporary-exit')
 })

--- a/tests/e2e/mobile-share-intent.spec.ts
+++ b/tests/e2e/mobile-share-intent.spec.ts
@@ -193,7 +193,7 @@ test('imports shared Android text as a local draft on app launch', async ({ page
   expect(storage.recentDocuments).not.toContain('Shared From QQ')
 })
 
-test('opens a shared Markdown file with temporary Android access', async ({ page }) => {
+test('imports a shared Markdown file without durable access as a local draft', async ({ page }) => {
   await installAndroidShareAppMock(page, {
     pendingShareEvent: {
       document: {
@@ -214,12 +214,15 @@ test('opens a shared Markdown file with temporary Android access', async ({ page
 
   await expectEditorReady(page)
   await expect(page.getByTestId('editor-host')).toContainText('Shared Stream')
-  await expect(page.getByText('Opened temporarily')).toBeVisible()
+  await expect(page.getByText('Imported this file as a local draft.')).toBeVisible()
 
-  const recentDocuments = await page.evaluate(
-    () => localStorage.getItem('marktext-for-android:recent-documents') ?? '',
-  )
-  expect(recentDocuments).not.toContain('content://test/share-stream')
+  const storage = await page.evaluate(() => ({
+    drafts: localStorage.getItem('marktext-for-android:drafts') ?? '',
+    recentDocuments: localStorage.getItem('marktext-for-android:recent-documents') ?? '',
+  }))
+  expect(storage.drafts).toContain('Shared Stream.md')
+  expect(storage.drafts).toContain('received as a content URI')
+  expect(storage.recentDocuments).not.toContain('content://test/share-stream')
 })
 
 test('shares the current draft as a Markdown file through Android', async ({ page }) => {


### PR DESCRIPTION
Fixes #162.

## Problem

A Markdown file opened from another app (for example a file received in QQ) opens fine, but leaves no trace in MarkText: after leaving the app it is not on the Home screen and cannot be reopened. Same for files shared into the app as streams.

## Root cause

These intents deliver one-shot `content://` grants without `FLAG_GRANT_PERSISTABLE_URI_PERMISSION`, so the URI dies with the task. The app reacted by deliberately not recording the document (`persisted: false` → `remember: false` → `rememberDocument: null`, status "Opened temporarily"), and the storage layer additionally filters recents to `kind === 'android-document'`. "Don't remember what we can't reopen" avoided dead history entries — by silently discarding the document instead.

## Fix

The one durable record such a grant can never be is the content itself, so a non-persistable incoming file is now **imported as a named local draft at open time**, the same path shared text already uses:

- The file appears on Home immediately, survives app exit, and reopens offline through the existing draft machinery (rename, delete, share, save-to-device all work).
- Edits autosave durably into the draft instead of into a URI that dies with the task; the Android recovery-draft workaround is no longer involved in this flow.
- Reopening the same unchanged file reuses the existing draft (matched by display name plus normalized content) and bumps it to the top; a changed file becomes a new draft so neither version is lost.
- Persistable documents (in-app picker, providers granting persistable access) keep the current real-document Recents behavior.
- With the "keep local drafts" setting off, the previous temporary-access messaging is preserved unchanged.

`createAndroidDocumentOpenResult` loses its temporary-access limbo — it now only ever serves durable documents — and the orchestration routes on the `persisted` flag instead of threading `remember` through the open path. New status message "Imported this file as a local draft." is localized in all 10 locales.

## Behavior change to note

A transiently writable open-with session previously wrote edits back to the source file until the task ended (and then silently lost access). With the import model those edits stay in the app copy. Editing the original file remains the in-app picker's job, which holds a persistable grant. Flagging this explicitly for review.

## Verification

- `pnpm exec vue-tsc --noEmit`: clean.
- `pnpm test`: 75 files / 587 tests passed (includes 5 new workflow tests and 4 new orchestration tests covering import, draft reuse, changed-file fork, persisted routing, and the drafts-disabled fallback).
- `pnpm exec playwright test mobile-android-document-lifecycle mobile-share-intent`: 17 passed, including the rewritten warm open-with, temporary-exit, and shared-stream specs asserting the imported draft in storage.
- `eslint` on all changed files with `--max-warnings 0`: clean (repo-wide `pnpm lint` currently trips over the gitignored local-archive/ evidence folder, which CI's clean checkout does not have).
- `pnpm build`: passes.

Not run: on-device intent injection (emulator smoke); the mocked bridge e2e covers the event contract end to end.
