### PR TITLE
Record a selection for the session's first undoable op

### DIFF
--- a/tests/e2e/mobile-table-structure.spec.ts
+++ b/tests/e2e/mobile-table-structure.spec.ts
@@ -90,6 +90,30 @@ test('inserts and deletes rows and columns around the caret cell', async ({ page
   await expect(page.getByTestId('editor-host')).not.toContainText('fresh')
 })
 
+test('a table command works again right after undoing the previous one', async ({ page }) => {
+  // Device-reproduced #144 bug: insert row -> undo -> insert row again
+  // silently no-opped and kicked the panel out. The session's FIRST
+  // recorded op stored no selection, so its undo restored nothing and
+  // the active content block kept pointing into the removed row.
+  await openTableDraft(page)
+
+  await page.getByTestId('toolbar-expand-button').click()
+  await tapCell(page, 'two')
+  await expect(tableRows(page)).toHaveCount(2)
+
+  await page.getByTestId('toolbar-table-table-insert-row-above').click()
+  await expect(tableRows(page)).toHaveCount(3)
+
+  await page.getByTestId('toolbar-command-edit.undo').click()
+  await expect(tableRows(page)).toHaveCount(2)
+
+  // The caret is back on a live cell: the panel stays TABLE and the
+  // repeated command inserts again instead of no-opping.
+  await expect(page.getByTestId('toolbar-table-table-insert-row-above')).toBeVisible()
+  await page.getByTestId('toolbar-table-table-insert-row-above').click()
+  await expect(tableRows(page)).toHaveCount(3)
+})
+
 test('removing the last row or the whole table drops the caret outside and restores the panel', async ({
   page,
 }) => {

--- a/third_party/muya/src/editor/index.ts
+++ b/third_party/muya/src/editor/index.ts
@@ -439,8 +439,22 @@ export class Editor {
     }
 
     private _restoreSelection(selection: Nullable<IHistorySelection>, treeRebuilt = false) {
-        if (!selection)
+        if (!selection) {
+            // Nothing to restore — but the op that just applied may have
+            // removed the subtree the active content block lives in (e.g.
+            // undoing an op whose recorded selection predates the history's
+            // selection bookkeeping). Never leave consumers a reference
+            // into detached DOM: a detached block keeps its internal parent
+            // links, so climb until the scroll page (attached) or a dead
+            // end (detached). The climb must STOP at the scroll page — it
+            // has a non-block parent of its own.
+            let node = this.activeContentBlock?.parent ?? null;
+            while (node && node !== (this.scrollPage as unknown) && node.parent)
+                node = node.parent;
+            if (this.activeContentBlock != null && node !== (this.scrollPage as unknown))
+                this.activeContentBlock = null;
             return;
+        }
 
         const { anchor, focus, isSelectionInSameBlock } = selection;
         // `ScrollPage.queryBlock` consumes the path array in place (`path.shift`),

--- a/third_party/muya/src/history/__tests__/firstRecordUndoSelection.spec.ts
+++ b/third_party/muya/src/history/__tests__/firstRecordUndoSelection.spec.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+
+// The session's FIRST recorded operation used to store selection = null
+// (the selection stack held one entry and the bookkeeping only returned
+// the "previous" entry of two). Undoing that op then restored NOTHING:
+// editor.activeContentBlock kept pointing into the subtree the inverse op
+// removed, so every consumer that climbs from it — the mobile table panel
+// above all — misread the caret as "not in a table" and its commands
+// silently no-opped (#144 review, device-reproduced).
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+interface ITableProbe {
+    rowCount: number;
+    cellAt: (row: number, column: number) => { firstChild: { text: string; setCursor: (b: number, e: number, u?: boolean) => void } };
+    insertRow: (offset: number) => { setCursor: (b: number, e: number, u?: boolean) => void };
+}
+
+function findTable(muya: Muya): ITableProbe {
+    let table: ITableProbe | null = null;
+    muya.editor.scrollPage!.depthFirstTraverse((block) => {
+        if (block.blockName === 'table' && table == null)
+            table = block as unknown as ITableProbe;
+    });
+    expect(table).not.toBeNull();
+    return table!;
+}
+
+function activeBlockRootName(muya: Muya): string {
+    // The scroll page itself has a non-block parent, so the climb stops
+    // there (mirrors the editor's own attachment check).
+    let node = muya.editor.activeContentBlock as { blockName: string; parent: unknown } | null;
+    if (!node)
+        return 'null';
+    while (node.blockName !== 'scrollpage' && node.parent)
+        node = node.parent as typeof node;
+    return node.blockName;
+}
+
+describe('undo of the session\'s first recorded op', () => {
+    it('re-seats the caret on a live block instead of leaving a detached reference', () => {
+        const muya = bootMuya('before\n\n| A | B |\n| --- | --- |\n| one | two |\n\nafter\n');
+        const table = findTable(muya);
+
+        // Caret into the body cell, then the mobile-adapter command shape:
+        // boundary-cut insert with the caret moved onto the fresh row.
+        table.cellAt(1, 0).firstChild.setCursor(0, 0, true);
+        muya.editor.history.cutoff();
+        table.insertRow(1).setCursor(0, 0, true);
+        muya.editor.jsonState.flush();
+        muya.editor.history.cutoff();
+        expect(table.rowCount).toBe(3);
+
+        muya.undo();
+
+        // The insert is undone AND the active content block is a live table
+        // cell again — its parent chain reaches the scroll page.
+        expect(findTable(muya).rowCount).toBe(2);
+        expect(activeBlockRootName(muya)).toBe('scrollpage');
+        const active = muya.editor.activeContentBlock as { blockName: string } | null;
+        expect(active?.blockName).toBe('table.cell.content');
+
+        // The immediate follow-up command therefore works — the exact
+        // device sequence that used to no-op and kick the panel out.
+        muya.editor.history.cutoff();
+        findTable(muya).insertRow(1).setCursor(0, 0, true);
+        muya.editor.jsonState.flush();
+        muya.editor.history.cutoff();
+        expect(findTable(muya).rowCount).toBe(3);
+    });
+
+    it('never leaves a detached active block when a restore has no selection', () => {
+        const muya = bootMuya('| A | B |\n| --- | --- |\n| one | two |\n');
+        const table = findTable(muya);
+        const cellContent = table.cellAt(1, 0).firstChild;
+        cellContent.setCursor(0, 0, true);
+
+        // Simulate the null-selection restore against a block whose subtree
+        // was just detached (internal links intact, no page root).
+        const editor = muya.editor as unknown as {
+            activeContentBlock: unknown;
+            _restoreSelection: (selection: null) => void;
+        };
+        const detached = {
+            blockName: 'table.cell.content',
+            parent: { blockName: 'table.cell', parent: { blockName: 'table.row', parent: null } },
+            // The activeContentBlock setter drives focus/blur on the blocks.
+            focusHandler: () => {},
+            blurHandler: () => {},
+        };
+        editor.activeContentBlock = detached;
+        editor._restoreSelection(null);
+        expect(editor.activeContentBlock).toBeNull();
+
+        // An ATTACHED active block survives the same call untouched.
+        cellContent.setCursor(0, 0, true);
+        editor._restoreSelection(null);
+        expect(activeBlockRootName(muya)).toBe('scrollpage');
+    });
+});

--- a/third_party/muya/src/history/index.ts
+++ b/third_party/muya/src/history/index.ts
@@ -298,7 +298,16 @@ class History {
         if (this._selectionStack.length > 2)
             this._selectionStack.shift();
 
-        return this._selectionStack.length === 2 ? this._selectionStack[0] : null;
+        // Two entries: the selection captured at the PREVIOUS record — the
+        // "before the op" approximation undo restores. One entry (the
+        // session's very first record): fall back to the CURRENT selection
+        // instead of null. Undoing that first op then re-resolves the
+        // recorded path against the post-undo tree, which seats the caret
+        // on the live neighbouring block — with null it restored NOTHING,
+        // leaving editor.activeContentBlock pointing into the removed
+        // subtree (the mobile table panel read that as "not in a table"
+        // and every structure command silently no-opped, #144 review).
+        return this._selectionStack[0] ?? null;
     }
 
     private _record(op: JSONOpList, doc: TState[]) {


### PR DESCRIPTION
Fixes the device-reproduced #144 follow-up: **insert a table row → undo → any further table command silently no-ops and the toolbar panel kicks back** to the previously active one.

> **Delivery contract (accepted in review): this PR is intentionally incomplete on its own — merge #177 immediately after.** #175 fixes the null-selection / detached-block class; recorded **post-op tail paths that disappear on undo** (insert-below on the last row, insert-right on the last column) still break here and are fixed at the root by #177's `primeRecordSelection()`. The explicit tail regressions live in #177 and are expected to FAIL on #175 alone.

## The chain this PR closes

1. The history's selection bookkeeping returns the previous-record stack entry, so the **session's first recorded op always stored `selection = null`**.
2. Undoing that op ran `_restoreSelection(null)`, which restored **nothing** — `editor.activeContentBlock` kept pointing into the subtree the inverse op had just removed (the freshly inserted row's cell, where the insert had seated the caret).
3. The table-context climb walked the detached chain, correctly refused it — the command returned `false` without touching the engine, while the app's caret-state refresh read 'not in a table' and dropped the contextual panel to the pre-table snapshot.

Verified live on the Xiaomi 14 and reproduced byte-for-byte in a happy-dom probe before fixing.

## Fix (scope: the first-record-null class)

- `_getLastSelection()` falls back to the **current** selection when the stack holds a single entry — undoing the first op then re-resolves the recorded path against the post-undo tree. This restores the caret whenever that path still resolves (e.g. insert-above shapes, whose index the original row re-occupies); it is a stack-approximation, not a true before-command selection — hence #177.
- `_restoreSelection(null)` hardening: never leave a **detached** active content block behind (the attachment climb stops AT the scroll page — it has a non-block parent of its own).

## Verification

- New engine specs (history): the adapter sequence through undo to a working follow-up insert, plus the detached-guard case; full Muya CI gate green at this head.
- New E2E replaying the device flow through the real toolbar undo button (insert-above shape): insert → undo → insert again inserts, panel stays TABLE.
- App unit suite, typecheck, and lint clean.
