### PR TITLE
Shard and parallelize the Mobile WebView E2E job

### DIFF
--- a/.github/workflows/web-quality.yml
+++ b/.github/workflows/web-quality.yml
@@ -68,17 +68,31 @@ jobs:
         run: pnpm build
 
   e2e:
-    name: Mobile WebView E2E
+    name: Mobile WebView E2E (${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    # The suite outgrew a single serial job (it started hitting the
+    # 15-minute timeout), so it runs sharded across two jobs with parallel
+    # workers inside each (see workers in playwright.config.ts).
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Playwright E2E
-        run: pnpm test:e2e
+        run: pnpm test:e2e -- --shard=${{ matrix.shard }}/2

--- a/.github/workflows/web-quality.yml
+++ b/.github/workflows/web-quality.yml
@@ -94,5 +94,9 @@ jobs:
       - name: Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium
 
+      # pnpm forwards a bare `--` to the underlying command, so the script
+      # form (`pnpm test:e2e -- --shard=…`) hands Playwright a positional
+      # `--` and the shard flag never takes effect — both jobs silently run
+      # the full suite. Invoke the binary directly instead.
       - name: Run Playwright E2E
-        run: pnpm test:e2e -- --shard=${{ matrix.shard }}/2
+        run: pnpm exec playwright test --shard=${{ matrix.shard }}/2

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,11 @@ import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests/e2e',
-  workers: 1,
+  // CI runners have four cores, and every test file is independent (fresh
+  // context + storage per test, one shared dev server), so parallel workers
+  // divide the wall clock by ~4. Local runs stay serial: a long-lived dev
+  // server on the workstation ages under parallel cold-transform load.
+  workers: process.env.CI ? '100%' : 1,
   timeout: 30_000,
   // The Vite cold-transform storm sporadically fails the first editor init (a
   // rejected @muyajs/core dynamic import); a retry clears it, and Playwright


### PR DESCRIPTION
## Why it was slow

Three compounding causes, confirmed from the config and run history (one recent run hit the 15-minute job timeout exactly):

1. **`workers: 1` pinned globally** in playwright.config.ts — 24 spec files ran strictly one at a time while the runner has four cores.
2. The suite has grown (172 tests; the theme gallery alone adds 30+ full page loads), and CI `retries: 2` triples the cost of any flake.
3. Every run re-downloads ~120 MB of Playwright Chromium.

## What changed

- **Workers**: `'100%'` in CI (one per core); local runs stay serial — a long-lived workstation dev server ages under parallel cold-transform load, which is exactly the flake the config's retry comment describes.
- **Sharding**: the job becomes a 2-shard matrix (`--shard=1/2`, `2/2`), so two runners each take half the suite; `fail-fast: false` keeps one shard's failure from masking the other's result.
- **Browser cache**: `~/.cache/ms-playwright` keyed on the lockfile; `playwright install` becomes a no-op on hit (`--with-deps` still applies system packages).

Expected wall time: from >15 min (timeout) to roughly **3–5 min per shard**, running concurrently.

## Verification

- `--shard=1/2` / `2/2` `--list`: clean 12+12 file split (99 + 73 tests).
- Full local run at 4 workers: **172 passed, 0 flaky, 4.8 min** — validates that tests are parallel-safe (each test uses a fresh context and storage against the one shared dev server).

Note: the open theme-stack PRs (#166–#168) run the workflow from their own branches, so they keep the old serial job until this merges and the stack is refreshed from main (happy to do that refresh once this lands).