### PR TITLE
Dismiss the panel menu on outside taps and hide the caret handle under it

### DIFF
--- a/src/features/editor/components/MobileEditorToolbar.vue
+++ b/src/features/editor/components/MobileEditorToolbar.vue
@@ -83,14 +83,68 @@ watch(
   },
 )
 
+// The Android WebView draws the native caret handle in a compositor layer
+// ABOVE all DOM content — no popup can cover it, so while the panel menu
+// is open the editor's DOM selection is stashed away (which hides the
+// handle) and restored when the menu closes. Muya's own cached selection
+// is untouched, so the editing context survives; the keyboard stays
+// because focus never moves.
+let stashedEditorRanges: Range[] = []
+
+watch(groupMenuOpen, open => {
+  const selection = document.getSelection()
+  if (!selection) {
+    return
+  }
+
+  if (open) {
+    const ranges = Array.from({ length: selection.rangeCount }, (_, i) =>
+      selection.getRangeAt(i),
+    )
+    const editorRanges = ranges.filter(
+      range => props.host?.contains(range.commonAncestorContainer) ?? false,
+    )
+    if (editorRanges.length > 0) {
+      stashedEditorRanges = editorRanges.map(range => range.cloneRange())
+      selection.removeAllRanges()
+    }
+    return
+  }
+
+  if (stashedEditorRanges.length > 0) {
+    selection.removeAllRanges()
+    for (const range of stashedEditorRanges) {
+      selection.addRange(range)
+    }
+    stashedEditorRanges = []
+  }
+})
+
+// A tap anywhere outside the open panel menu (and its trigger) dismisses
+// it, like any popup — including taps into the document body, which then
+// place the caret as they normally would.
+function dismissGroupMenuFromOutsidePointer(event: PointerEvent) {
+  if (!groupMenuOpen.value || !(event.target instanceof Element)) {
+    return
+  }
+
+  const insideMenu = event.target.closest('[data-testid="mobile-editor-toolbar-panel"]')
+  const onTrigger = event.target.closest('[data-testid="toolbar-group-switcher"]')
+  if (!insideMenu && !onTrigger) {
+    groupMenuOpen.value = false
+  }
+}
+
 onMounted(() => {
   document.addEventListener('selectionchange', rememberCurrentEditorSelection)
   document.addEventListener('pointerdown', clearEditorSelectionRangeFromEditorPointer, true)
+  document.addEventListener('pointerdown', dismissGroupMenuFromOutsidePointer, true)
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('selectionchange', rememberCurrentEditorSelection)
   document.removeEventListener('pointerdown', clearEditorSelectionRangeFromEditorPointer, true)
+  document.removeEventListener('pointerdown', dismissGroupMenuFromOutsidePointer, true)
 })
 
 watch(

--- a/src/features/editor/components/MobileEditorToolbar.vue
+++ b/src/features/editor/components/MobileEditorToolbar.vue
@@ -84,39 +84,34 @@ watch(
 )
 
 // The Android WebView draws the native caret handle in a compositor layer
-// ABOVE all DOM content — no popup can cover it, so while the panel menu
-// is open the editor's DOM selection is stashed away (which hides the
-// handle) and restored when the menu closes. Muya's own cached selection
-// is untouched, so the editing context survives; the keyboard stays
-// because focus never moves.
-let stashedEditorRanges: Range[] = []
-
+// ABOVE all DOM content — no popup can cover it. Chromium only shows the
+// touch handles for GESTURE-made selections, so re-applying the current
+// selection programmatically hides the handle while the selection, the
+// focus, and therefore the soft keyboard all stay exactly as they were.
+// (Clearing the selection instead would hide the keyboard: with no
+// editable selection the IME dismisses.) The remove+add pair runs in one
+// synchronous task, so no observable empty-selection state exists.
 watch(groupMenuOpen, open => {
+  if (!open) {
+    return
+  }
+
   const selection = document.getSelection()
-  if (!selection) {
+  if (!selection || selection.rangeCount === 0) {
     return
   }
 
-  if (open) {
-    const ranges = Array.from({ length: selection.rangeCount }, (_, i) =>
-      selection.getRangeAt(i),
-    )
-    const editorRanges = ranges.filter(
-      range => props.host?.contains(range.commonAncestorContainer) ?? false,
-    )
-    if (editorRanges.length > 0) {
-      stashedEditorRanges = editorRanges.map(range => range.cloneRange())
-      selection.removeAllRanges()
-    }
+  const ranges = Array.from({ length: selection.rangeCount }, (_, i) =>
+    selection.getRangeAt(i),
+  )
+  if (!ranges.some(range => props.host?.contains(range.commonAncestorContainer))) {
     return
   }
 
-  if (stashedEditorRanges.length > 0) {
-    selection.removeAllRanges()
-    for (const range of stashedEditorRanges) {
-      selection.addRange(range)
-    }
-    stashedEditorRanges = []
+  const clones = ranges.map(range => range.cloneRange())
+  selection.removeAllRanges()
+  for (const range of clones) {
+    selection.addRange(range)
   }
 })
 

--- a/tests/e2e/mobile-editor-toolbar.spec.ts
+++ b/tests/e2e/mobile-editor-toolbar.spec.ts
@@ -194,39 +194,47 @@ test('a tap outside the panel menu dismisses it like any popup', async ({ page }
   await expect(page.getByTestId('mobile-editor-toolbar-panel')).toBeHidden()
 })
 
-test('the open panel menu stashes the editor selection and restores it on close', async ({
-  page,
-}) => {
+test('the open panel menu keeps the editor selection and focus intact', async ({ page }) => {
   await newBlankDocument(page)
   await page.getByTestId('editor-host').click()
   await page.keyboard.type('caret anchor')
 
-  // The native Android caret handle is composited ABOVE all DOM content,
-  // so the only way to keep it from floating over the popup is an empty
-  // DOM selection while the menu is open.
+  // The native caret handle hides because the selection is RE-APPLIED
+  // programmatically on menu open (Chromium only shows touch handles for
+  // gesture-made selections). The selection itself and the editor focus
+  // must survive — an empty selection or a focus move would dismiss the
+  // soft keyboard on device.
+  const editorSelectionState = () =>
+    page.evaluate(() => {
+      const host = document.querySelector('[data-testid="editor-host"]')
+      const selection = document.getSelection()
+      const focusInEditor = Boolean(
+        document.activeElement && host?.contains(document.activeElement),
+      )
+      if (!selection || selection.rangeCount === 0) {
+        return { focusInEditor, selection: 'none' }
+      }
+      const anchor = selection.getRangeAt(0).commonAncestorContainer
+      return {
+        focusInEditor,
+        selection: host?.contains(anchor) ? 'in-editor' : 'elsewhere',
+      }
+    })
+
   await page.getByTestId('toolbar-expand-button').click()
   await page.getByTestId('toolbar-group-switcher').click()
   await expect(page.getByTestId('mobile-editor-toolbar-panel')).toBeVisible()
-  await expect
-    .poll(() => page.evaluate(() => document.getSelection()?.rangeCount ?? -1))
-    .toBe(0)
+  await expect.poll(editorSelectionState).toEqual({
+    focusInEditor: true,
+    selection: 'in-editor',
+  })
 
-  // Closing through a panel choice restores the caret into the editor.
   await page.getByTestId('toolbar-section-option-insert').click()
   await expect(page.getByTestId('mobile-editor-toolbar-panel')).toBeHidden()
-  await expect
-    .poll(() =>
-      page.evaluate(() => {
-        const selection = document.getSelection()
-        if (!selection || selection.rangeCount === 0) {
-          return 'no-selection'
-        }
-        const anchor = selection.getRangeAt(0).commonAncestorContainer
-        const host = document.querySelector('[data-testid="editor-host"]')
-        return host?.contains(anchor) ? 'in-editor' : 'elsewhere'
-      }),
-    )
-    .toBe('in-editor')
+  await expect.poll(editorSelectionState).toEqual({
+    focusInEditor: true,
+    selection: 'in-editor',
+  })
 })
 
 test('applies quick toolbar inline formatting to selected editor text', async ({ page }) => {

--- a/tests/e2e/mobile-editor-toolbar.spec.ts
+++ b/tests/e2e/mobile-editor-toolbar.spec.ts
@@ -179,6 +179,56 @@ async function installAndroidImagePickerMock(page: Page) {
   })
 }
 
+test('a tap outside the panel menu dismisses it like any popup', async ({ page }) => {
+  await newBlankDocument(page)
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('body text')
+
+  await page.getByTestId('toolbar-expand-button').click()
+  await page.getByTestId('toolbar-group-switcher').click()
+  await expect(page.getByTestId('mobile-editor-toolbar-panel')).toBeVisible()
+
+  // Tapping the document body closes the menu; the tap then places the
+  // caret as it normally would.
+  await page.getByTestId('editor-host').getByText('body text').click()
+  await expect(page.getByTestId('mobile-editor-toolbar-panel')).toBeHidden()
+})
+
+test('the open panel menu stashes the editor selection and restores it on close', async ({
+  page,
+}) => {
+  await newBlankDocument(page)
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('caret anchor')
+
+  // The native Android caret handle is composited ABOVE all DOM content,
+  // so the only way to keep it from floating over the popup is an empty
+  // DOM selection while the menu is open.
+  await page.getByTestId('toolbar-expand-button').click()
+  await page.getByTestId('toolbar-group-switcher').click()
+  await expect(page.getByTestId('mobile-editor-toolbar-panel')).toBeVisible()
+  await expect
+    .poll(() => page.evaluate(() => document.getSelection()?.rangeCount ?? -1))
+    .toBe(0)
+
+  // Closing through a panel choice restores the caret into the editor.
+  await page.getByTestId('toolbar-section-option-insert').click()
+  await expect(page.getByTestId('mobile-editor-toolbar-panel')).toBeHidden()
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const selection = document.getSelection()
+        if (!selection || selection.rangeCount === 0) {
+          return 'no-selection'
+        }
+        const anchor = selection.getRangeAt(0).commonAncestorContainer
+        const host = document.querySelector('[data-testid="editor-host"]')
+        return host?.contains(anchor) ? 'in-editor' : 'elsewhere'
+      }),
+    )
+    .toBe('in-editor')
+})
+
 test('applies quick toolbar inline formatting to selected editor text', async ({ page }) => {
   await newBlankDocument(page)
 


### PR DESCRIPTION
Two device findings from the table-panel acceptance pass on the Xiaomi 14.

## The caret handle floated above the menu

The Android WebView composites the native text-caret handle in a layer **above all DOM content** — no z-index can put a popup over it, so the teal drop hovered mid-menu. When the panel menu opens, the current editor selection is **synchronously re-applied** (clone → removeAllRanges → addRange in one task): Chromium only shows the touch handles for gesture-made selections, so a script-set selection hides the handle while **the selection, the editor focus, and therefore the soft keyboard stay continuously present**. Nothing is stashed and nothing needs restoring on close.

Device-critical contract note: the first attempt kept an EMPTY DOM selection while the menu was open — that dismissed the MIUI soft keyboard (no editable selection → IME hides). The E2E pins the accepted contract directly: the selection and the editor focus remain inside the editor both while the menu is open and after it closes.

## Outside taps did not dismiss the menu

The menu only closed via its trigger or a panel choice; tapping the document body left it hanging — against every popup convention. A capture-phase pointer listener now dismisses it on any tap outside the menu and its trigger, without consuming the event — the tap then places the caret exactly where it normally would.

## Verification

- Verified on the Xiaomi 14 with real input taps: menu open, handle gone, `mInputShown=true` throughout, outside tap dismisses.
- New E2E: outside-tap dismissal; selection/focus intact through the menu round-trip.
- Full `mobile-editor-toolbar` suite 36/36; `mobile-table-structure` 7/7 (the caret-contextual TABLE panel state holds through a menu round-trip, proving the re-apply does not disturb Muya's cached editing context); 633 unit tests, typecheck and lint clean.
