### PR TITLE
Restore the caret near its edit after undoing a table command

### DIFF
--- a/src/features/editor/tableCommands.test.ts
+++ b/src/features/editor/tableCommands.test.ts
@@ -91,7 +91,7 @@ function createFakeEditor({
     offset: vi.fn(),
   }
 
-  const history = { cutoff: vi.fn() }
+  const history = { cutoff: vi.fn(), primeRecordSelection: vi.fn() }
   const jsonState = { flush: vi.fn() }
   const editor = {
     editor: { activeContentBlock: content, history, jsonState, scrollPage },
@@ -184,6 +184,11 @@ describe('runTableCommand', () => {
     runTableCommand(harness.editor, 'table-insert-row-below')
 
     expect(harness.insertedCaret.setCursor).toHaveBeenCalledWith(0, 0, true)
+    // The before-command selection is primed BEFORE the mutation, so the
+    // entry's undo restores the caret where the user actually was.
+    const primeOrder = harness.history.primeRecordSelection.mock.invocationCallOrder[0]
+    const mutateOrder = harness.table.insertRow.mock.invocationCallOrder[0]
+    expect(primeOrder).toBeLessThan(mutateOrder)
     // cutoff -> mutate -> flush -> cutoff: one undo step per tap, pinned
     // engine-side in Muya's search.spec undo-boundary contract.
     expect(harness.history.cutoff).toHaveBeenCalledTimes(2)

--- a/src/features/editor/tableCommands.ts
+++ b/src/features/editor/tableCommands.ts
@@ -131,6 +131,11 @@ export function runTableCommand(editor: MuyaEditor | null, commandId: TableComma
   }
 
   inner.history.cutoff()
+  // Stamp the entry with the TRUE before-command selection: undoing the
+  // command then puts the caret back where the user actually was (e.g.
+  // inside the restored table after undoing delete-table), instead of the
+  // history's one-record-behind approximation.
+  inner.history.primeRecordSelection()
   let caret: TableCaretContent | null | undefined
   try {
     switch (commandId) {

--- a/src/types/muya-core.d.ts
+++ b/src/types/muya-core.d.ts
@@ -87,9 +87,11 @@ declare module '@muyajs/core' {
       jsonState: { readonly rawState: readonly unknown[]; flush(): void }
       /**
        * `cutoff()` breaks the history's time-window undo coalescing so the
-       * next recorded operation starts its own undo entry.
+       * next recorded operation starts its own undo entry;
+       * `primeRecordSelection()` stamps the next entry with the CURRENT
+       * selection so its undo restores the true before-command caret.
        */
-      history: { cutoff(): void }
+      history: { cutoff(): void; primeRecordSelection(): void }
       /**
        * The live block-tree root. Kept opaque here — callers narrow it to
        * the members they use (e.g. the table commands' empty-page recovery).

--- a/tests/e2e/mobile-table-structure.spec.ts
+++ b/tests/e2e/mobile-table-structure.spec.ts
@@ -90,6 +90,30 @@ test('inserts and deletes rows and columns around the caret cell', async ({ page
   await expect(page.getByTestId('editor-host')).not.toContainText('fresh')
 })
 
+test('a table command works again right after undoing the previous one', async ({ page }) => {
+  // Device-reproduced #144 bug: insert row -> undo -> insert row again
+  // silently no-opped and kicked the panel out. The session's FIRST
+  // recorded op stored no selection, so its undo restored nothing and
+  // the active content block kept pointing into the removed row.
+  await openTableDraft(page)
+
+  await page.getByTestId('toolbar-expand-button').click()
+  await tapCell(page, 'two')
+  await expect(tableRows(page)).toHaveCount(2)
+
+  await page.getByTestId('toolbar-table-table-insert-row-above').click()
+  await expect(tableRows(page)).toHaveCount(3)
+
+  await page.getByTestId('toolbar-command-edit.undo').click()
+  await expect(tableRows(page)).toHaveCount(2)
+
+  // The caret is back on a live cell: the panel stays TABLE and the
+  // repeated command inserts again instead of no-opping.
+  await expect(page.getByTestId('toolbar-table-table-insert-row-above')).toBeVisible()
+  await page.getByTestId('toolbar-table-table-insert-row-above').click()
+  await expect(tableRows(page)).toHaveCount(3)
+})
+
 test('removing the last row or the whole table drops the caret outside and restores the panel', async ({
   page,
 }) => {

--- a/tests/e2e/mobile-table-structure.spec.ts
+++ b/tests/e2e/mobile-table-structure.spec.ts
@@ -114,6 +114,30 @@ test('a table command works again right after undoing the previous one', async (
   await expect(tableRows(page)).toHaveCount(3)
 })
 
+test('a tail insert undo keeps the table context (insert below the last row)', async ({
+  page,
+}) => {
+  // Review gap on #175: inserting BELOW the last row parks the caret at a
+  // tail index the undo removes, so the recorded post-op path stopped
+  // resolving and the context fell to the document head. Priming records
+  // the before-command cell instead.
+  await openTableDraft(page)
+
+  await page.getByTestId('toolbar-expand-button').click()
+  await tapCell(page, 'two')
+  await page.getByTestId('toolbar-table-table-insert-row-below').click()
+  await expect(tableRows(page)).toHaveCount(3)
+
+  await page.getByTestId('toolbar-command-edit.undo').click()
+  await expect(tableRows(page)).toHaveCount(2)
+
+  // Context intact: the panel still shows the table strip and the repeat
+  // inserts again.
+  await expect(page.getByTestId('toolbar-table-table-insert-row-below')).toBeVisible()
+  await page.getByTestId('toolbar-table-table-insert-row-below').click()
+  await expect(tableRows(page)).toHaveCount(3)
+})
+
 test('undoing a table delete puts the caret back into the restored table', async ({ page }) => {
   // Device-reported: delete the table (caret lands on the following
   // prose), undo — the table came back but the caret teleported to the

--- a/tests/e2e/mobile-table-structure.spec.ts
+++ b/tests/e2e/mobile-table-structure.spec.ts
@@ -114,6 +114,30 @@ test('a table command works again right after undoing the previous one', async (
   await expect(tableRows(page)).toHaveCount(3)
 })
 
+test('undoing a table delete puts the caret back into the restored table', async ({ page }) => {
+  // Device-reported: delete the table (caret lands on the following
+  // prose), undo — the table came back but the caret teleported to the
+  // DOCUMENT HEAD. The command primes the entry with the true
+  // before-command selection, so the undo restores the caret into the
+  // cell it came from.
+  await openTableDraft(page)
+
+  await page.getByTestId('toolbar-expand-button').click()
+  await tapCell(page, 'one')
+  // Pin the caret to the cell start so the restored offset is exact.
+  await page.keyboard.press('Home')
+  await page.getByTestId('toolbar-table-table-delete-table').click()
+  await expect(page.getByTestId('editor-host').locator('figure.mu-table')).toHaveCount(0)
+
+  await page.getByTestId('toolbar-command-edit.undo').click()
+  await expect(tableRows(page)).toHaveCount(2)
+
+  await page.keyboard.type('X')
+  await expect(tableRows(page).nth(1)).toContainText('Xone')
+  // Nowhere near the document head.
+  await expect(page.getByTestId('editor-host')).not.toContainText('X# Table probe')
+})
+
 test('removing the last row or the whole table drops the caret outside and restores the panel', async ({
   page,
 }) => {

--- a/third_party/muya/src/editor/index.ts
+++ b/third_party/muya/src/editor/index.ts
@@ -439,8 +439,22 @@ export class Editor {
     }
 
     private _restoreSelection(selection: Nullable<IHistorySelection>, treeRebuilt = false) {
-        if (!selection)
+        if (!selection) {
+            // Nothing to restore — but the op that just applied may have
+            // removed the subtree the active content block lives in (e.g.
+            // undoing an op whose recorded selection predates the history's
+            // selection bookkeeping). Never leave consumers a reference
+            // into detached DOM: a detached block keeps its internal parent
+            // links, so climb until the scroll page (attached) or a dead
+            // end (detached). The climb must STOP at the scroll page — it
+            // has a non-block parent of its own.
+            let node = this.activeContentBlock?.parent ?? null;
+            while (node && node !== (this.scrollPage as unknown) && node.parent)
+                node = node.parent;
+            if (this.activeContentBlock != null && node !== (this.scrollPage as unknown))
+                this.activeContentBlock = null;
             return;
+        }
 
         const { anchor, focus, isSelectionInSameBlock } = selection;
         // `ScrollPage.queryBlock` consumes the path array in place (`path.shift`),

--- a/third_party/muya/src/editor/index.ts
+++ b/third_party/muya/src/editor/index.ts
@@ -461,11 +461,29 @@ export class Editor {
         // so query against a copy and leave the caller's selection untouched.
         const cursorBlock = this.scrollPage?.queryBlock([...anchor.path]);
 
+        // A recorded path can stop resolving after an op shifted the
+        // top-level indices — undoing a whole-table delete re-inserts the
+        // table exactly where the recorded paragraph path points, and the
+        // paragraph-shaped remainder misses inside it. Fall back to the
+        // LONGEST RESOLVABLE PREFIX of the path and land on its nearest
+        // content with a collapsed caret: local to the edit, instead of the
+        // old `focus()` fallback teleporting the caret to the document head.
+        const toContent = (block: ReturnType<NonNullable<typeof this.scrollPage>['queryBlock']>) =>
+            block == null ? null : block.isContent() ? block : block.firstContentInDescendant();
+
+        let cursorContent = toContent(cursorBlock);
+        for (let length = anchor.path.length - 1; length > 0 && cursorContent == null; length--)
+            cursorContent = toContent(this.scrollPage?.queryBlock(anchor.path.slice(0, length)));
+
         const begin = Math.min(anchor.offset, focus.offset);
         const end = Math.max(anchor.offset, focus.offset);
 
-        if (isSelectionInSameBlock && cursorBlock && cursorBlock.isContent()) {
-            cursorBlock.setCursor(begin, end, true);
+        if (isSelectionInSameBlock && cursorContent) {
+            if (cursorContent === cursorBlock)
+                cursorContent.setCursor(begin, end, true);
+            else
+                cursorContent.setCursor(0, 0, true);
+
             return;
         }
 
@@ -474,11 +492,13 @@ export class Editor {
         // nodes from the previous tree — resolving them would set the native DOM
         // range onto a detached node and crash the next `getSelection()` read.
         // Re-resolve the caret from the (cloned) path against the fresh tree;
-        // fall back to focusing the first content block when the saved path no
-        // longer points at a content leaf (e.g. a paragraph became a table).
+        // fall back to the nearest content at that path, then to focusing the
+        // first content block of the document.
         if (treeRebuilt) {
-            if (cursorBlock && cursorBlock.isContent())
-                cursorBlock.setCursor(begin, end, true);
+            if (cursorContent === cursorBlock && cursorContent)
+                cursorContent.setCursor(begin, end, true);
+            else if (cursorContent)
+                cursorContent.setCursor(0, 0, true);
             else
                 this.focus();
 
@@ -491,7 +511,10 @@ export class Editor {
         const anchorBlock = this.scrollPage?.queryBlock([...anchor.path]);
         const focusBlock = this.scrollPage?.queryBlock([...focus.path]);
         if (!anchorBlock || !anchorBlock.isContent() || !focusBlock || !focusBlock.isContent()) {
-            this.focus();
+            if (cursorContent)
+                cursorContent.setCursor(0, 0, true);
+            else
+                this.focus();
             return;
         }
 

--- a/third_party/muya/src/history/__tests__/firstRecordUndoSelection.spec.ts
+++ b/third_party/muya/src/history/__tests__/firstRecordUndoSelection.spec.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+
+// The session's FIRST recorded operation used to store selection = null
+// (the selection stack held one entry and the bookkeeping only returned
+// the "previous" entry of two). Undoing that op then restored NOTHING:
+// editor.activeContentBlock kept pointing into the subtree the inverse op
+// removed, so every consumer that climbs from it — the mobile table panel
+// above all — misread the caret as "not in a table" and its commands
+// silently no-opped (#144 review, device-reproduced).
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+interface ITableProbe {
+    rowCount: number;
+    cellAt: (row: number, column: number) => { firstChild: { text: string; setCursor: (b: number, e: number, u?: boolean) => void } };
+    insertRow: (offset: number) => { setCursor: (b: number, e: number, u?: boolean) => void };
+}
+
+function findTable(muya: Muya): ITableProbe {
+    let table: ITableProbe | null = null;
+    muya.editor.scrollPage!.depthFirstTraverse((block) => {
+        if (block.blockName === 'table' && table == null)
+            table = block as unknown as ITableProbe;
+    });
+    expect(table).not.toBeNull();
+    return table!;
+}
+
+function activeBlockRootName(muya: Muya): string {
+    // The scroll page itself has a non-block parent, so the climb stops
+    // there (mirrors the editor's own attachment check).
+    let node = muya.editor.activeContentBlock as { blockName: string; parent: unknown } | null;
+    if (!node)
+        return 'null';
+    while (node.blockName !== 'scrollpage' && node.parent)
+        node = node.parent as typeof node;
+    return node.blockName;
+}
+
+describe('undo of the session\'s first recorded op', () => {
+    it('re-seats the caret on a live block instead of leaving a detached reference', () => {
+        const muya = bootMuya('before\n\n| A | B |\n| --- | --- |\n| one | two |\n\nafter\n');
+        const table = findTable(muya);
+
+        // Caret into the body cell, then the mobile-adapter command shape:
+        // boundary-cut insert with the caret moved onto the fresh row.
+        table.cellAt(1, 0).firstChild.setCursor(0, 0, true);
+        muya.editor.history.cutoff();
+        table.insertRow(1).setCursor(0, 0, true);
+        muya.editor.jsonState.flush();
+        muya.editor.history.cutoff();
+        expect(table.rowCount).toBe(3);
+
+        muya.undo();
+
+        // The insert is undone AND the active content block is a live table
+        // cell again — its parent chain reaches the scroll page.
+        expect(findTable(muya).rowCount).toBe(2);
+        expect(activeBlockRootName(muya)).toBe('scrollpage');
+        const active = muya.editor.activeContentBlock as { blockName: string } | null;
+        expect(active?.blockName).toBe('table.cell.content');
+
+        // The immediate follow-up command therefore works — the exact
+        // device sequence that used to no-op and kick the panel out.
+        muya.editor.history.cutoff();
+        findTable(muya).insertRow(1).setCursor(0, 0, true);
+        muya.editor.jsonState.flush();
+        muya.editor.history.cutoff();
+        expect(findTable(muya).rowCount).toBe(3);
+    });
+
+    it('never leaves a detached active block when a restore has no selection', () => {
+        const muya = bootMuya('| A | B |\n| --- | --- |\n| one | two |\n');
+        const table = findTable(muya);
+        const cellContent = table.cellAt(1, 0).firstChild;
+        cellContent.setCursor(0, 0, true);
+
+        // Simulate the null-selection restore against a block whose subtree
+        // was just detached (internal links intact, no page root).
+        const editor = muya.editor as unknown as {
+            activeContentBlock: unknown;
+            _restoreSelection: (selection: null) => void;
+        };
+        const detached = {
+            blockName: 'table.cell.content',
+            parent: { blockName: 'table.cell', parent: { blockName: 'table.row', parent: null } },
+            // The activeContentBlock setter drives focus/blur on the blocks.
+            focusHandler: () => {},
+            blurHandler: () => {},
+        };
+        editor.activeContentBlock = detached;
+        editor._restoreSelection(null);
+        expect(editor.activeContentBlock).toBeNull();
+
+        // An ATTACHED active block survives the same call untouched.
+        cellContent.setCursor(0, 0, true);
+        editor._restoreSelection(null);
+        expect(activeBlockRootName(muya)).toBe('scrollpage');
+    });
+});

--- a/third_party/muya/src/history/__tests__/undoCaretRestore.spec.ts
+++ b/third_party/muya/src/history/__tests__/undoCaretRestore.spec.ts
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+
+// Undoing a whole-table delete used to teleport the caret to the document
+// head: the entry's recorded selection pointed at the POST-delete caret
+// (the paragraph after the table), whose path the undo's re-insert now
+// occupies with the table — a non-content block — and the restore fell
+// back to focus(). Two fixes pinned here: primeRecordSelection() stamps
+// the entry with the true before-command selection, and the restore's
+// fallback seats the caret at the nearest content under the resolved
+// block instead of the document head.
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+interface ITableProbe {
+    cellAt: (row: number, column: number) => {
+        firstChild: { text: string; setCursor: (b: number, e: number, u?: boolean) => void };
+    };
+    outsideContentInContext: () => { setCursor: (b: number, e: number, u?: boolean) => void } | null;
+    remove: () => void;
+}
+
+function findTable(muya: Muya): ITableProbe | null {
+    let table: ITableProbe | null = null;
+    muya.editor.scrollPage!.depthFirstTraverse((block) => {
+        if (block.blockName === 'table' && table == null)
+            table = block as unknown as ITableProbe;
+    });
+    return table;
+}
+
+function activeText(muya: Muya): string {
+    return (muya.editor.activeContentBlock as { text?: string } | null)?.text ?? 'null';
+}
+
+const DOC = 'before\n\n| A | B |\n| --- | --- |\n| one | two |\n\nafter\n';
+
+function deleteWholeTable(muya: Muya, { prime }: { prime: boolean }) {
+    const table = findTable(muya)!;
+    table.cellAt(1, 0).firstChild.setCursor(0, 0, true);
+
+    muya.editor.history.cutoff();
+    if (prime)
+        muya.editor.history.primeRecordSelection();
+    const outside = table.outsideContentInContext();
+    table.remove();
+    outside?.setCursor(0, 0, true);
+    muya.editor.jsonState.flush();
+    muya.editor.history.cutoff();
+
+    expect(findTable(muya)).toBeNull();
+    expect(activeText(muya)).toBe('after');
+}
+
+describe('caret restore across a whole-table delete undo', () => {
+    it('primed: the caret returns INTO the restored table cell it came from', () => {
+        const muya = bootMuya(DOC);
+        deleteWholeTable(muya, { prime: true });
+
+        muya.undo();
+
+        expect(findTable(muya)).not.toBeNull();
+        expect(activeText(muya)).toBe('one');
+    });
+
+    it('unprimed: the nearest-content fallback lands in the restored table, never the head', () => {
+        const muya = bootMuya(DOC);
+        deleteWholeTable(muya, { prime: false });
+
+        muya.undo();
+
+        // The recorded (post-delete) path now points at the re-inserted
+        // table; the caret lands on its first content — not on 'before'
+        // and not at the document head.
+        expect(findTable(muya)).not.toBeNull();
+        expect(activeText(muya)).toBe('A');
+    });
+});

--- a/third_party/muya/src/history/__tests__/undoCaretRestore.spec.ts
+++ b/third_party/muya/src/history/__tests__/undoCaretRestore.spec.ts
@@ -41,9 +41,13 @@ function bootMuya(markdown: string): Muya {
 }
 
 interface ITableProbe {
+    rowCount: number;
+    columnCount: number;
     cellAt: (row: number, column: number) => {
         firstChild: { text: string; setCursor: (b: number, e: number, u?: boolean) => void };
     };
+    insertRow: (offset: number) => { setCursor: (b: number, e: number, u?: boolean) => void };
+    insertColumn: (offset: number) => { setCursor: (b: number, e: number, u?: boolean) => void };
     outsideContentInContext: () => { setCursor: (b: number, e: number, u?: boolean) => void } | null;
     remove: () => void;
 }
@@ -102,5 +106,51 @@ describe('caret restore across a whole-table delete undo', () => {
         // and not at the document head.
         expect(findTable(muya)).not.toBeNull();
         expect(activeText(muya)).toBe('A');
+    });
+});
+
+describe('caret restore across TAIL insertions (#175 review gap)', () => {
+    // Inserting below the LAST row / right of the LAST column parks the
+    // caret at a tail index that the undo then removes — the recorded
+    // post-op path stops resolving entirely, which is exactly where the
+    // first-record stack fallback broke. Priming records the true
+    // before-command cell, so these must return there.
+    function primedCommand(muya: Muya, run: (table: ITableProbe) => void) {
+        muya.editor.history.cutoff();
+        muya.editor.history.primeRecordSelection();
+        run(findTable(muya)!);
+        muya.editor.jsonState.flush();
+        muya.editor.history.cutoff();
+    }
+
+    it('undoing an insert-below on the last row returns to the origin cell', () => {
+        const muya = bootMuya(DOC);
+        const table = findTable(muya)!;
+        table.cellAt(1, 0).firstChild.setCursor(1, 1, true);
+
+        primedCommand(muya, t => t.insertRow(2).setCursor(0, 0, true));
+        expect(findTable(muya)!.rowCount).toBe(3);
+
+        muya.undo();
+
+        expect(findTable(muya)!.rowCount).toBe(2);
+        expect(activeText(muya)).toBe('one');
+    });
+
+    it('undoing an insert-right on the last column returns to the origin cell', () => {
+        const muya = bootMuya(DOC);
+        const table = findTable(muya)!;
+        table.cellAt(1, 1).firstChild.setCursor(1, 1, true);
+
+        primedCommand(muya, (t) => {
+            t.insertColumn(2);
+            t.cellAt(1, 2)!.firstChild.setCursor(0, 0, true);
+        });
+        expect(findTable(muya)!.columnCount).toBe(3);
+
+        muya.undo();
+
+        expect(findTable(muya)!.columnCount).toBe(2);
+        expect(activeText(muya)).toBe('two');
     });
 });

--- a/third_party/muya/src/history/index.ts
+++ b/third_party/muya/src/history/index.ts
@@ -108,6 +108,7 @@ class History {
     private _lastRecorded: number = 0;
     private _lastInputKind: Nullable<TInputKind> = null;
     private _ignoreChange: boolean = false;
+    private _primedSelection: Nullable<IHistorySelection> = null;
     private _selectionStack: (Nullable<IHistorySelection>)[] = [];
     private _stack: IStack = {
         undo: [],
@@ -196,6 +197,7 @@ class History {
         this._selectionStack = [];
         this._lastRecorded = 0;
         this._ignoreChange = false;
+        this._primedSelection = null;
     }
 
     getHistory(): ISerializedHistory {
@@ -283,6 +285,18 @@ class History {
         this._lastRecorded = 0;
     }
 
+    /**
+     * Stamp the NEXT recorded operation with the CURRENT selection instead
+     * of the selection-stack approximation (which lags one record behind).
+     * Boundary-cut commands — the mobile table panel — call this right
+     * before mutating, so undoing e.g. a whole-table delete puts the caret
+     * back INTO the restored table where the user actually was, rather
+     * than restoring a shifted path that lands on a non-content block.
+     */
+    primeRecordSelection() {
+        this._primedSelection = this._selection.getSelection();
+    }
+
     markInputBoundary(inputType: string, data: Nullable<string>): void {
         const kind = classifyInputKind(inputType);
         if (kind == null)
@@ -314,7 +328,11 @@ class History {
         if (op.length === 0)
             return;
 
-        let selection = this._getLastSelection();
+        // The stack bookkeeping must advance regardless, so later records
+        // keep their previous-selection semantics.
+        const stackSelection = this._getLastSelection();
+        let selection = this._primedSelection ?? stackSelection;
+        this._primedSelection = null;
         this._stack.redo = [];
         let undoOperation = json1.type.invertWithDoc(op, asDoc(doc));
 

--- a/third_party/muya/src/history/index.ts
+++ b/third_party/muya/src/history/index.ts
@@ -298,7 +298,16 @@ class History {
         if (this._selectionStack.length > 2)
             this._selectionStack.shift();
 
-        return this._selectionStack.length === 2 ? this._selectionStack[0] : null;
+        // Two entries: the selection captured at the PREVIOUS record — the
+        // "before the op" approximation undo restores. One entry (the
+        // session's very first record): fall back to the CURRENT selection
+        // instead of null. Undoing that first op then re-resolves the
+        // recorded path against the post-undo tree, which seats the caret
+        // on the live neighbouring block — with null it restored NOTHING,
+        // leaving editor.activeContentBlock pointing into the removed
+        // subtree (the mobile table panel read that as "not in a table"
+        // and every structure command silently no-opped, #144 review).
+        return this._selectionStack[0] ?? null;
     }
 
     private _record(op: JSONOpList, doc: TState[]) {


### PR DESCRIPTION
Stacked on #175 (same engine region) — **the completing fix for #175's accepted review gap**. Fixes the device-reported caret teleport: **delete the table → undo → the table returns but the caret jumps to the document head**, and closes the disappearing-tail-path class (insert-below on the last row, insert-right on the last column) that #175's stack-approximation cannot cover.

## The chain

The undo entry's recorded selection is the history's one-record-behind approximation — for the delete that meant the **post-delete** caret (the paragraph after the table). Undo re-inserts the table exactly where that recorded path points; the paragraph-shaped path remainder misses inside the table, `queryBlock` resolves nothing, and `_restoreSelection` fell back to `focus()` — the document head. Tail insertions break the same way: the post-op caret sits at a tail index the undo removes, so the recorded path stops resolving entirely.

## Two-layer fix

- **`History.primeRecordSelection()`** — boundary-cut commands stamp the next entry with the TRUE before-command selection right before mutating (the adapter calls it inside the cutoff window, so all seven table commands inherit it). Undoing any table command now puts the caret back exactly where the user was — including the original cell inside the restored table after undoing delete-table, at the exact offset.
- **Longest-resolvable-prefix fallback** in `_restoreSelection` — when a recorded path no longer resolves (or resolves to a container), the caret lands collapsed at the nearest content under the deepest resolvable prefix. Unprimed entries — typing, legacy histories, redo paths — now land local to the edit instead of at the head.

## Verification (head 6f58f45)

- Engine specs pin both layers plus the tail class: primed exactness onto the original cell (`one`); the unprimed fallback landing on the restored table's first content (`A`) — never `before`/head; and **explicit tail regressions** (insert-below-last-row and insert-right-last-column undos returning to the origin cell) that fail on #175 alone. History folder **20/20**; **full Muya gate green** (typing-undo grouping and coalescing semantics untouched).
- E2E replays the device flows through the real toolbar undo button: the delete-table undo with an exact caret-offset assertion (`Xone` typed into the restored cell) and the tail insert-below flow re-inserting after undo. `mobile-table-structure` **10/10**.
- App unit 633/633, typecheck and lint clean. (A pleasing detail from test development: before pinning the caret to the cell start, the restore reproduced the user's original mid-word tap offset exactly — `oXne`.)
