### PR TITLE
Mirror the table panel in the collapsed quick strip

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1065,6 +1065,10 @@ function insertTableFromSheet() {
 
   closeTableSheet()
   syncAfterToolbarCommand(result.beforeMarkdown)
+  // The engine seats the caret in the fresh table without emitting a
+  // selection change, so enter the table toolbar state explicitly —
+  // shaping the just-created table is the most likely next action.
+  refreshEditorTableCaretState()
 }
 
 async function insertImageFromAndroidPicker(restoreRange: Range | null = null) {

--- a/src/features/editor/components/MobileEditorToolbar.vue
+++ b/src/features/editor/components/MobileEditorToolbar.vue
@@ -37,6 +37,9 @@ const emit = defineEmits<{
 
 const panels = MOBILE_TOOLBAR_PANELS
 const editCommands = MOBILE_TOOLBAR_EDIT_COMMANDS
+// The table quick strip keeps undo in reach — repeated structure edits
+// and one-step undos are the panel's natural rhythm.
+const quickUndoCommand = MOBILE_TOOLBAR_EDIT_COMMANDS[0]
 const groupMenuOpen = ref(false)
 const { t } = useI18n()
 let lastEditorSelectionRange: Range | null = null
@@ -140,25 +143,69 @@ function getCommandTitle(command: { title: string; titleKey: I18nKey }) {
     :aria-label="t('toolbar.markdownTools')"
     data-testid="mobile-editor-toolbar"
   >
-    <!-- collapsed: quick actions + fixed expand handle -->
+    <!-- collapsed: quick actions + fixed expand handle. While the caret is
+         in a table, the strip mirrors the expanded TABLE panel — undo plus
+         the seven structure commands — so the caret-contextual switch is
+         visible in BOTH toolbar states, and restores the user's quick
+         commands the moment the caret leaves. -->
     <div v-if="!expanded" class="toolbar-collapsed">
-      <div class="toolbar-quick-strip" role="toolbar" :aria-label="t('toolbar.quickActions')">
-        <button
-          v-for="command in quickCommands"
-          :key="command.commandId"
-          class="toolbar-button"
-          type="button"
-          :aria-label="getCommandTitle(command)"
-          :title="getCommandTitle(command)"
-          :disabled="!editorReady"
-          :data-command-id="command.commandId"
-          :data-testid="`toolbar-command-${command.commandId}`"
-          @pointerdown.prevent
-          @mousedown.prevent
-          @click="runCommand(command.commandId)"
-        >
-          <ToolbarCommandGlyph :command="command" />
-        </button>
+      <div
+        class="toolbar-quick-strip"
+        role="toolbar"
+        :aria-label="caretInTable ? t(MOBILE_TOOLBAR_TABLE_PANEL.titleKey) : t('toolbar.quickActions')"
+      >
+        <template v-if="caretInTable">
+          <button
+            class="toolbar-button"
+            type="button"
+            :aria-label="getCommandTitle(quickUndoCommand)"
+            :title="getCommandTitle(quickUndoCommand)"
+            :disabled="!editorReady"
+            :data-command-id="quickUndoCommand.commandId"
+            :data-testid="`toolbar-command-${quickUndoCommand.commandId}`"
+            @pointerdown.prevent
+            @mousedown.prevent
+            @click="runCommand(quickUndoCommand.commandId)"
+          >
+            <ToolbarCommandGlyph :command="quickUndoCommand" />
+          </button>
+          <button
+            v-for="command in TABLE_STRIP"
+            :key="command.id"
+            class="toolbar-button toolbar-table-button"
+            :class="{ 'toolbar-table-danger': command.danger }"
+            type="button"
+            :aria-label="t(command.titleKey)"
+            :title="t(command.titleKey)"
+            :disabled="!editorReady"
+            :data-testid="`toolbar-table-${command.id}`"
+            @pointerdown.prevent
+            @mousedown.prevent
+            @click="emit('runTableCommand', command.id)"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path v-for="path in command.paths" :key="path" :d="path" />
+            </svg>
+          </button>
+        </template>
+        <template v-else>
+          <button
+            v-for="command in quickCommands"
+            :key="command.commandId"
+            class="toolbar-button"
+            type="button"
+            :aria-label="getCommandTitle(command)"
+            :title="getCommandTitle(command)"
+            :disabled="!editorReady"
+            :data-command-id="command.commandId"
+            :data-testid="`toolbar-command-${command.commandId}`"
+            @pointerdown.prevent
+            @mousedown.prevent
+            @click="runCommand(command.commandId)"
+          >
+            <ToolbarCommandGlyph :command="command" />
+          </button>
+        </template>
       </div>
       <button
         class="toolbar-expand-handle"

--- a/tests/e2e/mobile-table-structure.spec.ts
+++ b/tests/e2e/mobile-table-structure.spec.ts
@@ -33,6 +33,31 @@ async function tapCell(page: Page, text: string) {
   await page.getByTestId('editor-host').locator('figure.mu-table').getByText(text).click()
 }
 
+test('the collapsed quick strip swaps to table commands with the caret', async ({ page }) => {
+  await openTableDraft(page)
+
+  // Toolbar collapsed (the resting state while writing): generic quick
+  // commands, no table trace.
+  await expect(page.getByTestId('toolbar-command-format.strong')).toBeVisible()
+  await expect(page.getByTestId('toolbar-table-table-insert-row-below')).toHaveCount(0)
+
+  // Caret into a cell: the strip mirrors the TABLE panel — undo stays in
+  // reach, the seven structure commands replace the quick commands.
+  await tapCell(page, 'two')
+  await expect(page.getByTestId('toolbar-table-table-insert-row-below')).toBeVisible()
+  await expect(page.getByTestId('toolbar-command-edit.undo')).toBeVisible()
+  await expect(page.getByTestId('toolbar-command-format.strong')).toHaveCount(0)
+
+  // The strip is live, not just visible.
+  await page.getByTestId('toolbar-table-table-insert-row-below').click()
+  await expect(tableRows(page)).toHaveCount(3)
+
+  // Caret out: the user's quick commands return.
+  await page.getByTestId('editor-host').getByText('after').click()
+  await expect(page.getByTestId('toolbar-command-format.strong')).toBeVisible()
+  await expect(page.getByTestId('toolbar-table-table-insert-row-below')).toHaveCount(0)
+})
+
 test('the toolbar follows the caret into the table and back out', async ({ page }) => {
   await openTableDraft(page)
 
@@ -179,18 +204,11 @@ test('recovers an editable paragraph when the deleted table was a list item\'s o
   await expect(page.getByTestId('table-insert-sheet')).toBeVisible()
   await page.getByTestId('table-insert-button').click()
 
-  // The table nests as the list item's ONLY child.
+  // The table nests as the list item's ONLY child, and inserting from the
+  // sheet enters the table toolbar state directly (the engine seats the
+  // caret in the fresh table without a selection change; the app enters
+  // explicitly) — the collapsed strip already shows the commands.
   await expect(page.getByTestId('editor-host').locator('li > figure.mu-table')).toHaveCount(1)
-
-  // Tapping a cell brings the TABLE panel up (programmatic insertion does
-  // not emit a selection change, so the panel follows the first tap), and
-  // the sheet flow collapsed the toolbar, so expand it again to see it.
-  await page
-    .getByTestId('editor-host')
-    .locator('figure.mu-table span.mu-table-cell-content')
-    .first()
-    .click()
-  await page.getByTestId('toolbar-expand-button').click()
   await expect(page.getByTestId('toolbar-table-table-delete-table')).toBeVisible()
 
   await page.getByTestId('toolbar-table-table-delete-table').click()


### PR DESCRIPTION
Follow-up to #173, from device feedback: the caret-contextual table switch only touched the EXPANDED panel — in the resting collapsed state (where most writing happens) entering a table showed nothing, and the feature read as missing entirely.

## Change

- While the caret is in a table, the **collapsed quick strip mirrors the TABLE panel**: undo stays in reach (structure edits + one-step undos are the panel's natural rhythm), the seven structure commands replace the user's quick commands, and the strip restores the moment the caret leaves. The contextual switch is now visible in **both** toolbar states with zero extra taps.
- **Inserting a table from the size sheet enters the table toolbar state explicitly** — the engine seats the caret in the fresh table without emitting a selection change (previously the panel lagged until the first tap), and shaping the just-created table is the most likely next action.

## Verification

- New E2E: collapsed strip swaps in/out with the caret and the swapped strip is live (a real insert lands); the sheet-insert flow now asserts direct entry into the table state (no cell tap, no expand).
- `mobile-table-structure` 8/8, full `mobile-editor-toolbar` regression 34/34, unit suite green (the one vendor-sync failure during the run was a branch-switch environment artifact, re-verified green after resync), typecheck and lint clean.