### PR TITLE
Render authored soft breaks as <br> at the export DOM stage

### DIFF
--- a/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
+++ b/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { renderToStaticHTML } from '../renderToStaticHTML';
+import { MarkdownToHtml } from '../markdownToHtml';
+
+// marktext#3676 — a soft line break (a bare `\n` inside a block) shows as a
+// line break in the editor (`.mu-content` is pre-wrap) but collapsed to a
+// space on HTML/PDF export.
+//
+// Second attempt (#160/#4951 post-mortem): the token-level guard — deciding
+// "is this newline raw HTML?" from marked's token stream — required
+// emulating HTML-parser semantics and died under review. This design moves
+// the conversion to the DOM stage `renderHtml` already owns: after
+// sanitize + innerHTML, the BROWSER has authoritatively resolved raw-text
+// elements, nesting, and mismatched tags, so one `closest()` covers the
+// entire protection surface. The token layer contributes the single bit
+// only it knows — "this text came from a raw HTML token" — as a newline
+// sentinel, with no tag tracking at all.
+//
+// The parked suite's ground truths all hold: the sentinel carries every
+// raw-token newline (comment-adjacent ones included — marked folds them
+// into the html token) through the DOM pass verbatim, so the output
+// matches the token-level design case for case, minus the state machine.
+
+// happy-dom quirk: DOMPurify under happy-dom strips the FIRST element's
+// wrapper tags (verified directly: `<p>a</p>` -> `a`; real Chromium does
+// not do this). Every fixture leads with a sacrificial pad block so the
+// content under test never sits first. Test-environment workaround only.
+const PAD = '# pad\n\n';
+
+async function exportHtml(markdown: string) {
+    return new MarkdownToHtml(PAD + markdown).renderHtml();
+}
+
+describe('marktext#3676 — authored soft breaks render as <br> on export', () => {
+    it('renders a paragraph soft break as <br>', async () => {
+        expect(await exportHtml('line one\nline two\n')).toContain(
+            '<p>line one<br>line two</p>',
+        );
+    });
+
+    it('renders a tight-item soft break as <br>', async () => {
+        expect(await exportHtml('- line A\n  line B\n')).toContain(
+            '<li>line A<br>line B</li>',
+        );
+    });
+
+    it('renders a soft break between inline-wrapped lines as <br>', async () => {
+        expect(await exportHtml('- **left**\n  **right**\n')).toContain(
+            '<strong>left</strong><br><strong>right</strong>',
+        );
+    });
+
+    it('renders a soft break inside an inline span as <br>', async () => {
+        expect(await exportHtml('**left\nright**\n')).toContain(
+            '<strong>left<br>right</strong>',
+        );
+    });
+
+    it('renders a blockquote paragraph soft break as <br>', async () => {
+        expect(await exportHtml('> line one\n> line two\n')).toContain(
+            'line one<br>line two',
+        );
+    });
+
+    it('keeps a real hard break working (two trailing spaces)', async () => {
+        expect(await exportHtml('line one  \nline two\n')).toMatch(
+            /line one<br\s*\/?>\s*line two/,
+        );
+    });
+
+    it('reaches the final document through generate()', async () => {
+        const doc = await new MarkdownToHtml(PAD + '- line A\n  line B\n').generate({
+            title: 't',
+            inlineStyles: false,
+        });
+        expect(doc).toContain('line A<br>line B');
+    });
+
+    it('leaves the conformance renderer untouched', () => {
+        const html = renderToStaticHTML('line one\nline two\n');
+        expect(html).toContain('line one\nline two');
+        expect(html).not.toContain('<br>');
+    });
+});
+
+describe('everything that is NOT an authored soft break stays untouched', () => {
+    it('keeps canonical block separators between paragraphs', async () => {
+        const html = await exportHtml('para one\n\npara two\n');
+        expect(html).toContain('</p>\n<p>');
+        expect(html).not.toContain('<br>');
+    });
+
+    it('keeps the newline before a nested list structural', async () => {
+        const html = await exportHtml('- a\n  - b\n');
+        expect(html).not.toContain('a<br>');
+        expect(html).toContain('<ul>');
+    });
+
+    it('preserves an authored &nbsp; item next to a nested list', async () => {
+        const html = await exportHtml('- &nbsp;\n  - child\n');
+        expect(html).not.toContain('<br>');
+    });
+
+    it('keeps loose-item paragraph boundaries structural', async () => {
+        const html = await exportHtml('- para one\n\n  para two\n');
+        expect(html).not.toContain('<br>');
+    });
+
+    it('collapses a code-span newline to a space per spec, never <br>', async () => {
+        expect(await exportHtml('a `x\ny` b\n')).toContain('<code>x y</code>');
+    });
+
+    it('keeps fenced code content verbatim', async () => {
+        const html = await exportHtml('```\nline one\nline two\n```\n');
+        expect(html).toContain('line one\nline two');
+        expect(html).not.toContain('line one<br>');
+    });
+
+    it('keeps raw-HTML formatting newlines verbatim (raw <p>)', async () => {
+        // At the DOM stage a raw-authored <p> and a markdown paragraph are
+        // the same element — the raw-newline sentinel is what keeps this
+        // distinction alive across the parse.
+        const html = await exportHtml(
+            '<p>\n<strong>left</strong>\n<strong>right</strong>\n</p>\n',
+        );
+        expect(html).toContain(
+            '<p>\n<strong>left</strong>\n<strong>right</strong>\n</p>',
+        );
+        expect(html).not.toContain('<br>');
+    });
+
+    it('keeps raw blockquote inline whitespace untouched', async () => {
+        const raw
+            = '<blockquote><strong>left</strong> <strong>right</strong></blockquote>';
+        expect(await exportHtml(`${raw}\n`)).toContain(raw);
+    });
+
+    it('keeps inline raw-text element content verbatim (<pre>)', async () => {
+        // The war case of the token-level attempt: marked hands the interior
+        // of an inline <pre> over as ordinary text tokens. Post-parse, the
+        // DOM knows exactly where the pre is.
+        const html = await exportHtml('text <pre>a\nb</pre> more\n');
+        expect(html).toContain('a\nb');
+        expect(html).not.toContain('a<br>b');
+    });
+
+    it('keeps inline raw-text element content verbatim (<textarea>)', async () => {
+        const html = await exportHtml('text <textarea>a\nb</textarea> more\n');
+        expect(html).toContain('a\nb');
+        expect(html).not.toContain('a<br>b');
+    });
+
+    it('a mismatched closing tag inside a raw-text element cannot corrupt it', async () => {
+        // Token-level this took a two-tier state machine; the browser's
+        // parser settles it before the pass ever runs.
+        const html = await exportHtml(
+            'before <textarea>left\n</style>\nright</textarea> after\n',
+        );
+        expect(html).not.toContain('left<br>');
+        expect(html).not.toContain('<br>\nright');
+    });
+
+    it('keeps legitimate nesting like <pre><code> protected through the inner close', async () => {
+        const html = await exportHtml('<pre><code>a\nb</code>\nc\nd</pre>\n');
+        expect(html).not.toContain('<br>');
+    });
+
+    it('keeps raw newlines inside attributes intact', async () => {
+        const html = await exportHtml('<div title="a\nb">x</div>\n');
+        expect(html).toContain('title="a\nb"');
+    });
+
+    it('keeps table cells untouched', async () => {
+        const html = await exportHtml('| a | b |\n| - | - |\n| c | d |\n');
+        expect(html).not.toContain('<br>');
+    });
+});
+
+describe('raw-token newlines survive verbatim', () => {
+    it('keeps the newline riding an inline comment token untouched', async () => {
+        // marked folds the newline after the comment into the html token
+        // itself; the sentinel walks it through the DOM pass verbatim —
+        // byte-identical to the parked token-level ground truth.
+        const html = await exportHtml('- left\n  <!-- c -->\n  right\n');
+        expect(html).toContain('left<!-- c -->\nright');
+        expect(html).not.toContain('<br>');
+    });
+});

--- a/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
+++ b/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
@@ -18,11 +18,13 @@ import { MarkdownToHtml } from '../markdownToHtml';
 // entire protection surface. The token layer contributes the single bit
 // only it knows — "this newline is markdown text, not raw HTML" — as a
 // sentinel inside TEXT tokens, with no tag tracking at all. The marking
-// direction is the security and correctness contract: text-token content
-// is escaped text by construction, so the sentinel can never sit in tag
-// syntax, an attribute value, or comment data — raw HTML reaches
-// DOMPurify and the parser byte-identical to a sentinel-free render, and
-// the DOM pass resolves every sentinel to either <br> or `\n` (a total
+// direction is the security and correctness contract, with two legs:
+// BY CONSTRUCTION, escaped text-token content cannot originate tag
+// syntax or comment data, so raw HTML reaches DOMPurify and the parser
+// byte-identical to a sentinel-free render; BY SINK INVENTORY, the one
+// text-token path that renders into an ATTRIBUTE (image labels -> alt)
+// is exempted from marking, so every sentinel lands in a DOM Text node
+// and the DOM pass resolves each to either <br> or `\n` (a total
 // function; nothing can leak into the output).
 //
 // The parked suite's ground truths all hold: raw-token newlines

--- a/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
+++ b/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { describe, expect, it } from 'vitest';
+import { isValidAttribute } from '../../utils/dompurify';
 import { renderToStaticHTML } from '../renderToStaticHTML';
 import { MarkdownToHtml } from '../markdownToHtml';
 
@@ -15,13 +16,19 @@ import { MarkdownToHtml } from '../markdownToHtml';
 // sanitize + innerHTML, the BROWSER has authoritatively resolved raw-text
 // elements, nesting, and mismatched tags, so one `closest()` covers the
 // entire protection surface. The token layer contributes the single bit
-// only it knows — "this text came from a raw HTML token" — as a newline
-// sentinel, with no tag tracking at all.
+// only it knows — "this newline is markdown text, not raw HTML" — as a
+// sentinel inside TEXT tokens, with no tag tracking at all. The marking
+// direction is the security and correctness contract: text-token content
+// is escaped text by construction, so the sentinel can never sit in tag
+// syntax, an attribute value, or comment data — raw HTML reaches
+// DOMPurify and the parser byte-identical to a sentinel-free render, and
+// the DOM pass resolves every sentinel to either <br> or `\n` (a total
+// function; nothing can leak into the output).
 //
-// The parked suite's ground truths all hold: the sentinel carries every
-// raw-token newline (comment-adjacent ones included — marked folds them
-// into the html token) through the DOM pass verbatim, so the output
-// matches the token-level design case for case, minus the state machine.
+// The parked suite's ground truths all hold: raw-token newlines
+// (comment-adjacent ones included — marked folds them into the html
+// token) are simply never touched, so the output matches the token-level
+// design case for case, minus the state machine.
 
 // happy-dom quirk: DOMPurify under happy-dom strips the FIRST element's
 // wrapper tags (verified directly: `<p>a</p>` -> `a`; real Chromium does
@@ -29,8 +36,15 @@ import { MarkdownToHtml } from '../markdownToHtml';
 // content under test never sits first. Test-environment workaround only.
 const PAD = '# pad\n\n';
 
+// The sentinel is random per render, but its prefix is stable. Every
+// sentinel must resolve inside the DOM pass, so the prefix showing up in
+// ANY output is an implementation leak — assert on every export.
+const SENTINEL_PREFIX = 'mu-soft-br-';
+
 async function exportHtml(markdown: string) {
-    return new MarkdownToHtml(PAD + markdown).renderHtml();
+    const html = await new MarkdownToHtml(PAD + markdown).renderHtml();
+    expect(html).not.toContain(SENTINEL_PREFIX);
+    return html;
 }
 
 describe('marktext#3676 — authored soft breaks render as <br> on export', () => {
@@ -120,8 +134,9 @@ describe('everything that is NOT an authored soft break stays untouched', () => 
 
     it('keeps raw-HTML formatting newlines verbatim (raw <p>)', async () => {
         // At the DOM stage a raw-authored <p> and a markdown paragraph are
-        // the same element — the raw-newline sentinel is what keeps this
-        // distinction alive across the parse.
+        // the same element — the soft-break sentinel marking only markdown
+        // text is what keeps this distinction alive across the parse: raw
+        // newlines are never marked, so the pass never visits them.
         const html = await exportHtml(
             '<p>\n<strong>left</strong>\n<strong>right</strong>\n</p>\n',
         );
@@ -139,8 +154,10 @@ describe('everything that is NOT an authored soft break stays untouched', () => 
 
     it('keeps inline raw-text element content verbatim (<pre>)', async () => {
         // The war case of the token-level attempt: marked hands the interior
-        // of an inline <pre> over as ordinary text tokens. Post-parse, the
-        // DOM knows exactly where the pre is.
+        // of an inline <pre> over as ordinary TEXT tokens, so these newlines
+        // DO get sentinel-marked — and post-parse the DOM knows exactly
+        // where the pre is, so the pass restores them to `\n` instead of
+        // converting.
         const html = await exportHtml('text <pre>a\nb</pre> more\n');
         expect(html).toContain('a\nb');
         expect(html).not.toContain('a<br>b');
@@ -167,15 +184,35 @@ describe('everything that is NOT an authored soft break stays untouched', () => 
         expect(html).not.toContain('<br>');
     });
 
-    it('downgrades raw attribute newlines to spaces', async () => {
-        // Attribute sentinels restore as SPACE, not `\n`: URL parsing
-        // strips tab/newline/CR but preserves interior spaces, so a
-        // dangerous scheme can never reassemble around the restored
-        // character (see the href smuggling test below). An attribute
-        // newline is collapsible whitespace semantically, so the space
-        // is presentation-equivalent.
+    it('keeps raw attribute newlines verbatim', async () => {
+        // Raw HTML is never sentinelized, so the attribute value reaches
+        // DOMPurify and the serializer with its real newline — full
+        // fidelity, and DOMPurify judges the true value (see the
+        // javascript: smuggling tests below).
         const html = await exportHtml('<div title="a\nb">x</div>\n');
-        expect(html).toContain('title="a b"');
+        expect(html).toContain('title="a\nb"');
+    });
+
+    it('keeps multiline start tags intact (newline between attributes)', async () => {
+        // A sentinel in tag-syntax whitespace would glue itself onto the
+        // next attribute name and destroy it; unmarked raw HTML parses
+        // exactly as authored.
+        const html = await exportHtml('<div id="kept-id"\nclass="kept-class">x</div>\n');
+        expect(html).toContain('id="kept-id"');
+        expect(html).toContain('class="kept-class"');
+    });
+
+    it('keeps multiline start tags intact (newline after the tag name)', async () => {
+        const html = await exportHtml('<div\nclass="kept-class">x</div>\n');
+        expect(html).toContain('<div class="kept-class">x</div>');
+    });
+
+    it('keeps newlines inside raw comment data verbatim', async () => {
+        // Comments parse into Comment nodes, which SHOW_TEXT walkers never
+        // visit — safe here because raw comment data is never marked in
+        // the first place.
+        const html = await exportHtml('before <!-- left\nright --> after\n');
+        expect(html).toContain('<!-- left\nright -->');
     });
 
     it('keeps table cells untouched', async () => {
@@ -205,35 +242,80 @@ describe('everything that is NOT an authored soft break stays untouched', () => 
 describe('raw-token newlines survive verbatim', () => {
     it('keeps the newline riding an inline comment token untouched', async () => {
         // marked folds the newline after the comment into the html token
-        // itself; the sentinel walks it through the DOM pass verbatim —
-        // byte-identical to the parked token-level ground truth.
+        // itself; unmarked raw newlines pass through the DOM stage
+        // verbatim — byte-identical to the parked token-level ground
+        // truth.
         const html = await exportHtml('- left\n  <!-- c -->\n  right\n');
         expect(html).toContain('left<!-- c -->\nright');
         expect(html).not.toContain('<br>');
     });
 });
 
-describe('the sentinel round-trip cannot be abused', () => {
-    it('cannot smuggle a javascript: URI through an attribute newline', async () => {
-        // The attack the string-level restore allowed: `java\nscript:`
-        // rides through DOMPurify as an inert sentinel-carrying value,
-        // then the post-serialization swap turns it back into a newline
-        // that URL parsing strips — a working javascript: href. Restoring
-        // ON the DOM before serialization, and restoring attributes as
-        // SPACE, kills both halves: nothing textual changes after
-        // sanitization, and a space never disappears from URL parsing.
+describe('the sentinel cannot weaken sanitization or leak', () => {
+    // The security contract of the flipped marking direction: this
+    // feature never rewrites raw HTML, so DOMPurify judges the authored
+    // bytes and its verdict is final — no pass of ours runs after it
+    // that could turn an inert value into a dangerous one. (Both prior
+    // designs failed exactly there: the sentinel made
+    // `href="\njavascript:alert(1)"` look like an inert relative URL at
+    // check time, and the restore — even a space downgrade, since URL
+    // parsing strips LEADING spaces — re-armed the scheme afterwards.)
+    //
+    // happy-dom cannot assert the browser-side removal: its DOMPurify
+    // attribute pass is inert (probe: even a literal javascript: href
+    // survives sanitize() here, while real Chromium strips it). What IS
+    // assertable in this environment, and is the property this feature
+    // owns, is byte fidelity: the authored whitespace reaches the
+    // output unlaundered, so DOMPurify's policy — proven below via its
+    // string-level isValidAttribute, which does work here — is applied
+    // to exactly what the author wrote.
+    it('never launders a LEADING attribute newline into a space', async () => {
+        const html = await exportHtml('<a href="\njavascript:alert(1)">x</a>\n');
+        expect(html).toContain('href="\njavascript:alert(1)"');
+        expect(html).not.toContain('href=" javascript:');
+    });
+
+    it('never launders an interior attribute newline', async () => {
         const html = await exportHtml('<a href="java\nscript:alert(1)">x</a>\n');
+        expect(html).toContain('href="java\nscript:alert(1)"');
+        expect(html).not.toContain('href="java script:');
         expect(html).not.toContain('javascript:');
-        expect(html).not.toContain('java\nscript');
-        expect(html).not.toContain('java&#10;script');
+    });
+
+    it('DOMPurify itself rejects the whitespace-split URIs we hand through', () => {
+        // The browser-side half of the contract, testable here because
+        // isValidAttribute is a pure string check (no DOM involved).
+        for (const value of [
+            '\njavascript:alert(1)',
+            ' javascript:alert(1)',
+            'java\nscript:alert(1)',
+            'jav\tascript:alert(1)',
+            'javascript:alert(1)\n',
+        ]) {
+            expect(isValidAttribute('a', 'href', value)).toBe(false);
+        }
     });
 
     it('leaves authored text that looks like a sentinel untouched', async () => {
         // The sentinel is freshly random per render, so authored content
         // — including a verbatim copy of some earlier render's token —
-        // cannot collide with it and get rewritten into a newline.
-        const literal = 'mu-raw-nl-00112233445566778899aabbccddeeff';
-        const html = await exportHtml(`before ${literal} after\n`);
+        // cannot collide with it and get rewritten into a break.
+        const literal = 'mu-soft-br-00112233445566778899aabbccddeeff';
+        const html = await new MarkdownToHtml(
+            `${PAD}before ${literal} after\n`,
+        ).renderHtml();
         expect(html).toContain(literal);
+    });
+});
+
+describe('conversion cost stays linear', () => {
+    it('converts a very long single paragraph without quadratic blowup', async () => {
+        // Per-boundary prefix/suffix array copies made this quadratic
+        // (~3s at 16k lines); the precomputed emptiness frontiers keep it
+        // linear. The vitest timeout is the regression tripwire.
+        const lines = Array.from({ length: 8000 }, (_, i) => `line ${i}`);
+        const html = await exportHtml(`${lines.join('\n')}\n`);
+        expect(html).toContain('line 0<br>line 1<br>');
+        expect(html).toContain('line 7998<br>line 7999');
     });
 });

--- a/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
+++ b/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
@@ -167,14 +167,38 @@ describe('everything that is NOT an authored soft break stays untouched', () => 
         expect(html).not.toContain('<br>');
     });
 
-    it('keeps raw newlines inside attributes intact', async () => {
+    it('downgrades raw attribute newlines to spaces', async () => {
+        // Attribute sentinels restore as SPACE, not `\n`: URL parsing
+        // strips tab/newline/CR but preserves interior spaces, so a
+        // dangerous scheme can never reassemble around the restored
+        // character (see the href smuggling test below). An attribute
+        // newline is collapsible whitespace semantically, so the space
+        // is presentation-equivalent.
         const html = await exportHtml('<div title="a\nb">x</div>\n');
-        expect(html).toContain('title="a\nb"');
+        expect(html).toContain('title="a b"');
     });
 
     it('keeps table cells untouched', async () => {
         const html = await exportHtml('| a | b |\n| - | - |\n| c | d |\n');
         expect(html).not.toContain('<br>');
+    });
+
+    it('keeps serializer newlines between nested-list siblings structural', async () => {
+        // A multi-child nested list puts `\n` text nodes directly under
+        // the inner <ul> (between the <li>s) — direct children of a
+        // structural container are serializer whitespace, never breaks.
+        const html = await exportHtml('- parent\n  - c1\n  - c2\n');
+        expect(html).not.toContain('<br>');
+        expect(html).toContain('<li>c1</li>');
+        expect(html).toContain('<li>c2</li>');
+    });
+
+    it('keeps a table nested in a list item free of <br>', async () => {
+        const html = await exportHtml(
+            '- item\n\n  | a | b |\n  | - | - |\n  | c | d |\n',
+        );
+        expect(html).not.toContain('<br>');
+        expect(html).toContain('<table>');
     });
 });
 
@@ -186,5 +210,30 @@ describe('raw-token newlines survive verbatim', () => {
         const html = await exportHtml('- left\n  <!-- c -->\n  right\n');
         expect(html).toContain('left<!-- c -->\nright');
         expect(html).not.toContain('<br>');
+    });
+});
+
+describe('the sentinel round-trip cannot be abused', () => {
+    it('cannot smuggle a javascript: URI through an attribute newline', async () => {
+        // The attack the string-level restore allowed: `java\nscript:`
+        // rides through DOMPurify as an inert sentinel-carrying value,
+        // then the post-serialization swap turns it back into a newline
+        // that URL parsing strips — a working javascript: href. Restoring
+        // ON the DOM before serialization, and restoring attributes as
+        // SPACE, kills both halves: nothing textual changes after
+        // sanitization, and a space never disappears from URL parsing.
+        const html = await exportHtml('<a href="java\nscript:alert(1)">x</a>\n');
+        expect(html).not.toContain('javascript:');
+        expect(html).not.toContain('java\nscript');
+        expect(html).not.toContain('java&#10;script');
+    });
+
+    it('leaves authored text that looks like a sentinel untouched', async () => {
+        // The sentinel is freshly random per render, so authored content
+        // — including a verbatim copy of some earlier render's token —
+        // cannot collide with it and get rewritten into a newline.
+        const literal = 'mu-raw-nl-00112233445566778899aabbccddeeff';
+        const html = await exportHtml(`before ${literal} after\n`);
+        expect(html).toContain(literal);
     });
 });

--- a/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
+++ b/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
@@ -207,12 +207,35 @@ describe('everything that is NOT an authored soft break stays untouched', () => 
         expect(html).toContain('<div class="kept-class">x</div>');
     });
 
-    it('keeps newlines inside raw comment data verbatim', async () => {
+    it('never marks raw comment data (observable via happy-dom)', async () => {
         // Comments parse into Comment nodes, which SHOW_TEXT walkers never
         // visit — safe here because raw comment data is never marked in
-        // the first place.
+        // the first place. Environment note: happy-dom keeps the comment
+        // observable, which makes it a leak probe; PRODUCTION DOMPurify
+        // removes comments outright (pre-existing, sentinel-free
+        // behavior), so this pins "no sentinel ever enters comment data",
+        // not byte-fidelity of comments in shipped exports.
         const html = await exportHtml('before <!-- left\nright --> after\n');
         expect(html).toContain('<!-- left\nright -->');
+    });
+
+    it('keeps a multiline image label out of the sentinel pass (inline)', async () => {
+        // The one place a text token does NOT become a DOM Text node:
+        // marked renders image-label text tokens into the `alt`
+        // attribute, which no text-node pass can visit. The label subtree
+        // is therefore never marked, and alt keeps marked's own newline
+        // (the exportHtml helper asserts no sentinel leaked).
+        const html = await exportHtml(
+            '![alt\ntext](https://example.test/image.png)\n',
+        );
+        expect(html).toContain('alt="alt\ntext"');
+    });
+
+    it('keeps a multiline image label out of the sentinel pass (reference)', async () => {
+        const html = await exportHtml(
+            '![alt\ntext][img]\n\n[img]: https://example.test/image.png\n',
+        );
+        expect(html).toContain('alt="alt\ntext"');
     });
 
     it('keeps table cells untouched', async () => {

--- a/third_party/muya/src/state/markdownToHtml.ts
+++ b/third_party/muya/src/state/markdownToHtml.ts
@@ -31,9 +31,26 @@ const CDN_STYLESHEET_LINKS = `  <!-- https://cdnjs.com/libraries/github-markdown
 // sanitize + DOM stage (#3676): raw-HTML formatting whitespace and
 // authored soft breaks are indistinguishable once parsed, so the marked
 // renderer marks raw newlines before parsing and `renderHtml` swaps them
-// back after the soft-break pass. Private-use characters survive both
-// DOMPurify and innerHTML parsing in text and attribute positions alike.
-const RAW_NEWLINE_SENTINEL = 'mu:raw-nl';
+// back ON THE DOM, before serialization (see _restoreRawNewlines for the
+// security contract). The marker is freshly RANDOM per render, so
+// authored content cannot collide with it — not even through numeric
+// character references, which no input-scan check could enumerate.
+function pickRawNewlineSentinel(): string {
+    const bytes = new Uint8Array(16);
+    if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+        crypto.getRandomValues(bytes);
+    }
+    else {
+        for (let i = 0; i < bytes.length; i++)
+            bytes[i] = Math.floor(Math.random() * 256);
+    }
+
+    let token = 'mu-raw-nl-';
+    for (const byte of bytes)
+        token += byte.toString(16).padStart(2, '0');
+
+    return token;
+}
 
 // Containers whose text newlines are CONTENT, never soft breaks. The
 // browser's parser has already resolved raw-text elements, nesting, and
@@ -42,14 +59,19 @@ const RAW_NEWLINE_SENTINEL = 'mu:raw-nl';
 // review rounds of HTML-parser emulation for. `.katex`/`math`/`svg`
 // guard generated math and diagram output.
 const SOFT_BREAK_PROTECTED
-    = 'pre, code, kbd, script, style, textarea, title, svg, math, .katex';
+    = 'pre, code, kbd, script, style, textarea, title, svg, math, table, .katex';
 
-// Block-level elements: a newline touching one of these (or a container
-// edge) separates BLOCKS — marked's own serialization shape — and must
-// not become a visible break. Everything else adjacent is phrasing
-// content, where a newline is an authored soft break.
+// Containers whose DIRECT text children are always serializer whitespace
+// (between <li>s, between table sections/rows/cells): never convert there.
+const STRUCTURAL_PARENT_TAG
+    = /^(?:UL|OL|MENU|DL|TABLE|THEAD|TBODY|TFOOT|TR|COLGROUP|SELECT|OPTGROUP)$/;
+
+// Block-level / structural elements: a newline touching one of these (or
+// a container edge) separates STRUCTURE — marked's own serialization
+// shape — and must not become a visible break. Everything else adjacent
+// is phrasing content, where a newline is an authored soft break.
 const BLOCKISH_TAG
-    = /^(?:ADDRESS|ARTICLE|ASIDE|BLOCKQUOTE|DETAILS|DIV|DL|DD|DT|FIELDSET|FIGCAPTION|FIGURE|FOOTER|FORM|H[1-6]|HEADER|HR|MAIN|NAV|OL|P|PRE|SECTION|TABLE|UL)$/;
+    = /^(?:ADDRESS|ARTICLE|ASIDE|BLOCKQUOTE|CAPTION|COL|COLGROUP|DETAILS|DIV|DL|DD|DT|FIELDSET|FIGCAPTION|FIGURE|FOOTER|FORM|H[1-6]|HEADER|HR|LI|MAIN|NAV|OL|P|PRE|SECTION|TABLE|TBODY|TD|TFOOT|TH|THEAD|TR|UL)$/;
 
 export class MarkdownToHtml {
     private _exportContainer: HTMLDivElement | null = null;
@@ -81,6 +103,8 @@ export class MarkdownToHtml {
     private _convertSoftBreaks(text: Text) {
         const parent = text.parentElement;
         if (!parent || parent.closest(SOFT_BREAK_PROTECTED))
+            return;
+        if (STRUCTURAL_PARENT_TAG.test(parent.tagName))
             return;
         if (!parent.closest('p, li'))
             return;
@@ -122,6 +146,42 @@ export class MarkdownToHtml {
 
         if (converted)
             text.parentNode!.replaceChild(fragment, text);
+    }
+
+    /**
+     * Swap the raw-newline sentinels back, ON THE DOM and BEFORE
+     * serialization — nothing textual is ever modified after the
+     * sanitized document is serialized (the string-level restore this
+     * replaces let `href="java<sentinel>script:alert(1)"` pass DOMPurify
+     * and re-materialize as a newline that URL normalization strips).
+     *
+     * - TEXT nodes restore the real `\n`: text-node mutation cannot cross
+     *   into markup by construction.
+     * - ATTRIBUTE values restore a SPACE instead. Attribute newlines are
+     *   collapsible whitespace semantically, and space is the provably
+     *   safe direction: URL parsing strips tab/newline/CR but preserves
+     *   interior spaces, so a scheme can never reassemble. (Deleting the
+     *   sentinel would be the DANGEROUS direction — `java` + `script:`
+     *   joins.) Sentinels that landed in attribute NAMES (a newline
+     *   between attributes) are junk attributes DOMPurify already
+     *   stripped before this pass.
+     */
+    private _restoreRawNewlines(container: HTMLElement, sentinel: string) {
+        const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+        const texts: Text[] = [];
+        for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+            if ((node as Text).data.includes(sentinel))
+                texts.push(node as Text);
+        }
+        for (const text of texts)
+            text.data = text.data.split(sentinel).join('\n');
+
+        for (const element of container.querySelectorAll('*')) {
+            for (const attribute of element.attributes) {
+                if (attribute.value.includes(sentinel))
+                    attribute.value = attribute.value.split(sentinel).join(' ');
+            }
+        }
     }
 
     private async _renderMermaid() {
@@ -274,13 +334,14 @@ export class MarkdownToHtml {
     // render pure html by marked
     async renderHtml() {
         const footnote = this._muya?.options?.footnote ?? false;
+        const rawNewlineSentinel = pickRawNewlineSentinel();
         let html = getHighlightHtml(this.markdown, {
             superSubScript: this._muya?.options?.superSubScript ?? true,
             footnote,
             isGitlabCompatibilityEnabled:
         this._muya?.options?.isGitlabCompatibilityEnabled ?? true,
             math: this._muya?.options?.math ?? true,
-        }, { rawNewlineSentinel: RAW_NEWLINE_SENTINEL });
+        }, { rawNewlineSentinel });
 
         // Post-process footnotes into the standard GFM / pandoc shape (inline
         // numbered <sup> refs + bottom <section class="footnotes"> with
@@ -309,8 +370,11 @@ export class MarkdownToHtml {
 
         // Authored soft breaks -> <br> (#3676), on the parsed DOM where
         // the browser has already resolved everything the token stream
-        // cannot express.
+        // cannot express — then restore raw-token newlines, still on the
+        // DOM: serialization is the last step and nothing rewrites the
+        // serialized string afterwards.
         this._renderSoftBreaks(exportContainer);
+        this._restoreRawNewlines(exportContainer, rawNewlineSentinel);
 
         let result = exportContainer.innerHTML;
         exportContainer.remove();
@@ -328,10 +392,6 @@ export class MarkdownToHtml {
         });
 
         this._exportContainer = null;
-
-        // Raw-HTML newlines ride through the DOM pass as sentinels (text
-        // and attribute positions alike); a string-wide swap restores them.
-        result = result.split(RAW_NEWLINE_SENTINEL).join('\n');
 
         return `<article class="markdown-body">${result}</article>`;
     }

--- a/third_party/muya/src/state/markdownToHtml.ts
+++ b/third_party/muya/src/state/markdownToHtml.ts
@@ -27,10 +27,102 @@ const CDN_STYLESHEET_LINKS = `  <!-- https://cdnjs.com/libraries/github-markdown
   <!-- https://cdnjs.com/libraries/prism -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/themes/prism.min.css" integrity="sha512-/mZ1FHPkg6EKcxo0fKXF51ak6Cr2ocgDi5ytaTBjsQZIH/RNs6GF6+oId/vPe3eJB836T36nXwVh/WBl/cWT4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />`;
 
+// Sentinel standing in for `\n` INSIDE raw HTML tokens through the
+// sanitize + DOM stage (#3676): raw-HTML formatting whitespace and
+// authored soft breaks are indistinguishable once parsed, so the marked
+// renderer marks raw newlines before parsing and `renderHtml` swaps them
+// back after the soft-break pass. Private-use characters survive both
+// DOMPurify and innerHTML parsing in text and attribute positions alike.
+const RAW_NEWLINE_SENTINEL = 'mu:raw-nl';
+
+// Containers whose text newlines are CONTENT, never soft breaks. The
+// browser's parser has already resolved raw-text elements, nesting, and
+// mismatched tags by the time the DOM pass runs — this one selector is
+// the entire protection the token-level attempt (#4951/#160) needed ten
+// review rounds of HTML-parser emulation for. `.katex`/`math`/`svg`
+// guard generated math and diagram output.
+const SOFT_BREAK_PROTECTED
+    = 'pre, code, kbd, script, style, textarea, title, svg, math, .katex';
+
+// Block-level elements: a newline touching one of these (or a container
+// edge) separates BLOCKS — marked's own serialization shape — and must
+// not become a visible break. Everything else adjacent is phrasing
+// content, where a newline is an authored soft break.
+const BLOCKISH_TAG
+    = /^(?:ADDRESS|ARTICLE|ASIDE|BLOCKQUOTE|DETAILS|DIV|DL|DD|DT|FIELDSET|FIGCAPTION|FIGURE|FOOTER|FORM|H[1-6]|HEADER|HR|MAIN|NAV|OL|P|PRE|SECTION|TABLE|UL)$/;
+
 export class MarkdownToHtml {
     private _exportContainer: HTMLDivElement | null = null;
 
     constructor(public markdown: string, private _muya?: Muya) {}
+
+    /**
+     * Render authored soft line breaks as `<br>` (#3676). CommonMark
+     * explicitly permits a renderer to emit soft breaks as hard line
+     * breaks; the editor already SHOWS them as line breaks
+     * (`.mu-content` is pre-wrap), so exports must match. Runs on the
+     * sanitized export DOM: only text nodes in phrasing context under a
+     * paragraph-like host (`p`, `li`) convert, protected containers and
+     * block-structural newlines stay verbatim, and marked's canonical
+     * string output is never modified.
+     */
+    private _renderSoftBreaks(container: HTMLElement) {
+        const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+        const texts: Text[] = [];
+        for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+            if ((node as Text).data.includes('\n'))
+                texts.push(node as Text);
+        }
+
+        for (const text of texts)
+            this._convertSoftBreaks(text);
+    }
+
+    private _convertSoftBreaks(text: Text) {
+        const parent = text.parentElement;
+        if (!parent || parent.closest(SOFT_BREAK_PROTECTED))
+            return;
+        if (!parent.closest('p, li'))
+            return;
+
+        // A newline at the node's EDGE next to a block-level sibling (a
+        // nested list inside a tight item, a paragraph boundary inside a
+        // loose one) — or at the container edge itself — is structural.
+        const structuralBefore
+            = text.previousSibling == null
+                || (isHTMLElement(text.previousSibling)
+                    && BLOCKISH_TAG.test(text.previousSibling.tagName));
+        const structuralAfter
+            = text.nextSibling == null
+                || (isHTMLElement(text.nextSibling)
+                    && BLOCKISH_TAG.test(text.nextSibling.tagName));
+
+        const parts = text.data.split('\n');
+        const fragment = document.createDocumentFragment();
+        let converted = false;
+        for (let i = 0; i < parts.length; i++) {
+            if (i > 0) {
+                // The boundary between parts[i-1] and parts[i].
+                const leadingEmpty = parts.slice(0, i).every(part => part === '');
+                const trailingEmpty = parts.slice(i).every(part => part === '');
+                const structural
+                    = (leadingEmpty && structuralBefore)
+                        || (trailingEmpty && structuralAfter);
+                if (structural) {
+                    fragment.appendChild(document.createTextNode('\n'));
+                }
+                else {
+                    fragment.appendChild(document.createElement('br'));
+                    converted = true;
+                }
+            }
+            if (parts[i])
+                fragment.appendChild(document.createTextNode(parts[i]));
+        }
+
+        if (converted)
+            text.parentNode!.replaceChild(fragment, text);
+    }
 
     private async _renderMermaid() {
         const codes = this._exportContainer!.querySelectorAll(
@@ -188,7 +280,7 @@ export class MarkdownToHtml {
             isGitlabCompatibilityEnabled:
         this._muya?.options?.isGitlabCompatibilityEnabled ?? true,
             math: this._muya?.options?.math ?? true,
-        });
+        }, { rawNewlineSentinel: RAW_NEWLINE_SENTINEL });
 
         // Post-process footnotes into the standard GFM / pandoc shape (inline
         // numbered <sup> refs + bottom <section class="footnotes"> with
@@ -215,6 +307,11 @@ export class MarkdownToHtml {
         // renderer (`renderToStaticHTML`) is deliberately left untouched.
         this._injectHeadingIds(exportContainer);
 
+        // Authored soft breaks -> <br> (#3676), on the parsed DOM where
+        // the browser has already resolved everything the token stream
+        // cannot express.
+        this._renderSoftBreaks(exportContainer);
+
         let result = exportContainer.innerHTML;
         exportContainer.remove();
 
@@ -231,6 +328,10 @@ export class MarkdownToHtml {
         });
 
         this._exportContainer = null;
+
+        // Raw-HTML newlines ride through the DOM pass as sentinels (text
+        // and attribute positions alike); a string-wide swap restores them.
+        result = result.split(RAW_NEWLINE_SENTINEL).join('\n');
 
         return `<article class="markdown-body">${result}</article>`;
     }

--- a/third_party/muya/src/state/markdownToHtml.ts
+++ b/third_party/muya/src/state/markdownToHtml.ts
@@ -27,15 +27,20 @@ const CDN_STYLESHEET_LINKS = `  <!-- https://cdnjs.com/libraries/github-markdown
   <!-- https://cdnjs.com/libraries/prism -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/themes/prism.min.css" integrity="sha512-/mZ1FHPkg6EKcxo0fKXF51ak6Cr2ocgDi5ytaTBjsQZIH/RNs6GF6+oId/vPe3eJB836T36nXwVh/WBl/cWT4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />`;
 
-// Sentinel standing in for `\n` INSIDE raw HTML tokens through the
+// Sentinel standing in for `\n` INSIDE markdown text tokens through the
 // sanitize + DOM stage (#3676): raw-HTML formatting whitespace and
-// authored soft breaks are indistinguishable once parsed, so the marked
-// renderer marks raw newlines before parsing and `renderHtml` swaps them
-// back ON THE DOM, before serialization (see _restoreRawNewlines for the
-// security contract). The marker is freshly RANDOM per render, so
-// authored content cannot collide with it — not even through numeric
-// character references, which no input-scan check could enumerate.
-function pickRawNewlineSentinel(): string {
+// authored soft breaks are indistinguishable once parsed, so the token
+// layer marks the newlines that are provably markdown text — and ONLY
+// those. Raw HTML is never rewritten in any way: DOMPurify judges its
+// real attribute values (its URI policy sees `\njavascript:` as
+// authored), the HTML parser sees its real tag-syntax whitespace, and
+// comments keep their real data. The sentinel lives exclusively inside
+// escaped text content, where the DOM pass resolves every occurrence to
+// either `<br>` or `\n` — a total function, so none can leak into the
+// output. The marker is freshly RANDOM per render, so authored content
+// cannot collide with it — not even through numeric character
+// references, which no input-scan check could enumerate.
+function pickSoftBreakSentinel(): string {
     const bytes = new Uint8Array(16);
     if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
         crypto.getRandomValues(bytes);
@@ -45,7 +50,7 @@ function pickRawNewlineSentinel(): string {
             bytes[i] = Math.floor(Math.random() * 256);
     }
 
-    let token = 'mu-raw-nl-';
+    let token = 'mu-soft-br-';
     for (const byte of bytes)
         token += byte.toString(16).padStart(2, '0');
 
@@ -83,31 +88,43 @@ export class MarkdownToHtml {
      * explicitly permits a renderer to emit soft breaks as hard line
      * breaks; the editor already SHOWS them as line breaks
      * (`.mu-content` is pre-wrap), so exports must match. Runs on the
-     * sanitized export DOM: only text nodes in phrasing context under a
-     * paragraph-like host (`p`, `li`) convert, protected containers and
-     * block-structural newlines stay verbatim, and marked's canonical
-     * string output is never modified.
+     * sanitized export DOM, driven by the soft-break sentinel: only
+     * sentinel-carrying text nodes (markdown text by construction) are
+     * ever touched, and every sentinel resolves to either `<br>`
+     * (authored soft break in phrasing context) or `\n` (protected
+     * containers, structural positions) — newlines that arrived as real
+     * `\n` (raw HTML, marked's own block separators) are never visited
+     * at all.
      */
-    private _renderSoftBreaks(container: HTMLElement) {
+    private _renderSoftBreaks(container: HTMLElement, sentinel: string) {
         const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
         const texts: Text[] = [];
         for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-            if ((node as Text).data.includes('\n'))
+            if ((node as Text).data.includes(sentinel))
                 texts.push(node as Text);
         }
 
         for (const text of texts)
-            this._convertSoftBreaks(text);
+            this._convertSoftBreaks(text, sentinel);
     }
 
-    private _convertSoftBreaks(text: Text) {
+    private _convertSoftBreaks(text: Text, sentinel: string) {
+        const parts = text.data.split(sentinel);
         const parent = text.parentElement;
-        if (!parent || parent.closest(SOFT_BREAK_PROTECTED))
+
+        // Contexts that never convert restore the plain newline: a text
+        // token's newline that parsed into a protected or structural
+        // position (an inline raw `<pre>` interior, a multiline setext
+        // heading) is content, not a soft break.
+        if (
+            !parent
+            || parent.closest(SOFT_BREAK_PROTECTED)
+            || STRUCTURAL_PARENT_TAG.test(parent.tagName)
+            || !parent.closest('p, li')
+        ) {
+            text.data = parts.join('\n');
             return;
-        if (STRUCTURAL_PARENT_TAG.test(parent.tagName))
-            return;
-        if (!parent.closest('p, li'))
-            return;
+        }
 
         // A newline at the node's EDGE next to a block-level sibling (a
         // nested list inside a tight item, a paragraph boundary inside a
@@ -121,14 +138,31 @@ export class MarkdownToHtml {
                 || (isHTMLElement(text.nextSibling)
                     && BLOCKISH_TAG.test(text.nextSibling.tagName));
 
-        const parts = text.data.split('\n');
+        // Precomputed emptiness frontiers make each boundary check O(1);
+        // per-boundary prefix/suffix scans made a long single paragraph
+        // quadratic in its line count.
+        let firstNonEmpty = parts.length;
+        for (let i = 0; i < parts.length; i++) {
+            if (parts[i] !== '') {
+                firstNonEmpty = i;
+                break;
+            }
+        }
+        let lastNonEmpty = -1;
+        for (let i = parts.length - 1; i >= 0; i--) {
+            if (parts[i] !== '') {
+                lastNonEmpty = i;
+                break;
+            }
+        }
+
         const fragment = document.createDocumentFragment();
         let converted = false;
         for (let i = 0; i < parts.length; i++) {
             if (i > 0) {
                 // The boundary between parts[i-1] and parts[i].
-                const leadingEmpty = parts.slice(0, i).every(part => part === '');
-                const trailingEmpty = parts.slice(i).every(part => part === '');
+                const leadingEmpty = firstNonEmpty >= i;
+                const trailingEmpty = lastNonEmpty < i;
                 const structural
                     = (leadingEmpty && structuralBefore)
                         || (trailingEmpty && structuralAfter);
@@ -146,42 +180,8 @@ export class MarkdownToHtml {
 
         if (converted)
             text.parentNode!.replaceChild(fragment, text);
-    }
-
-    /**
-     * Swap the raw-newline sentinels back, ON THE DOM and BEFORE
-     * serialization — nothing textual is ever modified after the
-     * sanitized document is serialized (the string-level restore this
-     * replaces let `href="java<sentinel>script:alert(1)"` pass DOMPurify
-     * and re-materialize as a newline that URL normalization strips).
-     *
-     * - TEXT nodes restore the real `\n`: text-node mutation cannot cross
-     *   into markup by construction.
-     * - ATTRIBUTE values restore a SPACE instead. Attribute newlines are
-     *   collapsible whitespace semantically, and space is the provably
-     *   safe direction: URL parsing strips tab/newline/CR but preserves
-     *   interior spaces, so a scheme can never reassemble. (Deleting the
-     *   sentinel would be the DANGEROUS direction — `java` + `script:`
-     *   joins.) Sentinels that landed in attribute NAMES (a newline
-     *   between attributes) are junk attributes DOMPurify already
-     *   stripped before this pass.
-     */
-    private _restoreRawNewlines(container: HTMLElement, sentinel: string) {
-        const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-        const texts: Text[] = [];
-        for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-            if ((node as Text).data.includes(sentinel))
-                texts.push(node as Text);
-        }
-        for (const text of texts)
-            text.data = text.data.split(sentinel).join('\n');
-
-        for (const element of container.querySelectorAll('*')) {
-            for (const attribute of element.attributes) {
-                if (attribute.value.includes(sentinel))
-                    attribute.value = attribute.value.split(sentinel).join(' ');
-            }
-        }
+        else
+            text.data = parts.join('\n');
     }
 
     private async _renderMermaid() {
@@ -334,14 +334,14 @@ export class MarkdownToHtml {
     // render pure html by marked
     async renderHtml() {
         const footnote = this._muya?.options?.footnote ?? false;
-        const rawNewlineSentinel = pickRawNewlineSentinel();
+        const softBreakSentinel = pickSoftBreakSentinel();
         let html = getHighlightHtml(this.markdown, {
             superSubScript: this._muya?.options?.superSubScript ?? true,
             footnote,
             isGitlabCompatibilityEnabled:
         this._muya?.options?.isGitlabCompatibilityEnabled ?? true,
             math: this._muya?.options?.math ?? true,
-        }, { rawNewlineSentinel });
+        }, { softBreakSentinel });
 
         // Post-process footnotes into the standard GFM / pandoc shape (inline
         // numbered <sup> refs + bottom <section class="footnotes"> with
@@ -358,6 +358,14 @@ export class MarkdownToHtml {
         exportContainer.innerHTML = html;
         document.body.appendChild(exportContainer);
 
+        // Authored soft breaks -> <br> (#3676), on the parsed DOM where
+        // the browser has already resolved everything the token stream
+        // cannot express. Runs FIRST so no later pass (mermaid, heading
+        // slugs) ever observes a sentinel, and resolves every sentinel
+        // in place — nothing textual changes after this point except
+        // subtree replacement by the diagram renderers.
+        this._renderSoftBreaks(exportContainer, softBreakSentinel);
+
         // render only render the light theme of mermaid and diagram...
         await this._renderMermaid();
         await this._renderDiagram();
@@ -367,14 +375,6 @@ export class MarkdownToHtml {
         // resolve. Scoped to this export DOM path — the conformance
         // renderer (`renderToStaticHTML`) is deliberately left untouched.
         this._injectHeadingIds(exportContainer);
-
-        // Authored soft breaks -> <br> (#3676), on the parsed DOM where
-        // the browser has already resolved everything the token stream
-        // cannot express — then restore raw-token newlines, still on the
-        // DOM: serialization is the last step and nothing rewrites the
-        // serialized string afterwards.
-        this._renderSoftBreaks(exportContainer);
-        this._restoreRawNewlines(exportContainer, rawNewlineSentinel);
 
         let result = exportContainer.innerHTML;
         exportContainer.remove();

--- a/third_party/muya/src/state/markdownToHtml.ts
+++ b/third_party/muya/src/state/markdownToHtml.ts
@@ -34,12 +34,15 @@ const CDN_STYLESHEET_LINKS = `  <!-- https://cdnjs.com/libraries/github-markdown
 // those. Raw HTML is never rewritten in any way: DOMPurify judges its
 // real attribute values (its URI policy sees `\njavascript:` as
 // authored), the HTML parser sees its real tag-syntax whitespace, and
-// comments keep their real data. The sentinel lives exclusively inside
-// escaped text content, where the DOM pass resolves every occurrence to
-// either `<br>` or `\n` — a total function, so none can leak into the
-// output. The marker is freshly RANDOM per render, so authored content
-// cannot collide with it — not even through numeric character
-// references, which no input-scan check could enumerate.
+// comments keep their real data. The sentinel reaches DOM Text nodes
+// only — partly by construction (escaped text cannot originate markup)
+// and partly by sink inventory (image labels, the one text-token path
+// that renders into an ATTRIBUTE, are explicitly exempted in the marking
+// hook) — and the DOM pass resolves every occurrence to either `<br>` or
+// `\n`: a total function, so none can leak into the output. The marker
+// is freshly RANDOM per render, so authored content cannot collide with
+// it — not even through numeric character references, which no
+// input-scan check could enumerate.
 function pickSoftBreakSentinel(): string {
     const bytes = new Uint8Array(16);
     if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {

--- a/third_party/muya/src/utils/marked/getHighlightHtml.ts
+++ b/third_party/muya/src/utils/marked/getHighlightHtml.ts
@@ -35,7 +35,26 @@ function highlight(code: string, lang: string) {
     return Prism.highlight(code, grammar, lang);
 }
 
-export function getHighlightHtml(src: string, options: ILexOption = {}) {
+export interface IHighlightHtmlOptions {
+    /**
+     * Replace `\n` INSIDE raw HTML tokens with this sentinel string
+     * (#3676, #4951). The DOM-stage export pass converts authored soft
+     * breaks to `<br>` but must leave raw-HTML formatting whitespace
+     * alone — and after parsing, the two are indistinguishable in the
+     * DOM. The token layer contributes the one bit only it knows ("this
+     * text came from a raw HTML token") with NO tag tracking of any
+     * kind; the exporter swaps the sentinel back to `\n` string-wide
+     * after the DOM pass. Export-only: the editor and the conformance
+     * renderer never pass it, so their output stays spec-canonical.
+     */
+    rawNewlineSentinel?: string;
+}
+
+export function getHighlightHtml(
+    src: string,
+    options: ILexOption = {},
+    { rawNewlineSentinel }: IHighlightHtmlOptions = {},
+) {
     options = Object.assign({}, DEFAULT_OPTIONS, options);
     const { footnote, frontMatter, math, isGitlabCompatibilityEnabled, superSubScript }
         = options;
@@ -64,6 +83,18 @@ export function getHighlightHtml(src: string, options: ILexOption = {}) {
                 useKatexRender: true,
             }),
         );
+    }
+
+    if (rawNewlineSentinel) {
+        marked.use({
+            renderer: {
+                // marked v18's base html renderer is `({ text }) => text` for
+                // block and inline raw-HTML tokens alike.
+                html(token) {
+                    return token.text.replace(/\n/g, rawNewlineSentinel);
+                },
+            },
+        });
     }
 
     if (superSubScript)

--- a/third_party/muya/src/utils/marked/getHighlightHtml.ts
+++ b/third_party/muya/src/utils/marked/getHighlightHtml.ts
@@ -43,10 +43,19 @@ export interface IHighlightHtmlOptions {
      * alone — and after parsing, the two are indistinguishable in the
      * DOM. The token layer contributes the one bit only it knows ("this
      * newline is markdown text, not raw HTML"), and it marks the SAFE
-     * side of that line: text-token content is escaped text by
-     * construction, so the sentinel can never land in tag syntax, an
-     * attribute, or a comment — raw HTML flows through marked, DOMPurify
-     * and the HTML parser byte-identical to a sentinel-free render.
+     * side of that line. The guarantee has two distinct legs:
+     *
+     * - BY CONSTRUCTION: text-token content is escaped text, so it can
+     *   never originate tag syntax or comment data — raw HTML flows
+     *   through marked, DOMPurify and the HTML parser byte-identical to
+     *   a sentinel-free render.
+     * - BY SINK INVENTORY: a text token's DESTINATION is not guaranteed
+     *   to be a DOM Text node. Marked's image renderer writes label
+     *   text tokens into the `alt` ATTRIBUTE — the one such sink in the
+     *   core renderers — so the hook explicitly exempts image-label
+     *   subtrees. Deleting that exemption re-leaks the sentinel into
+     *   `alt`; the "escaped text" argument alone does NOT cover it.
+     *
      * (The inverse marking — sentinels INSIDE raw HTML tokens — rewrote
      * markup text and died three ways at once: it corrupted multiline
      * tags, leaked into comment data, and let sanitized-inert URI values

--- a/third_party/muya/src/utils/marked/getHighlightHtml.ts
+++ b/third_party/muya/src/utils/marked/getHighlightHtml.ts
@@ -93,6 +93,21 @@ export function getHighlightHtml(
     }
 
     if (softBreakSentinel) {
+        // Text tokens inside an image LABEL are the one place a text
+        // token does not become a DOM Text node: marked renders the
+        // label into the `alt` attribute, which no text-node pass can
+        // ever visit — a sentinel there would leak into the export
+        // verbatim. Marked walks parents before children, so tagging the
+        // image's subtree at the image token keeps its descendants
+        // unmarked (and the alt newline keeps marked's own behavior).
+        const imageLabelTokens = new WeakSet<object>();
+        const tagImageLabel = (token: { tokens?: object[] }) => {
+            for (const child of token.tokens ?? []) {
+                imageLabelTokens.add(child);
+                tagImageLabel(child);
+            }
+        };
+
         marked.use({
             // Mark soft breaks where they live: leaf `text` tokens. Raw
             // `html` tokens, code, codespans, and every extension token
@@ -102,8 +117,17 @@ export function getHighlightHtml(
             // it.) This instance is per-call, so the closure over this
             // render's sentinel cannot chain into the next render.
             walkTokens(token) {
-                if (token.type === 'text' && token.text.includes('\n'))
+                if (token.type === 'image') {
+                    tagImageLabel(token);
+                    return;
+                }
+                if (
+                    token.type === 'text'
+                    && !imageLabelTokens.has(token)
+                    && token.text.includes('\n')
+                ) {
                     token.text = token.text.replace(/\n/g, softBreakSentinel);
+                }
             },
         });
     }

--- a/third_party/muya/src/utils/marked/getHighlightHtml.ts
+++ b/third_party/muya/src/utils/marked/getHighlightHtml.ts
@@ -37,23 +37,30 @@ function highlight(code: string, lang: string) {
 
 export interface IHighlightHtmlOptions {
     /**
-     * Replace `\n` INSIDE raw HTML tokens with this sentinel string
+     * Replace `\n` INSIDE markdown TEXT tokens with this sentinel string
      * (#3676, #4951). The DOM-stage export pass converts authored soft
      * breaks to `<br>` but must leave raw-HTML formatting whitespace
      * alone — and after parsing, the two are indistinguishable in the
      * DOM. The token layer contributes the one bit only it knows ("this
-     * text came from a raw HTML token") with NO tag tracking of any
-     * kind; the exporter swaps the sentinel back to `\n` string-wide
-     * after the DOM pass. Export-only: the editor and the conformance
-     * renderer never pass it, so their output stays spec-canonical.
+     * newline is markdown text, not raw HTML"), and it marks the SAFE
+     * side of that line: text-token content is escaped text by
+     * construction, so the sentinel can never land in tag syntax, an
+     * attribute, or a comment — raw HTML flows through marked, DOMPurify
+     * and the HTML parser byte-identical to a sentinel-free render.
+     * (The inverse marking — sentinels INSIDE raw HTML tokens — rewrote
+     * markup text and died three ways at once: it corrupted multiline
+     * tags, leaked into comment data, and let sanitized-inert URI values
+     * re-materialize as dangerous ones after DOMPurify.) Export-only:
+     * the editor and the conformance renderer never pass it, so their
+     * output stays spec-canonical.
      */
-    rawNewlineSentinel?: string;
+    softBreakSentinel?: string;
 }
 
 export function getHighlightHtml(
     src: string,
     options: ILexOption = {},
-    { rawNewlineSentinel }: IHighlightHtmlOptions = {},
+    { softBreakSentinel }: IHighlightHtmlOptions = {},
 ) {
     options = Object.assign({}, DEFAULT_OPTIONS, options);
     const { footnote, frontMatter, math, isGitlabCompatibilityEnabled, superSubScript }
@@ -85,14 +92,18 @@ export function getHighlightHtml(
         );
     }
 
-    if (rawNewlineSentinel) {
+    if (softBreakSentinel) {
         marked.use({
-            renderer: {
-                // marked v18's base html renderer is `({ text }) => text` for
-                // block and inline raw-HTML tokens alike.
-                html(token) {
-                    return token.text.replace(/\n/g, rawNewlineSentinel);
-                },
+            // Mark soft breaks where they live: leaf `text` tokens. Raw
+            // `html` tokens, code, codespans, and every extension token
+            // keep their own types, so nothing but escaped markdown text
+            // is ever touched. (The renderer escapes token.text — the
+            // sentinel is alphanumeric-plus-hyphen, so escaping preserves
+            // it.) This instance is per-call, so the closure over this
+            // render's sentinel cannot chain into the next render.
+            walkTokens(token) {
+                if (token.type === 'text' && token.text.includes('\n'))
+                    token.text = token.text.replace(/\n/g, softBreakSentinel);
             },
         });
     }


### PR DESCRIPTION
Fixes #143 (upstream marktext#3676) — second attempt, on a fundamentally different footing than the closed-parked #160.

## Why the first attempt died, and what changed

#160's core was accepted as right: render authored soft breaks as `<br>` on export (CommonMark explicitly permits it), matching what the editor already shows (`.mu-content` is pre-wrap). What died under ten review rounds was the **guard** — deciding "is this newline inside raw HTML?" from marked's token stream requires emulating HTML-parser semantics (raw-text elements, legal nesting, mismatched closes, fragmented tokens, comments, self-closing forms). ~20 of its 28 regression tests existed solely to pin that emulation.

**The fact nobody used: `renderHtml()` already builds a real DOM** (after DOMPurify, for mermaid/diagrams/heading ids). At that stage the BROWSER has authoritatively resolved everything the emulation chased. This PR does the conversion there:

- **The token layer contributes exactly one bit** — the only thing it authoritatively knows: "this newline is markdown text, not raw HTML." A `walkTokens` hook replaces newlines inside marked's `text` tokens with a per-render random sentinel. The marking DIRECTION is the design's security and correctness contract, and it has two legs: **by construction**, escaped text-token content cannot originate tag syntax or comment data, so **raw HTML is never rewritten in any way** — it reaches DOMPurify and the HTML parser byte-identical to a sentinel-free render; **by sink inventory**, the one text-token path whose destination is an ATTRIBUTE rather than a DOM Text node — image labels, which marked renders into `alt` — is explicitly exempted from marking (review caught this: the construction argument alone does not cover destinations, and an unexempted multiline image label leaked the sentinel into `alt`).
- **The DOM pass resolves every sentinel** to either `<br>` (authored soft break in phrasing context under `p`/`li`) or `\n` (protected containers — `pre, code, kbd, script, style, textarea, title, svg, math, table, .katex` — plus structural-container text and block-edge newlines). A total function: nothing can leak into the output, pinned by a sentinel-prefix assertion on every test export. The pass runs before the mermaid/heading-id stages so no other pass ever observes a sentinel.
- **Scope rule:** newlines that arrive as real `\n` — raw HTML formatting, marked's own block separators — are never visited at all. marked's canonical string output is not modified; block separators, `[TOC]` paragraph shape, everything the string protocol's consumers match, untouched by construction.

## Security contract

Review killed two earlier shapes of this feature at the same boundary, and both failures came from rewriting raw HTML:

1. A string-level post-serialization restore let `href="java␤script:alert(1)"` ride through DOMPurify inert and re-materialize as a scheme-splitting newline.
2. A DOM-level attribute restore (newline → space) still re-armed `href="␤javascript:alert(1)"` — URL parsing strips LEADING spaces, so a leading-whitespace downgrade reassembles the scheme; sentinels in tag-syntax whitespace additionally corrupted multiline tags, and comment-data sentinels leaked unrestored.

The flipped marking direction removes the entire attack and corruption surface instead of patching instances: raw HTML is never touched at any stage, so DOMPurify judges the authored bytes and its verdict is final — no pass runs after it that could change what an attribute value means. Multiline start tags and attribute newlines now export byte-verbatim (better fidelity than the previous revisions, not just safer). Raw comment data is never marked either; production DOMPurify removes comments outright, which is pre-existing sentinel-free behavior — the guarantee this feature adds is that no sentinel can enter comment data, pinned via happy-dom where comments stay observable.

Note for reviewers: happy-dom's DOMPurify attribute pass is inert (a probe showed even a literal `javascript:` href survives `sanitize()` there; real Chromium strips it). The suite therefore asserts what this feature owns — byte fidelity of the authored whitespace, i.e. no laundering before DOMPurify or re-arming after — and proves the policy verdict via DOMPurify's string-level `isValidAttribute`, which does work in that environment.

## Parity with the parked ground truths

All of #160's regression ground truths hold **case for case** — including the subtle ones: the comment-adjacent newline rides inside marked's html token and is simply never touched; raw `<p>`/`<blockquote>` formatting whitespace exports byte-identical. The editor and the conformance renderer (`renderToStaticHTML`) are untouched — the pass lives only in `MarkdownToHtml`, which is inherently export-only, so no option flag is even needed.

## Verification

- 35-test suite over the full `renderHtml()`/`generate()` pipeline: 7 positives (paragraph, tight item, inline-wrapped, inside inline spans, blockquote, hard-break intact, final document), structural negatives (block separators, nested/loose lists — multi-child included, code spans, fenced code, tables — nested-in-list included), the raw-HTML war cases (inline `<pre>`/`<textarea>` interiors, mismatched closes, `<pre><code>` nesting), multiline start tags in both newline positions, multiline comment data (a sentinel-leak probe via happy-dom; production DOMPurify removes comments), multiline image labels in inline and reference form (alt stays sentinel-free and byte-identical to marked's own output), verbatim attribute newlines, whitespace-split `javascript:` fidelity + DOMPurify's own verdict on five split variants, sentinel-lookalike authored text, a sentinel-prefix leak assertion on every export, and an 8k-line linearity guard (per-boundary `slice()` copies previously made a long paragraph quadratic — ~3s at 16k lines — now O(1) boundary checks via precomputed emptiness frontiers). Fixtures pad past a happy-dom+DOMPurify first-element quirk (verified absent in real Chromium; documented in the spec).
- Full vendored-Muya CI gate **1530/1530**; app unit 633/633; typecheck and lint clean.
- Android's PDF/share path consumes `generate()` unchanged — the fix arrives there for free.

Groundwork for the export-pipeline blueprint (`ExportResult` + `[TOC]` token) intentionally deferred to its own PR: the DOM-stage design decouples this fix from the string-protocol concerns that made the blueprint's Stage A a prerequisite for the token-level approach.

