### PR TITLE
Make app chrome non-selectable so long presses drive gestures

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -83,6 +83,24 @@ body {
   min-height: 100vh;
   margin: 0;
   overflow: hidden;
+  /* App chrome is never text-selectable, matching native Android apps:
+     long presses drive gestures (home card selection, editor context),
+     and titles, dates, tab labels, or settings rows have no copy value.
+     User content opts back in below. */
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* The two places text selection IS the product: the Muya writing surface
+   (whole surface, not just the contenteditable blocks — dragging across
+   paragraphs passes through non-editable wrappers; Muya's own styles
+   re-disable its decorations) and editable fields, which must keep native
+   selection under a non-selectable ancestor. */
+.mu-container,
+input,
+textarea {
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 #app {

--- a/tests/e2e/mobile-home-document-management.spec.ts
+++ b/tests/e2e/mobile-home-document-management.spec.ts
@@ -28,8 +28,12 @@ test('manages home documents through long-press selection mode', async ({ page }
   await page.reload()
 
   // Long-press an Earlier row: selection mode starts with that row selected,
-  // and the release click must not immediately toggle it back off.
+  // and the release click must not immediately toggle it back off. Home
+  // chrome is not text-selectable, so the gesture cannot degrade into
+  // native selection handles grabbing the title or section label.
   const earlierRow = page.getByRole('button', { name: /Earlier selection note/ })
+  await expect(earlierRow).toHaveCSS('user-select', 'none')
+  await expect(page.getByText('Earlier').first()).toHaveCSS('user-select', 'none')
   await longPress(page, earlierRow)
 
   await expect(page.getByTestId('home-selection-bar')).toBeVisible()
@@ -129,6 +133,8 @@ test('drops a renamed Android recent when only temporary access remains', async 
   await longPress(page, row)
   await page.getByTestId('home-selection-menu').click()
   await page.getByTestId('home-selection-rename').click()
+  // The rename input opts back out of the home screen's user-select: none.
+  await expect(page.getByTestId('home-rename-input')).toHaveCSS('user-select', 'text')
   await page.getByTestId('home-rename-input').fill('trip-plan')
   await page.getByTestId('home-rename-confirm').click()
 


### PR DESCRIPTION
## Problem

Long-pressing a home card should enter card selection mode (select / pin / delete), but every chrome string in the app was text-selectable. On device, the WebView's native selection handles could grab the section label ("Local drafts"), a document title, or the date/word-count line mid-gesture instead of entering selection mode. The same applied to the home masthead, the Open button label, the bottom tab labels, and every settings row.

## Fix

App chrome opts out of text selection at the `body` level — the convention native Android apps follow: long presses drive gestures, and labels have no copy value. Exactly two things opt back in, because there selection *is* the product:

- **The Muya writing surface** (`.mu-container`) — the whole surface rather than just the `contenteditable` blocks, because dragging a selection across paragraphs passes through non-editable block wrappers; Muya's own styles keep re-disabling its internal decorations.
- **Input fields** (`input`, `textarea`) — e.g. the home rename sheet, link dialogs, editor search — which must keep native selection under a non-selectable ancestor.

## Verification

- `pnpm typecheck` clean, 597 unit tests pass, changed files lint clean.
- Focused E2E (40/40): `mobile-home-document-management` (with new assertions pinning the home row at `user-select: none` and the rename input at `text`), the full `mobile-selection-toolbar` suite (long-press word selection in the editor still works — proves the writing-surface opt-in), `mobile-editor-search`, `mobile-markdown-editing`.
