### PR TITLE
Make every draft reachable past the home recency cap

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -194,6 +194,7 @@ import { AUTO_APP_LOCALE, translateKnownText, useI18n } from './lib/i18n'
 import {
   createRecentDocumentFromLocalDraft,
   getRecentDocumentListItems,
+  normalizeRecentDocuments,
   type RecentDocumentRecord,
 } from './lib/recentDocuments'
 
@@ -398,10 +399,36 @@ const recentDocumentRecords = computed(() =>
   ],
 )
 const recentActivityDocumentItems = computed(() => getRecentDocumentListItems(recentDocumentRecords.value))
-const documentItems = computed(() =>
-  getSortedRecentDocumentListItems(recentDocumentRecords.value, documentSettings.value),
-)
+// The home's "show all" expansion (#151): the resting view keeps the quiet
+// recency cap, the expanded view reads the COMPLETE collection. Ephemeral —
+// never persisted, so paging can never modify the durable stores.
 const pinnedDocumentIds = computed(() => getPinnedDocumentIds(pinnedDocuments.value))
+const homeListExpanded = ref(false)
+const allDocumentItems = computed(() =>
+  getSortedRecentDocumentListItems(
+    recentDocumentRecords.value,
+    documentSettings.value,
+    Number.POSITIVE_INFINITY,
+  ),
+)
+const documentItems = computed(() => {
+  if (homeListExpanded.value) {
+    return allDocumentItems.value
+  }
+
+  // The resting view = the recency-capped set, plus any PINNED document
+  // beyond the cap — pinning is explicit intent and must keep an item
+  // visible without expanding.
+  const cappedIds = new Set(
+    normalizeRecentDocuments(recentDocumentRecords.value).map(record => record.id),
+  )
+  return allDocumentItems.value.filter(
+    item => cappedIds.has(item.id) || pinnedDocumentIds.value.has(item.id),
+  )
+})
+const hiddenHomeDocumentCount = computed(
+  () => allDocumentItems.value.length - documentItems.value.length,
+)
 const homeDocumentSections = computed(() =>
   partitionHomeDocumentItems(documentItems.value, pinnedDocumentIds.value),
 )
@@ -2053,6 +2080,7 @@ onBeforeUnmount(() => {
     :continue-document="continueDocument"
     :pinned-documents="pinnedHomeDocuments"
     :earlier-documents="earlierDocuments"
+    :hidden-document-count="hiddenHomeDocumentCount"
     :notice="displayHomeNotice"
     :selection-active="homeSelection.isActive.value"
     :selection-count="homeSelection.count.value"
@@ -2064,6 +2092,7 @@ onBeforeUnmount(() => {
     @new-document="newDocument"
     @open-document="openDocument"
     @open-file="openFileFromAndroid"
+    @show-all-documents="homeListExpanded = true"
     @set-tab="setHomeTab"
     @set-settings-page="setSettingsPage"
     @select-document="homeSelection.beginWith"

--- a/src/App.vue
+++ b/src/App.vue
@@ -86,7 +86,7 @@ import {
 } from './features/document-session/documentSessionState'
 import {
   getDocumentSettings,
-  getSortedRecentDocumentListItems,
+  getSortedRecentDocumentRecords,
 } from './features/document-session/documentSettings'
 import { createAutosaveScheduler } from './features/document-session/autosaveScheduler'
 import { createCurrentDocumentPersistence } from './features/document-session/currentDocumentPersistence'
@@ -195,6 +195,7 @@ import {
   createRecentDocumentFromLocalDraft,
   getRecentDocumentListItems,
   normalizeRecentDocuments,
+  toRecentDocumentListItems,
   type RecentDocumentRecord,
 } from './lib/recentDocuments'
 
@@ -402,18 +403,20 @@ const recentActivityDocumentItems = computed(() => getRecentDocumentListItems(re
 // The home's "show all" expansion (#151): the resting view keeps the quiet
 // recency cap, the expanded view reads the COMPLETE collection. Ephemeral —
 // never persisted, so paging can never modify the durable stores.
+//
+// The projection is layered so the cap limits COMPUTATION, not just
+// rendered rows: ordering, cap membership, and the hidden count come from
+// the records level (timestamp/title sort keys only), and list items —
+// whose statistics scan each draft's full Markdown — are materialized
+// only for the records the current state actually renders.
 const pinnedDocumentIds = computed(() => getPinnedDocumentIds(pinnedDocuments.value))
 const homeListExpanded = ref(false)
-const allDocumentItems = computed(() =>
-  getSortedRecentDocumentListItems(
-    recentDocumentRecords.value,
-    documentSettings.value,
-    Number.POSITIVE_INFINITY,
-  ),
+const sortedRecentRecords = computed(() =>
+  getSortedRecentDocumentRecords(recentDocumentRecords.value, documentSettings.value),
 )
-const documentItems = computed(() => {
+const visibleRecentRecords = computed(() => {
   if (homeListExpanded.value) {
-    return allDocumentItems.value
+    return sortedRecentRecords.value
   }
 
   // The resting view = the recency-capped set, plus any PINNED document
@@ -422,12 +425,13 @@ const documentItems = computed(() => {
   const cappedIds = new Set(
     normalizeRecentDocuments(recentDocumentRecords.value).map(record => record.id),
   )
-  return allDocumentItems.value.filter(
-    item => cappedIds.has(item.id) || pinnedDocumentIds.value.has(item.id),
+  return sortedRecentRecords.value.filter(
+    record => cappedIds.has(record.id) || pinnedDocumentIds.value.has(record.id),
   )
 })
+const documentItems = computed(() => toRecentDocumentListItems(visibleRecentRecords.value))
 const hiddenHomeDocumentCount = computed(
-  () => allDocumentItems.value.length - documentItems.value.length,
+  () => sortedRecentRecords.value.length - visibleRecentRecords.value.length,
 )
 const homeDocumentSections = computed(() =>
   partitionHomeDocumentItems(documentItems.value, pinnedDocumentIds.value),
@@ -453,10 +457,13 @@ const allSelectedDocumentsPinned = computed(() =>
 )
 
 // Documents can leave the list while selected (e.g. an autosave drops an
-// emptied draft); the selection must not keep counting them.
-watch(documentItems, items => {
+// emptied draft); the selection must not keep counting them. Watching the
+// RECORDS projection keeps `documentItems` lazy: a watcher on the items
+// computed would re-materialize statistics on every draft autosave even
+// while the home screen is not rendered.
+watch(visibleRecentRecords, records => {
   if (homeSelection.isActive.value) {
-    homeSelection.retain(items.map(item => item.id))
+    homeSelection.retain(records.map(record => record.id))
   }
 })
 
@@ -1258,7 +1265,10 @@ function persistLocalDrafts(nextDrafts: LocalDraftRecord[]) {
 }
 
 function persistAndroidRecentDocuments(nextDocuments: RecentDocumentRecord[]) {
-  const filteredDocuments = writeStoredAndroidRecentDocuments(nextDocuments)
+  const filteredDocuments = writeStoredAndroidRecentDocuments(
+    nextDocuments,
+    pinnedDocumentIds.value,
+  )
   androidRecentDocuments.value = filteredDocuments
 }
 
@@ -1284,6 +1294,7 @@ const {
   homeNotice,
   localDrafts,
   androidRecentDocuments,
+  pinnedDocumentIds,
   currentAndroidDocumentCanWrite,
   promptLocalDraftSaveOnExit,
   draftExitPromptOpen,
@@ -1343,7 +1354,13 @@ function protectAndroidDocumentImportedImages(document: OpenedAndroidDocument) {
 
 function rememberAndroidDocument(document: OpenedAndroidDocument) {
   protectAndroidDocumentImportedImages(document)
-  persistAndroidRecentDocuments(rememberAndroidRecentDocument(androidRecentDocuments.value, document))
+  persistAndroidRecentDocuments(
+    rememberAndroidRecentDocument(
+      androidRecentDocuments.value,
+      document,
+      pinnedDocumentIds.value,
+    ),
+  )
 }
 
 async function openAndroidDocumentResult(

--- a/src/App.vue
+++ b/src/App.vue
@@ -404,11 +404,14 @@ const recentActivityDocumentItems = computed(() => getRecentDocumentListItems(re
 // recency cap, the expanded view reads the COMPLETE collection. Ephemeral —
 // never persisted, so paging can never modify the durable stores.
 //
-// The projection is layered so the cap limits COMPUTATION, not just
-// rendered rows: ordering, cap membership, and the hidden count come from
-// the records level (timestamp/title sort keys only), and list items —
-// whose statistics scan each draft's full Markdown — are materialized
-// only for the records the current state actually renders.
+// The projection is layered to keep the heavy work off the resting path:
+// list-item STATISTICS (full-Markdown scans per draft) are materialized
+// only for the records the current state actually renders. The records
+// level is cheaper but not free — local-draft records derive their title
+// from the draft's Markdown — so it must only evaluate while something
+// actually renders it: the selection watcher below unsubscribes when no
+// selection is active, and everything else reading this chain is mounted
+// only on the home screen.
 const pinnedDocumentIds = computed(() => getPinnedDocumentIds(pinnedDocuments.value))
 const homeListExpanded = ref(false)
 const sortedRecentRecords = computed(() =>
@@ -457,15 +460,23 @@ const allSelectedDocumentsPinned = computed(() =>
 )
 
 // Documents can leave the list while selected (e.g. an autosave drops an
-// emptied draft); the selection must not keep counting them. Watching the
-// RECORDS projection keeps `documentItems` lazy: a watcher on the items
-// computed would re-materialize statistics on every draft autosave even
-// while the home screen is not rendered.
-watch(visibleRecentRecords, records => {
-  if (homeSelection.isActive.value) {
-    homeSelection.retain(records.map(record => record.id))
-  }
-})
+// emptied draft); the selection must not keep counting them. The source
+// getter short-circuits BEFORE touching the records projection when no
+// selection is active: a watcher must evaluate its source on every
+// dependency change (a guard inside the callback cannot prevent that),
+// so an unconditional source would pull the whole projection — including
+// per-draft title derivation over full Markdown bodies — hot on every
+// autosave even while the home screen is not rendered. With the
+// short-circuit, Vue's dynamic dependency tracking drops the projection
+// subscription entirely while selection is inactive.
+watch(
+  () => (homeSelection.isActive.value ? visibleRecentRecords.value : null),
+  records => {
+    if (records) {
+      homeSelection.retain(records.map(record => record.id))
+    }
+  },
+)
 
 watch(homeSelection.isActive, active => {
   if (!active) {

--- a/src/features/android-documents/androidRecentDocuments.ts
+++ b/src/features/android-documents/androidRecentDocuments.ts
@@ -20,9 +20,15 @@ interface SavedAndroidRecentDocumentOptions {
   canWrite: boolean
 }
 
+// The recents store is an Android document's ONLY durable home (local
+// drafts have the unbounded drafts store behind them), so every write
+// that re-applies the storage cap must know which ids are pinned —
+// a pin-blind cap would silently evict a pinned document and its pin
+// would be orphan-pruned on the next startup.
 export function rememberAndroidRecentDocument(
   records: RecentDocumentRecord[],
   document: AndroidRecentDocumentSource,
+  protectedIds?: ReadonlySet<string>,
 ) {
   return upsertRecentDocument(
     records,
@@ -34,6 +40,8 @@ export function rememberAndroidRecentDocument(
       markdown: document.markdown,
       canWrite: document.canWrite,
     }),
+    undefined,
+    protectedIds,
   )
 }
 
@@ -41,6 +49,7 @@ export function markSavedAndroidRecentDocument(
   records: RecentDocumentRecord[],
   sourceUri: string,
   options: SavedAndroidRecentDocumentOptions,
+  protectedIds?: ReadonlySet<string>,
 ) {
   const existingDocument = records.find(record => record.sourceUri === sourceUri)
   if (!existingDocument) {
@@ -54,5 +63,7 @@ export function markSavedAndroidRecentDocument(
       savedAt: options.savedAt,
       canWrite: options.canWrite,
     }),
+    undefined,
+    protectedIds,
   )
 }

--- a/src/features/document-session/currentDocumentPersistence.test.ts
+++ b/src/features/document-session/currentDocumentPersistence.test.ts
@@ -85,6 +85,7 @@ function createPersistence(overrides: {
     homeNotice: ref<string | null>(null),
     localDrafts,
     androidRecentDocuments,
+    pinnedDocumentIds: ref<ReadonlySet<string>>(new Set<string>()),
     currentAndroidDocumentCanWrite: ref(true),
     promptLocalDraftSaveOnExit: ref(true),
     draftExitPromptOpen: ref(false),

--- a/src/features/document-session/currentDocumentPersistence.ts
+++ b/src/features/document-session/currentDocumentPersistence.ts
@@ -55,6 +55,10 @@ export interface CurrentDocumentPersistenceOptions {
   homeNotice: Ref<string | null>
   localDrafts: Ref<LocalDraftRecord[]>
   androidRecentDocuments: Ref<RecentDocumentRecord[]>
+  // Pinned ids protect their records from the recents storage cap on
+  // every write (the recents store is an Android document's only durable
+  // home).
+  pinnedDocumentIds: Ref<ReadonlySet<string>>
   currentAndroidDocumentCanWrite: Ref<boolean>
   promptLocalDraftSaveOnExit: Ref<boolean>
   draftExitPromptOpen: Ref<boolean>
@@ -201,6 +205,7 @@ export function createCurrentDocumentPersistence(
         savedAt,
         canWrite: options.currentAndroidDocumentCanWrite.value,
       },
+      options.pinnedDocumentIds.value,
     )
     if (!nextDocuments) {
       options.documentLogger.warn('saved Android recent document not found', { sourceUri })

--- a/src/features/document-session/documentSettings.test.ts
+++ b/src/features/document-session/documentSettings.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_DOCUMENT_SETTINGS,
   getDocumentSettings,
   getSortedRecentDocumentListItems,
+  getSortedRecentDocumentRecords,
   normalizeAutoSaveDelaySeconds,
   normalizeDocumentSettingValue,
 } from './documentSettings'
@@ -149,4 +150,29 @@ describe('documentSettings', () => {
     ).toEqual(['charlie', 'alpha', 'bravo'])
   })
 
+  it('sorts the complete record collection without materializing statistics', () => {
+    // The records projection backs cap membership and hidden counts, so
+    // it must read the COMPLETE collection (no recency cap) and stay at
+    // the record level (no per-draft stats scans).
+    const base = Date.parse('2026-06-01T00:00:00.000Z')
+    const records = Array.from({ length: 105 }, (_, index) =>
+      createRecord({
+        id: `draft-${String(index + 1).padStart(3, '0')}`,
+        title: `Draft ${index + 1}`,
+        createdAt: new Date(base).toISOString(),
+        updatedAt: new Date(base + (index + 1) * 1000).toISOString(),
+        lastOpenedAt: new Date(base + (index + 1) * 1000).toISOString(),
+      }),
+    )
+
+    const sorted = getSortedRecentDocumentRecords(records, {
+      fileSortBy: 'modified',
+      fileSortOrder: 'asc',
+    })
+
+    expect(sorted).toHaveLength(105)
+    expect(sorted[0].id).toBe('draft-001')
+    expect(sorted.at(-1)?.id).toBe('draft-105')
+    expect('stats' in sorted[0]).toBe(false)
+  })
 })

--- a/src/features/document-session/documentSettings.ts
+++ b/src/features/document-session/documentSettings.ts
@@ -1,4 +1,8 @@
-import { getRecentDocumentListItems, type RecentDocumentRecord } from '../../lib/recentDocuments'
+import {
+  getRecentDocumentListItems,
+  normalizeRecentDocuments,
+  type RecentDocumentRecord,
+} from '../../lib/recentDocuments'
 import type { SettingsValue } from '../settings/settingsState'
 
 export type DocumentSettingKey =
@@ -176,9 +180,24 @@ export function compareRecentDocumentsForSettings(
 export function getSortedRecentDocumentListItems(
   records: RecentDocumentRecord[],
   settings: Pick<DocumentSettings, 'fileSortBy' | 'fileSortOrder'>,
-  limit?: number,
 ) {
-  return getRecentDocumentListItems(records, limit).sort((left, right) =>
+  return getRecentDocumentListItems(records).sort((left, right) =>
+    compareRecentDocumentsForSettings(left, right, settings),
+  )
+}
+
+/**
+ * The complete collection as sorted RECORDS — no list-item statistics.
+ * Sort keys are timestamps and titles, so ordering, cap membership, and
+ * hidden counts never need the per-draft full-Markdown scans that item
+ * materialization performs; callers materialize items only for the
+ * records they render (#151).
+ */
+export function getSortedRecentDocumentRecords(
+  records: RecentDocumentRecord[],
+  settings: Pick<DocumentSettings, 'fileSortBy' | 'fileSortOrder'>,
+) {
+  return normalizeRecentDocuments(records, Number.POSITIVE_INFINITY).sort((left, right) =>
     compareRecentDocumentsForSettings(left, right, settings),
   )
 }

--- a/src/features/document-session/documentSettings.ts
+++ b/src/features/document-session/documentSettings.ts
@@ -176,8 +176,9 @@ export function compareRecentDocumentsForSettings(
 export function getSortedRecentDocumentListItems(
   records: RecentDocumentRecord[],
   settings: Pick<DocumentSettings, 'fileSortBy' | 'fileSortOrder'>,
+  limit?: number,
 ) {
-  return getRecentDocumentListItems(records).sort((left, right) =>
+  return getRecentDocumentListItems(records, limit).sort((left, right) =>
     compareRecentDocumentsForSettings(left, right, settings),
   )
 }

--- a/src/features/home/DocumentHome.vue
+++ b/src/features/home/DocumentHome.vue
@@ -96,6 +96,45 @@ function onDocumentClick(id: string) {
   }
 }
 
+// The show-all button removes itself once nothing is hidden, which would
+// drop keyboard/switch-access focus to <body> and force a full re-traverse.
+// Snapshot the visible ids at activation; when the list grows, hand focus
+// to the first newly revealed row and announce the growth politely.
+const preExpandIds = ref<Set<string> | null>(null)
+const revealedAnnouncement = ref('')
+
+function showAllDocuments() {
+  preExpandIds.value = new Set(allDocuments.value.map(item => item.id))
+  emit('showAllDocuments')
+}
+
+watch(allDocuments, documents => {
+  const before = preExpandIds.value
+  if (!before) {
+    return
+  }
+  preExpandIds.value = null
+
+  const revealedCount = documents.filter(item => !before.has(item.id)).length
+  if (revealedCount === 0) {
+    return
+  }
+  revealedAnnouncement.value = t('home.documentsRevealed', { count: revealedCount })
+  void nextTick(() => {
+    // First newly revealed row in DOM order — under title or ascending
+    // sorts revealed records interleave rather than append.
+    const rows
+      = homeScreen.value?.querySelectorAll<HTMLElement>('[data-doc-id]') ?? []
+    for (const row of rows) {
+      const id = row.dataset.docId
+      if (id && !before.has(id)) {
+        row.focus()
+        break
+      }
+    }
+  })
+})
+
 function confirmDelete() {
   emit('update:deleteSheetOpen', false)
   emit('deleteSelected')
@@ -239,6 +278,7 @@ watch(
               'has-pin': section.pinned,
             }"
             type="button"
+            :data-doc-id="document.id"
             :aria-pressed="selectionActive ? isSelected(document.id) : undefined"
             @click="onDocumentClick(document.id)"
             @pointerdown="longPress.onPointerDown($event, document.id)"
@@ -289,10 +329,21 @@ watch(
         class="home-show-all"
         type="button"
         data-testid="home-show-all-button"
-        @click="emit('showAllDocuments')"
+        @click="showAllDocuments"
       >
         {{ t('home.showAllDocuments', { count: hiddenDocumentCount }) }}
       </button>
+
+      <!-- Always mounted so the polite live region exists before it is
+           populated — screen readers ignore text born inside a fresh
+           region. -->
+      <p
+        class="home-reveal-status"
+        role="status"
+        data-testid="home-reveal-status"
+      >
+        {{ revealedAnnouncement }}
+      </p>
 
       <section
         v-if="!continueDocument && pinnedDocuments.length === 0 && earlierDocuments.length === 0"

--- a/src/features/home/DocumentHome.vue
+++ b/src/features/home/DocumentHome.vue
@@ -238,6 +238,7 @@ watch(
             'is-selected': selectionActive && isSelected(continueDocument.id),
           }"
           type="button"
+          :data-doc-id="continueDocument.id"
           :aria-pressed="selectionActive ? isSelected(continueDocument.id) : undefined"
           @click="onDocumentClick(continueDocument.id)"
           @pointerdown="longPress.onPointerDown($event, continueDocument.id)"

--- a/src/features/home/DocumentHome.vue
+++ b/src/features/home/DocumentHome.vue
@@ -12,6 +12,8 @@ interface Props {
   continueDocument: HomeDocumentItem | null
   pinnedDocuments: HomeDocumentItem[]
   earlierDocuments: HomeDocumentItem[]
+  /** Documents beyond the resting recency cap; 0 hides the expander (#151). */
+  hiddenDocumentCount: number
   notice: string | null
   selectionActive: boolean
   selectionCount: number
@@ -29,6 +31,7 @@ const emit = defineEmits<{
   openDocument: [id: string]
   openFile: []
   newDocument: []
+  showAllDocuments: []
   selectDocument: [id: string]
   toggleDocument: [id: string]
   exitSelection: []
@@ -280,6 +283,16 @@ watch(
           </button>
         </div>
       </section>
+
+      <button
+        v-if="hiddenDocumentCount > 0"
+        class="home-show-all"
+        type="button"
+        data-testid="home-show-all-button"
+        @click="emit('showAllDocuments')"
+      >
+        {{ t('home.showAllDocuments', { count: hiddenDocumentCount }) }}
+      </button>
 
       <section
         v-if="!continueDocument && pinnedDocuments.length === 0 && earlierDocuments.length === 0"

--- a/src/features/home/HomeScreen.vue
+++ b/src/features/home/HomeScreen.vue
@@ -14,6 +14,7 @@ interface Props {
   continueDocument: HomeDocumentItem | null
   pinnedDocuments: HomeDocumentItem[]
   earlierDocuments: HomeDocumentItem[]
+  hiddenDocumentCount: number
   notice: string | null
   selectionActive: boolean
   selectionCount: number
@@ -31,6 +32,7 @@ const emit = defineEmits<{
   openDocument: [id: string]
   openFile: []
   newDocument: []
+  showAllDocuments: []
   setSettingsPage: [page: SettingsPage]
   selectDocument: [id: string]
   toggleDocument: [id: string]
@@ -68,6 +70,7 @@ watch(
         :continue-document="continueDocument"
         :pinned-documents="pinnedDocuments"
         :earlier-documents="earlierDocuments"
+        :hidden-document-count="hiddenDocumentCount"
         :notice="notice"
         :selection-active="selectionActive"
         :selection-count="selectionCount"
@@ -78,6 +81,7 @@ watch(
         @new-document="emit('newDocument')"
         @open-document="id => emit('openDocument', id)"
         @open-file="emit('openFile')"
+        @show-all-documents="emit('showAllDocuments')"
         @select-document="id => emit('selectDocument', id)"
         @toggle-document="id => emit('toggleDocument', id)"
         @exit-selection="emit('exitSelection')"

--- a/src/features/home/homeDocumentActions.test.ts
+++ b/src/features/home/homeDocumentActions.test.ts
@@ -10,7 +10,7 @@ import {
   serializeRecentDocuments,
 } from '../../lib/recentDocuments'
 import type { LocalDraftRecord } from '../../lib/localDrafts'
-import type { PinnedDocumentRecord } from '../../lib/pinnedDocuments'
+import { prunePinnedDocuments, type PinnedDocumentRecord } from '../../lib/pinnedDocuments'
 import type { RecentDocumentRecord } from '../../lib/recentDocuments'
 import type { ImageSharingSettings } from '../android-documents/imageSharingSettings'
 import { DEFAULT_MARKDOWN_SAVE_SETTINGS } from '../settings/advancedSettings'
@@ -266,7 +266,18 @@ describe('homeDocumentActions', () => {
     // renamed record keeps its old timestamps — persisting it while the
     // pin still carried the OLD id would evict it as an ordinary oldest
     // unpinned record on that very write.
-    const base = Date.parse('2026-07-01T00:00:00.000Z')
+    //
+    // The rename target's timestamps are set EXPLICITLY below the whole
+    // fleet (the shared fixture's 2026-07-09 would silently make it the
+    // NEWEST record and rob this test of its discriminating power — the
+    // first cut of this test had exactly that inversion and stayed green
+    // on the pre-fix ordering).
+    const pinnedOldest = {
+      ...androidRecord,
+      updatedAt: '2026-07-01T00:00:00.000Z',
+      lastOpenedAt: '2026-07-01T00:00:00.000Z',
+    }
+    const base = Date.parse('2026-07-09T00:00:00.000Z')
     const newerRecords = Array.from({ length: 100 }, (_, index) => ({
       ...androidRecord,
       id: `android-document:content://test/doc-${index}.md`,
@@ -275,9 +286,9 @@ describe('homeDocumentActions', () => {
       lastOpenedAt: new Date(base + (index + 1) * 60_000).toISOString(),
     }))
     const { actions, options } = createActions({
-      selectedIds: [androidRecord.id],
-      androidDocuments: [androidRecord, ...newerRecords],
-      pins: [{ id: androidRecord.id, pinnedAt: '2026-07-09T00:00:00.000Z' }],
+      selectedIds: [pinnedOldest.id],
+      androidDocuments: [pinnedOldest, ...newerRecords],
+      pins: [{ id: pinnedOldest.id, pinnedAt: '2026-07-09T00:00:00.000Z' }],
     })
     options.documentItems.value = getRecentDocumentListItems(
       options.androidRecentDocuments.value,
@@ -296,13 +307,18 @@ describe('homeDocumentActions', () => {
       },
     )
 
-    await actions.renameSelectedDocument(androidRecord.id, 'renamed')
+    await actions.renameSelectedDocument(pinnedOldest.id, 'renamed')
 
     const renamedId = 'android-document:content://test/renamed.md'
     const storedIds = options.androidRecentDocuments.value.map(record => record.id)
     expect(storedIds).toContain(renamedId)
-    expect(storedIds).not.toContain(androidRecord.id)
+    expect(storedIds).not.toContain(pinnedOldest.id)
     expect(options.pinnedDocuments.value.map(pin => pin.id)).toEqual([renamedId])
+
+    // The restart chain: startup pruning keeps the migrated pin only
+    // because the renamed record survived the capped, serialized write.
+    const prunedPins = prunePinnedDocuments(options.pinnedDocuments.value, storedIds)
+    expect(prunedPins.map(pin => pin.id)).toEqual([renamedId])
   })
 
   it('drops the entry and its pins when a rename keeps only temporary access', async () => {

--- a/src/features/home/homeDocumentActions.test.ts
+++ b/src/features/home/homeDocumentActions.test.ts
@@ -4,7 +4,11 @@ import { createHomeDocumentActions } from './homeDocumentActions'
 import { useDocumentSelection } from './useDocumentSelection'
 import { getAndroidDocumentUserMessage, AndroidDocumentError } from '../../lib/androidDocuments'
 import { createUntitledDocument } from '../../lib/documentState'
-import { getRecentDocumentListItems } from '../../lib/recentDocuments'
+import {
+  getRecentDocumentListItems,
+  parseRecentDocuments,
+  serializeRecentDocuments,
+} from '../../lib/recentDocuments'
 import type { LocalDraftRecord } from '../../lib/localDrafts'
 import type { PinnedDocumentRecord } from '../../lib/pinnedDocuments'
 import type { RecentDocumentRecord } from '../../lib/recentDocuments'
@@ -253,6 +257,52 @@ describe('homeDocumentActions', () => {
       ),
     ).toBe(true)
     expect(options.homeNotice.value).toBeNull()
+  })
+
+  it('migrates the pin before the recents write so a cap-exempt pinned record survives a rename', async () => {
+    // 100 newer unpinned records + the pinned OLDEST record being renamed:
+    // it only survives the recents storage cap through pin protection.
+    // The rename changes the URI (and therefore the record id), and the
+    // renamed record keeps its old timestamps — persisting it while the
+    // pin still carried the OLD id would evict it as an ordinary oldest
+    // unpinned record on that very write.
+    const base = Date.parse('2026-07-01T00:00:00.000Z')
+    const newerRecords = Array.from({ length: 100 }, (_, index) => ({
+      ...androidRecord,
+      id: `android-document:content://test/doc-${index}.md`,
+      sourceUri: `content://test/doc-${index}.md`,
+      updatedAt: new Date(base + (index + 1) * 60_000).toISOString(),
+      lastOpenedAt: new Date(base + (index + 1) * 60_000).toISOString(),
+    }))
+    const { actions, options } = createActions({
+      selectedIds: [androidRecord.id],
+      androidDocuments: [androidRecord, ...newerRecords],
+      pins: [{ id: androidRecord.id, pinnedAt: '2026-07-09T00:00:00.000Z' }],
+    })
+    options.documentItems.value = getRecentDocumentListItems(
+      options.androidRecentDocuments.value,
+      Number.POSITIVE_INFINITY,
+    )
+    // Mirror the App wiring: the persist callback applies the pin-aware
+    // storage cap with the pin set AS IT IS at call time.
+    options.persistAndroidRecentDocuments.mockImplementation(
+      (records: RecentDocumentRecord[]) => {
+        options.androidRecentDocuments.value = parseRecentDocuments(
+          serializeRecentDocuments(
+            records.filter(record => record.kind === 'android-document'),
+            new Set(options.pinnedDocuments.value.map(pin => pin.id)),
+          ),
+        )
+      },
+    )
+
+    await actions.renameSelectedDocument(androidRecord.id, 'renamed')
+
+    const renamedId = 'android-document:content://test/renamed.md'
+    const storedIds = options.androidRecentDocuments.value.map(record => record.id)
+    expect(storedIds).toContain(renamedId)
+    expect(storedIds).not.toContain(androidRecord.id)
+    expect(options.pinnedDocuments.value.map(pin => pin.id)).toEqual([renamedId])
   })
 
   it('drops the entry and its pins when a rename keeps only temporary access', async () => {

--- a/src/features/home/homeDocumentActions.ts
+++ b/src/features/home/homeDocumentActions.ts
@@ -202,6 +202,25 @@ export function createHomeDocumentActions(options: HomeDocumentActionsOptions): 
       return
     }
 
+    // Renaming can change the SAF URI, and the record ID embeds it —
+    // migrate the pin BEFORE the recents write: the recents storage cap
+    // uses the pin set for eviction protection, so persisting the renamed
+    // record while the pin still carries the OLD id would treat a
+    // cap-exempt pinned record as unpinned, evict it on that first write,
+    // and leave the subsequently migrated pin pointing at a record that
+    // startup pruning then deletes.
+    if (
+      result.updatedRecord.id !== result.previousId
+      && result.accessRetained
+      && options.pinnedDocuments.value.some(pin => pin.id === result.previousId)
+    ) {
+      options.persistPinnedDocuments(
+        options.pinnedDocuments.value.map(pin =>
+          pin.id === result.previousId ? { ...pin, id: result.updatedRecord.id } : pin,
+        ),
+      )
+    }
+
     const remainingRecentDocuments = options.androidRecentDocuments.value.filter(
       item => item.id !== result.previousId,
     )
@@ -211,19 +230,9 @@ export function createHomeDocumentActions(options: HomeDocumentActionsOptions): 
         : remainingRecentDocuments,
     )
 
-    // Renaming can change the SAF URI; migrate everything keyed by it.
+    // Everything else keyed by the SAF URI migrates after the stores are
+    // consistent.
     if (result.updatedRecord.id !== result.previousId) {
-      if (
-        result.accessRetained
-        && options.pinnedDocuments.value.some(pin => pin.id === result.previousId)
-      ) {
-        options.persistPinnedDocuments(
-          options.pinnedDocuments.value.map(pin =>
-            pin.id === result.previousId ? { ...pin, id: result.updatedRecord.id } : pin,
-          ),
-        )
-      }
-
       const previousUri = record.sourceUri
       const nextUri = result.updatedRecord.sourceUri
       if (previousUri && nextUri && previousUri !== nextUri) {

--- a/src/lib/documentStorage.test.ts
+++ b/src/lib/documentStorage.test.ts
@@ -102,6 +102,7 @@ describe('documentStorage', () => {
 
     const storedRecords = writeStoredAndroidRecentDocuments(
       [localRecentDocument, androidDocument],
+      undefined,
       storage,
     )
 
@@ -113,9 +114,39 @@ describe('documentStorage', () => {
     const storage = new MemoryStorage()
     storage.setItem(ANDROID_RECENT_DOCUMENTS_STORAGE_KEY, JSON.stringify([androidDocument]))
 
-    writeStoredAndroidRecentDocuments([createRecentDocumentFromLocalDraft(localDraft)], storage)
+    writeStoredAndroidRecentDocuments(
+      [createRecentDocumentFromLocalDraft(localDraft)],
+      undefined,
+      storage,
+    )
 
     expect(storage.getItem(ANDROID_RECENT_DOCUMENTS_STORAGE_KEY)).toBeNull()
+  })
+
+  it('keeps pinned Android records across the write cap and reloads', () => {
+    // The recents store is an Android document's only durable home, so a
+    // pin-blind write cap would silently delete the pinned document and
+    // its pin would be orphan-pruned on the next startup.
+    const storage = new MemoryStorage()
+    const base = Date.parse('2026-07-01T00:00:00.000Z')
+    // 102 records = 101 unpinned + 1 pinned: one over the 100-unpinned cap.
+    const records = Array.from({ length: 102 }, (_, index) => ({
+      ...androidDocument,
+      id: `android-document:content://provider/doc-${index}.md`,
+      sourceUri: `content://provider/doc-${index}.md`,
+      updatedAt: new Date(base + index * 60_000).toISOString(),
+      lastOpenedAt: new Date(base + index * 60_000).toISOString(),
+    }))
+    const pinnedOldest = records[0]
+
+    writeStoredAndroidRecentDocuments(records, new Set([pinnedOldest.id]), storage)
+
+    const reloaded = readStoredAndroidRecentDocuments(storage)
+    // 100 newest unpinned survive, plus the pinned oldest; the oldest
+    // UNPINNED record (index 1) is the one evicted.
+    expect(reloaded).toHaveLength(101)
+    expect(reloaded.some(record => record.id === pinnedOldest.id)).toBe(true)
+    expect(reloaded.some(record => record.id === records[1].id)).toBe(false)
   })
 
   it('round-trips pinned documents through their own storage key', () => {

--- a/src/lib/documentStorage.test.ts
+++ b/src/lib/documentStorage.test.ts
@@ -142,11 +142,13 @@ describe('documentStorage', () => {
     writeStoredAndroidRecentDocuments(records, new Set([pinnedOldest.id]), storage)
 
     const reloaded = readStoredAndroidRecentDocuments(storage)
-    // 100 newest unpinned survive, plus the pinned oldest; the oldest
-    // UNPINNED record (index 1) is the one evicted.
-    expect(reloaded).toHaveLength(101)
+    // The total cap holds: the pinned oldest claims a slot with priority
+    // and the 99 newest unpinned fill the rest; the oldest UNPINNED
+    // records are the ones evicted.
+    expect(reloaded).toHaveLength(100)
     expect(reloaded.some(record => record.id === pinnedOldest.id)).toBe(true)
     expect(reloaded.some(record => record.id === records[1].id)).toBe(false)
+    expect(reloaded.some(record => record.id === records[2].id)).toBe(false)
   })
 
   it('round-trips pinned documents through their own storage key', () => {

--- a/src/lib/documentStorage.ts
+++ b/src/lib/documentStorage.ts
@@ -72,6 +72,7 @@ export function readStoredAndroidRecentDocuments(
 
 export function writeStoredAndroidRecentDocuments(
   records: RecentDocumentRecord[],
+  protectedIds?: ReadonlySet<string>,
   storage: DocumentStorage = localStorage,
 ) {
   const androidDocuments = records.filter(record => record.kind === 'android-document')
@@ -79,7 +80,10 @@ export function writeStoredAndroidRecentDocuments(
   if (androidDocuments.length > 0) {
     storage.setItem(
       ANDROID_RECENT_DOCUMENTS_STORAGE_KEY,
-      serializeRecentDocuments(androidDocuments),
+      // Serialization re-applies the storage cap, so it needs the pinned
+      // ids too — otherwise a pinned record kept by a pin-aware upsert
+      // would be dropped right here on the way to disk.
+      serializeRecentDocuments(androidDocuments, protectedIds),
     )
   } else {
     storage.removeItem(ANDROID_RECENT_DOCUMENTS_STORAGE_KEY)

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -12,6 +12,7 @@ export const de = {
   'home.earlier': 'Früher',
   'home.emptyTitle': 'Keine zuletzt verwendeten Markdown-Dateien',
   'home.emptyBody': 'Beginne einen lokalen Entwurf oder öffne eine Markdown-Datei von diesem Gerät.',
+  'home.showAllDocuments': '{count} weitere anzeigen',
   'home.source.localDraft': 'Lokaler Entwurf',
   'home.source.markdownDocument': 'Markdown-Dokument',
   'home.wordCount.one': '{count} Wort',

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -13,6 +13,7 @@ export const de = {
   'home.emptyTitle': 'Keine zuletzt verwendeten Markdown-Dateien',
   'home.emptyBody': 'Beginne einen lokalen Entwurf oder öffne eine Markdown-Datei von diesem Gerät.',
   'home.showAllDocuments': '{count} weitere anzeigen',
+  'home.documentsRevealed': '{count} weitere Dokumente werden angezeigt',
   'home.source.localDraft': 'Lokaler Entwurf',
   'home.source.markdownDocument': 'Markdown-Dokument',
   'home.wordCount.one': '{count} Wort',

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -11,6 +11,7 @@ export const en = {
   'home.emptyTitle': 'No recent Markdown files',
   'home.emptyBody': 'Start a local draft or open a Markdown file from this device.',
   'home.showAllDocuments': 'Show {count} more',
+  'home.documentsRevealed': '{count} more documents shown',
   'home.source.localDraft': 'Local draft',
   'home.source.markdownDocument': 'Markdown document',
   'home.wordCount.one': '{count} word',

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -10,6 +10,7 @@ export const en = {
   'home.earlier': 'Earlier',
   'home.emptyTitle': 'No recent Markdown files',
   'home.emptyBody': 'Start a local draft or open a Markdown file from this device.',
+  'home.showAllDocuments': 'Show {count} more',
   'home.source.localDraft': 'Local draft',
   'home.source.markdownDocument': 'Markdown document',
   'home.wordCount.one': '{count} word',

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -13,6 +13,7 @@ export const es = {
   'home.emptyTitle': 'No hay archivos Markdown recientes',
   'home.emptyBody': 'Empieza un borrador local o abre un archivo Markdown de este dispositivo.',
   'home.showAllDocuments': 'Mostrar {count} más',
+  'home.documentsRevealed': 'Se muestran {count} documentos más',
   'home.source.localDraft': 'Borrador local',
   'home.source.markdownDocument': 'Documento Markdown',
   'home.wordCount.one': '{count} palabra',

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -12,6 +12,7 @@ export const es = {
   'home.earlier': 'Anteriores',
   'home.emptyTitle': 'No hay archivos Markdown recientes',
   'home.emptyBody': 'Empieza un borrador local o abre un archivo Markdown de este dispositivo.',
+  'home.showAllDocuments': 'Mostrar {count} más',
   'home.source.localDraft': 'Borrador local',
   'home.source.markdownDocument': 'Documento Markdown',
   'home.wordCount.one': '{count} palabra',

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -12,6 +12,7 @@ export const fr = {
   'home.earlier': 'Plus anciens',
   'home.emptyTitle': 'Aucun fichier Markdown récent',
   'home.emptyBody': 'Créez un brouillon local ou ouvrez un fichier Markdown depuis cet appareil.',
+  'home.showAllDocuments': 'Afficher {count} de plus',
   'home.source.localDraft': 'Brouillon local',
   'home.source.markdownDocument': 'Document Markdown',
   'home.wordCount.one': '{count} mot',

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -13,6 +13,7 @@ export const fr = {
   'home.emptyTitle': 'Aucun fichier Markdown récent',
   'home.emptyBody': 'Créez un brouillon local ou ouvrez un fichier Markdown depuis cet appareil.',
   'home.showAllDocuments': 'Afficher {count} de plus',
+  'home.documentsRevealed': '{count} documents de plus affichés',
   'home.source.localDraft': 'Brouillon local',
   'home.source.markdownDocument': 'Document Markdown',
   'home.wordCount.one': '{count} mot',

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -12,6 +12,7 @@ export const ja = {
   'home.earlier': 'それ以前',
   'home.emptyTitle': '最近の Markdown ファイルはありません',
   'home.emptyBody': 'ローカル下書きを新規作成するか、この端末の Markdown ファイルを開いてください。',
+  'home.showAllDocuments': 'さらに {count} 件を表示',
   'home.source.localDraft': 'ローカル下書き',
   'home.source.markdownDocument': 'Markdown ドキュメント',
   'home.wordCount.one': '{count} 語',

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -13,6 +13,7 @@ export const ja = {
   'home.emptyTitle': '最近の Markdown ファイルはありません',
   'home.emptyBody': 'ローカル下書きを新規作成するか、この端末の Markdown ファイルを開いてください。',
   'home.showAllDocuments': 'さらに {count} 件を表示',
+  'home.documentsRevealed': 'さらに {count} 件の文書を表示しました',
   'home.source.localDraft': 'ローカル下書き',
   'home.source.markdownDocument': 'Markdown ドキュメント',
   'home.wordCount.one': '{count} 語',

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -13,6 +13,7 @@ export const ko = {
   'home.emptyTitle': '최근 Markdown 파일 없음',
   'home.emptyBody': '로컬 초안을 시작하거나 이 기기의 Markdown 파일을 여세요.',
   'home.showAllDocuments': '이전 문서 {count}개 표시',
+  'home.documentsRevealed': '문서 {count}개를 더 표시했습니다',
   'home.source.localDraft': '로컬 초안',
   'home.source.markdownDocument': 'Markdown 문서',
   'home.wordCount.one': '{count}개 단어',

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -12,6 +12,7 @@ export const ko = {
   'home.earlier': '이전',
   'home.emptyTitle': '최근 Markdown 파일 없음',
   'home.emptyBody': '로컬 초안을 시작하거나 이 기기의 Markdown 파일을 여세요.',
+  'home.showAllDocuments': '이전 문서 {count}개 표시',
   'home.source.localDraft': '로컬 초안',
   'home.source.markdownDocument': 'Markdown 문서',
   'home.wordCount.one': '{count}개 단어',

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -12,6 +12,7 @@ export const pt = {
   'home.earlier': 'Anteriores',
   'home.emptyTitle': 'Nenhum arquivo Markdown recente',
   'home.emptyBody': 'Comece um rascunho local ou abra um arquivo Markdown deste dispositivo.',
+  'home.showAllDocuments': 'Mostrar mais {count}',
   'home.source.localDraft': 'Rascunho local',
   'home.source.markdownDocument': 'Documento Markdown',
   'home.wordCount.one': '{count} palavra',

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -13,6 +13,7 @@ export const pt = {
   'home.emptyTitle': 'Nenhum arquivo Markdown recente',
   'home.emptyBody': 'Comece um rascunho local ou abra um arquivo Markdown deste dispositivo.',
   'home.showAllDocuments': 'Mostrar mais {count}',
+  'home.documentsRevealed': 'Mais {count} documentos exibidos',
   'home.source.localDraft': 'Rascunho local',
   'home.source.markdownDocument': 'Documento Markdown',
   'home.wordCount.one': '{count} palavra',

--- a/src/lib/locales/tr.ts
+++ b/src/lib/locales/tr.ts
@@ -12,6 +12,7 @@ export const tr = {
   'home.earlier': 'Daha önce',
   'home.emptyTitle': 'Son kullanılan Markdown dosyası yok',
   'home.emptyBody': 'Yerel bir taslak başlatın veya bu cihazdan bir Markdown dosyası açın.',
+  'home.showAllDocuments': '{count} tane daha göster',
   'home.source.localDraft': 'Yerel taslak',
   'home.source.markdownDocument': 'Markdown belgesi',
   'home.wordCount.one': '{count} sözcük',

--- a/src/lib/locales/tr.ts
+++ b/src/lib/locales/tr.ts
@@ -13,6 +13,7 @@ export const tr = {
   'home.emptyTitle': 'Son kullanılan Markdown dosyası yok',
   'home.emptyBody': 'Yerel bir taslak başlatın veya bu cihazdan bir Markdown dosyası açın.',
   'home.showAllDocuments': '{count} tane daha göster',
+  'home.documentsRevealed': '{count} belge daha gösteriliyor',
   'home.source.localDraft': 'Yerel taslak',
   'home.source.markdownDocument': 'Markdown belgesi',
   'home.wordCount.one': '{count} sözcük',

--- a/src/lib/locales/zh-CN.ts
+++ b/src/lib/locales/zh-CN.ts
@@ -12,6 +12,7 @@ export const zhCN = {
   'home.earlier': '更早',
   'home.emptyTitle': '没有最近的 Markdown 文件',
   'home.emptyBody': '新建本地草稿，或从本机打开 Markdown 文件。',
+  'home.showAllDocuments': '显示更早的 {count} 篇',
   'home.source.localDraft': '本地草稿',
   'home.source.markdownDocument': 'Markdown 文档',
   'home.wordCount.one': '{count} 字',

--- a/src/lib/locales/zh-CN.ts
+++ b/src/lib/locales/zh-CN.ts
@@ -13,6 +13,7 @@ export const zhCN = {
   'home.emptyTitle': '没有最近的 Markdown 文件',
   'home.emptyBody': '新建本地草稿，或从本机打开 Markdown 文件。',
   'home.showAllDocuments': '显示更早的 {count} 篇',
+  'home.documentsRevealed': '已显示更早的 {count} 篇文档',
   'home.source.localDraft': '本地草稿',
   'home.source.markdownDocument': 'Markdown 文档',
   'home.wordCount.one': '{count} 字',

--- a/src/lib/locales/zh-TW.ts
+++ b/src/lib/locales/zh-TW.ts
@@ -12,6 +12,7 @@ export const zhTW = {
   'home.earlier': '更早',
   'home.emptyTitle': '沒有最近的 Markdown 檔案',
   'home.emptyBody': '建立本機草稿，或從此裝置開啟 Markdown 檔案。',
+  'home.showAllDocuments': '顯示更早的 {count} 篇',
   'home.source.localDraft': '本機草稿',
   'home.source.markdownDocument': 'Markdown 文件',
   'home.wordCount.one': '{count} 字',

--- a/src/lib/locales/zh-TW.ts
+++ b/src/lib/locales/zh-TW.ts
@@ -13,6 +13,7 @@ export const zhTW = {
   'home.emptyTitle': '沒有最近的 Markdown 檔案',
   'home.emptyBody': '建立本機草稿，或從此裝置開啟 Markdown 檔案。',
   'home.showAllDocuments': '顯示更早的 {count} 篇',
+  'home.documentsRevealed': '已顯示更早的 {count} 篇文件',
   'home.source.localDraft': '本機草稿',
   'home.source.markdownDocument': 'Markdown 文件',
   'home.wordCount.one': '{count} 字',

--- a/src/lib/recentDocuments.test.ts
+++ b/src/lib/recentDocuments.test.ts
@@ -256,7 +256,7 @@ describe('recentDocuments', () => {
       }))
     }
 
-    it('evicts the oldest UNPINNED record when an upsert crosses the cap', () => {
+    it('evicts the oldest UNPINNED records when an upsert crosses the cap', () => {
       // The concrete data-loss sequence: 100 unpinned Android records +
       // 1 pinned oldest, then the user opens one more document. Pin-blind
       // recency eviction would drop the pinned record — whose only
@@ -279,14 +279,17 @@ describe('recentDocuments', () => {
         new Set([pinnedOldest.id]),
       )
 
-      expect(records).toHaveLength(101)
+      // The limit is a TOTAL cap: the pinned record claims a slot with
+      // priority, the newest unprotected records fill the remainder.
+      expect(records).toHaveLength(100)
       expect(records.some(record => record.id === pinnedOldest.id)).toBe(true)
       expect(records.some(record => record.id === incoming.id)).toBe(true)
-      // The oldest unpinned record is the one that leaves.
+      // The oldest unpinned records are the ones that leave.
       expect(records.some(record => record.id === existing[1].id)).toBe(false)
+      expect(records.some(record => record.id === existing[2].id)).toBe(false)
     })
 
-    it('serializes pinned records past the cap and parses them back uncapped', () => {
+    it('serializes a pinned beyond-cap record and parses it back uncapped', () => {
       const records = androidRecords(102)
       const pinnedOldest = records[0]
 
@@ -294,10 +297,30 @@ describe('recentDocuments', () => {
         serializeRecentDocuments(records, new Set([pinnedOldest.id])),
       )
 
-      // 100 newest unpinned + the pinned oldest survive serialization;
-      // the read side must not re-cap them (it has no pin knowledge).
-      expect(roundTripped).toHaveLength(101)
+      // The pinned oldest plus the 99 newest unpinned survive within the
+      // total cap; the read side must not re-cap them (it has no pin
+      // knowledge).
+      expect(roundTripped).toHaveLength(100)
       expect(roundTripped.some(record => record.id === pinnedOldest.id)).toBe(true)
+    })
+
+    it('never exceeds the total cap even at the pin ceiling', () => {
+      // Worst case: 50 pinned (the pin store's own ceiling) + 100
+      // unpinned. The advertised cap is a TOTAL — the store must hold
+      // 100 records (50 pinned + the 50 newest unpinned), not 150,
+      // preserving the headroom argument under Android <= 10's
+      // 128-persisted-grant limit.
+      const records = androidRecords(150)
+      const pinnedIds = new Set(records.slice(0, 50).map(record => record.id))
+
+      const roundTripped = parseRecentDocuments(
+        serializeRecentDocuments(records, pinnedIds),
+      )
+
+      expect(roundTripped).toHaveLength(100)
+      for (const id of pinnedIds) {
+        expect(roundTripped.some(record => record.id === id)).toBe(true)
+      }
     })
   })
 })

--- a/src/lib/recentDocuments.test.ts
+++ b/src/lib/recentDocuments.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeRecentDocuments,
   parseRecentDocuments,
   serializeRecentDocuments,
+  toRecentDocumentListItems,
   upsertRecentDocument,
   type RecentDocumentRecord,
 } from './recentDocuments'
@@ -227,5 +228,76 @@ describe('recentDocuments', () => {
     expect(getRecentDocumentListItems(drafts)).toHaveLength(100)
     // The "show all" expansion reads the COMPLETE collection.
     expect(getRecentDocumentListItems(drafts, Number.POSITIVE_INFINITY)).toHaveLength(105)
+  })
+
+  it('materializes list items from pre-sorted records without reordering', () => {
+    // toRecentDocumentListItems is the projection stage AFTER settings
+    // sorting — re-normalizing here would re-sort by recency and destroy
+    // a title or ascending order.
+    const older = createRecentDocumentFromLocalDraft(olderDraft)
+    const newer = createRecentDocumentFromLocalDraft(newerDraft)
+
+    const items = toRecentDocumentListItems([older, newer])
+
+    expect(items.map(item => item.id)).toEqual(['older', 'newer'])
+    expect(items[0].stats?.words).toBe(3)
+  })
+
+  describe('the storage cap protects pinned records', () => {
+    const base = Date.parse('2026-06-01T00:00:00.000Z')
+
+    function androidRecords(count: number) {
+      return Array.from({ length: count }, (_, index) => ({
+        ...androidDocument,
+        id: `android-document:content://provider/doc-${index}.md`,
+        sourceUri: `content://provider/doc-${index}.md`,
+        updatedAt: new Date(base + index * 60_000).toISOString(),
+        lastOpenedAt: new Date(base + index * 60_000).toISOString(),
+      }))
+    }
+
+    it('evicts the oldest UNPINNED record when an upsert crosses the cap', () => {
+      // The concrete data-loss sequence: 100 unpinned Android records +
+      // 1 pinned oldest, then the user opens one more document. Pin-blind
+      // recency eviction would drop the pinned record — whose only
+      // durable home is this store — and its pin would be orphan-pruned
+      // at the next startup.
+      const existing = androidRecords(101)
+      const pinnedOldest = existing[0]
+      const incoming = {
+        ...androidDocument,
+        id: 'android-document:content://provider/incoming.md',
+        sourceUri: 'content://provider/incoming.md',
+        updatedAt: new Date(base + 200 * 60_000).toISOString(),
+        lastOpenedAt: new Date(base + 200 * 60_000).toISOString(),
+      }
+
+      const records = upsertRecentDocument(
+        existing,
+        incoming,
+        undefined,
+        new Set([pinnedOldest.id]),
+      )
+
+      expect(records).toHaveLength(101)
+      expect(records.some(record => record.id === pinnedOldest.id)).toBe(true)
+      expect(records.some(record => record.id === incoming.id)).toBe(true)
+      // The oldest unpinned record is the one that leaves.
+      expect(records.some(record => record.id === existing[1].id)).toBe(false)
+    })
+
+    it('serializes pinned records past the cap and parses them back uncapped', () => {
+      const records = androidRecords(102)
+      const pinnedOldest = records[0]
+
+      const roundTripped = parseRecentDocuments(
+        serializeRecentDocuments(records, new Set([pinnedOldest.id])),
+      )
+
+      // 100 newest unpinned + the pinned oldest survive serialization;
+      // the read side must not re-cap them (it has no pin knowledge).
+      expect(roundTripped).toHaveLength(101)
+      expect(roundTripped.some(record => record.id === pinnedOldest.id)).toBe(true)
+    })
   })
 })

--- a/src/lib/recentDocuments.test.ts
+++ b/src/lib/recentDocuments.test.ts
@@ -211,4 +211,21 @@ describe('recentDocuments', () => {
 
     expect(items[0].stats).toBeNull()
   })
+
+  it('caps the resting list at 100 and lets an explicit limit read past it (#151)', () => {
+    const base = Date.parse('2026-06-01T00:00:00.000Z')
+    const drafts = Array.from({ length: 105 }, (_, i) =>
+      createRecentDocumentFromLocalDraft({
+        id: `draft-${i + 1}`,
+        markdown: `# Draft ${i + 1}\n\ncontent`,
+        createdAt: new Date(base).toISOString(),
+        updatedAt: new Date(base + (i + 1) * 1000).toISOString(),
+        lastSavedAt: null,
+      }),
+    )
+
+    expect(getRecentDocumentListItems(drafts)).toHaveLength(100)
+    // The "show all" expansion reads the COMPLETE collection.
+    expect(getRecentDocumentListItems(drafts, Number.POSITIVE_INFINITY)).toHaveLength(105)
+  })
 })

--- a/src/lib/recentDocuments.ts
+++ b/src/lib/recentDocuments.ts
@@ -58,7 +58,14 @@ type StoredRecentDocumentRecord = Omit<RecentDocumentRecord, 'createdAt'> & {
   createdAt?: string
 }
 
-const DEFAULT_RECENT_LIMIT = 50
+// Presentation cap for the home's resting view AND the write cap for the
+// stored Android recents (their records carry SAF URI references, which
+// must not grow unboundedly — the fine-grained grant lifecycle is #153).
+// 100 is double Word's own recent-list ceiling and leaves headroom under
+// Android 10-and-below's 128-grant system limit. Local drafts are NEVER
+// bounded by this: their storage is complete, and the home's "show all"
+// expansion reads past the cap (#151).
+const DEFAULT_RECENT_LIMIT = 100
 
 function isRecentDocumentKind(value: unknown): value is RecentDocumentKind {
   return value === 'local-draft' || value === 'android-document' || value === 'incoming-document'
@@ -252,8 +259,9 @@ export function markRecentDocumentSaved(
 
 export function getRecentDocumentListItems(
   records: RecentDocumentRecord[],
+  limit = DEFAULT_RECENT_LIMIT,
 ): RecentDocumentListItem[] {
-  return normalizeRecentDocuments(records).map(record => ({
+  return normalizeRecentDocuments(records, limit).map(record => ({
     ...record,
     stats: record.markdownPreview ? getDocumentStats(record.markdownPreview) : null,
   }))

--- a/src/lib/recentDocuments.ts
+++ b/src/lib/recentDocuments.ts
@@ -62,9 +62,13 @@ type StoredRecentDocumentRecord = Omit<RecentDocumentRecord, 'createdAt'> & {
 // stored Android recents (their records carry SAF URI references, which
 // must not grow unboundedly — the fine-grained grant lifecycle is #153).
 // 100 is double Word's own recent-list ceiling and leaves headroom under
-// Android 10-and-below's 128-grant system limit. Local drafts are NEVER
-// bounded by this: their storage is complete, and the home's "show all"
-// expansion reads past the cap (#151).
+// Android 10-and-below's 128-grant system limit. The limit is a TOTAL:
+// protected (pinned) records occupy slots inside it with priority and the
+// newest unprotected records fill the remainder, so the store never
+// exceeds 100 records (pins are separately capped at 50, so protection
+// alone can never overflow the total). Local drafts are NEVER bounded by
+// this: their storage is complete, and the home's "show all" expansion
+// reads past the cap (#151).
 const DEFAULT_RECENT_LIMIT = 100
 
 function isRecentDocumentKind(value: unknown): value is RecentDocumentKind {
@@ -181,7 +185,6 @@ export function normalizeRecentDocuments(
 ) {
   const seen = new Set<string>()
   const normalized: RecentDocumentRecord[] = []
-  let unprotectedCount = 0
 
   for (const rawRecord of [...records].sort(compareRecentDocuments)) {
     const record = normalizeRecentDocumentRecord(rawRecord)
@@ -194,25 +197,40 @@ export function normalizeRecentDocuments(
       continue
     }
 
-    // The cap evicts the oldest UNPROTECTED records; a protected record
-    // (a pinned document, whose only durable home may be this store) is
-    // kept regardless of age — pinning is explicit intent, and recency
-    // eviction silently deleting it would also orphan-prune its pin on
-    // the next startup. Growth stays bounded: at most `limit` unprotected
-    // records plus the (separately capped) pinned set.
-    const isProtected = protectedIds?.has(record.id) ?? false
-    if (!isProtected) {
-      if (unprotectedCount >= limit) {
-        continue
-      }
-      unprotectedCount++
-    }
-
     seen.add(key)
     normalized.push(record)
   }
 
-  return normalized
+  if (normalized.length <= limit) {
+    return normalized
+  }
+
+  // The limit is a TOTAL cap. Protected records (pinned documents, whose
+  // only durable home may be this store) claim their slots first and are
+  // kept regardless of age — pinning is explicit intent, and recency
+  // eviction silently deleting one would also orphan-prune its pin on
+  // the next startup. The NEWEST unprotected records fill the remaining
+  // slots, so the oldest unprotected record is the one evicted and the
+  // store never exceeds `limit`.
+  const protectedCount = protectedIds
+    ? normalized.filter(record => protectedIds.has(record.id)).length
+    : 0
+  let unprotectedAllowance = Math.max(0, limit - protectedCount)
+
+  const capped: RecentDocumentRecord[] = []
+  for (const record of normalized) {
+    const isProtected = protectedIds?.has(record.id) ?? false
+    if (!isProtected) {
+      if (unprotectedAllowance <= 0) {
+        continue
+      }
+      unprotectedAllowance--
+    }
+
+    capped.push(record)
+  }
+
+  return capped
 }
 
 export function parseRecentDocuments(value: string | null) {

--- a/src/lib/recentDocuments.ts
+++ b/src/lib/recentDocuments.ts
@@ -177,9 +177,11 @@ export function createRecentDocumentFromAndroidDocument(
 export function normalizeRecentDocuments(
   records: StoredRecentDocumentRecord[],
   limit = DEFAULT_RECENT_LIMIT,
+  protectedIds?: ReadonlySet<string>,
 ) {
   const seen = new Set<string>()
   const normalized: RecentDocumentRecord[] = []
+  let unprotectedCount = 0
 
   for (const rawRecord of [...records].sort(compareRecentDocuments)) {
     const record = normalizeRecentDocumentRecord(rawRecord)
@@ -192,11 +194,25 @@ export function normalizeRecentDocuments(
       continue
     }
 
+    // The cap evicts the oldest UNPROTECTED records; a protected record
+    // (a pinned document, whose only durable home may be this store) is
+    // kept regardless of age — pinning is explicit intent, and recency
+    // eviction silently deleting it would also orphan-prune its pin on
+    // the next startup. Growth stays bounded: at most `limit` unprotected
+    // records plus the (separately capped) pinned set.
+    const isProtected = protectedIds?.has(record.id) ?? false
+    if (!isProtected) {
+      if (unprotectedCount >= limit) {
+        continue
+      }
+      unprotectedCount++
+    }
+
     seen.add(key)
     normalized.push(record)
   }
 
-  return normalized.slice(0, limit)
+  return normalized
 }
 
 export function parseRecentDocuments(value: string | null) {
@@ -210,20 +226,30 @@ export function parseRecentDocuments(value: string | null) {
       return []
     }
 
-    return normalizeRecentDocuments(parsed.filter(isStoredRecentDocumentRecord))
+    // Read-side is deliberately uncapped: the cap is enforced on every
+    // write (pin-aware), and re-capping here without the pin set would
+    // evict pinned-beyond-cap records on every restart.
+    return normalizeRecentDocuments(
+      parsed.filter(isStoredRecentDocumentRecord),
+      Number.POSITIVE_INFINITY,
+    )
   } catch {
     return []
   }
 }
 
-export function serializeRecentDocuments(records: RecentDocumentRecord[]) {
-  return JSON.stringify(normalizeRecentDocuments(records))
+export function serializeRecentDocuments(
+  records: RecentDocumentRecord[],
+  protectedIds?: ReadonlySet<string>,
+) {
+  return JSON.stringify(normalizeRecentDocuments(records, DEFAULT_RECENT_LIMIT, protectedIds))
 }
 
 export function upsertRecentDocument(
   records: RecentDocumentRecord[],
   nextRecord: RecentDocumentRecord,
   limit = DEFAULT_RECENT_LIMIT,
+  protectedIds?: ReadonlySet<string>,
 ) {
   const nextKey = getRecentDocumentKey(nextRecord)
   const existingRecord = records.find(record => getRecentDocumentKey(record) === nextKey)
@@ -238,6 +264,7 @@ export function upsertRecentDocument(
       ...records.filter(record => getRecentDocumentKey(record) !== nextKey),
     ],
     limit,
+    protectedIds,
   )
 }
 
@@ -257,12 +284,24 @@ export function markRecentDocumentSaved(
   }
 }
 
+/**
+ * Materialize list items (with document statistics) from ALREADY
+ * normalized records, preserving their order. Statistics scan each
+ * draft's full Markdown body, so callers keep projections cheap by
+ * materializing only the records they will actually render.
+ */
+export function toRecentDocumentListItems(
+  records: RecentDocumentRecord[],
+): RecentDocumentListItem[] {
+  return records.map(record => ({
+    ...record,
+    stats: record.markdownPreview ? getDocumentStats(record.markdownPreview) : null,
+  }))
+}
+
 export function getRecentDocumentListItems(
   records: RecentDocumentRecord[],
   limit = DEFAULT_RECENT_LIMIT,
 ): RecentDocumentListItem[] {
-  return normalizeRecentDocuments(records, limit).map(record => ({
-    ...record,
-    stats: record.markdownPreview ? getDocumentStats(record.markdownPreview) : null,
-  }))
+  return toRecentDocumentListItems(normalizeRecentDocuments(records, limit))
 }

--- a/src/style.css
+++ b/src/style.css
@@ -259,6 +259,35 @@ textarea {
   text-transform: uppercase;
 }
 
+/* The "show all" expander (#151): a quiet text action closing the Earlier
+   list; present only while older documents are hidden by the recency cap. */
+.home-show-all {
+  display: block;
+  min-height: 44px;
+  margin: 4px auto 0;
+  padding: 0 16px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--accent-strong);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.006em;
+  touch-action: manipulation;
+  transition: background-color var(--dur-standard) var(--ease-out);
+}
+
+.home-show-all:active {
+  background: var(--press);
+  transition-duration: 0ms;
+}
+
+.home-show-all:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
 .home-content {
   max-width: 720px;
   margin: 6px auto 0;

--- a/src/style.css
+++ b/src/style.css
@@ -288,6 +288,20 @@ textarea {
   outline-offset: -2px;
 }
 
+/* Screen-reader-only live region announcing how many rows the expander
+   revealed; visually collapsed but never display:none, which would mute
+   the announcement. */
+.home-reveal-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
 .home-content {
   max-width: 720px;
   margin: 6px auto 0;

--- a/tests/e2e/mobile-home-show-all.spec.ts
+++ b/tests/e2e/mobile-home-show-all.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test, type Page } from '@playwright/test'
 import { DRAFTS_STORAGE_KEY } from './helpers/drafts'
 
+const SETTINGS_STORAGE_KEY = 'marktext-for-android:settings-ui'
+
 test.describe.configure({ timeout: 60000 })
 
 // #151 — drafts beyond the home's recency cap existed with no UI path to
@@ -88,6 +90,56 @@ test('expansion hands focus to the first revealed row and announces the growth',
 
   // The polite live region tells assistive tech how many rows appeared.
   await expect(page.getByTestId('home-reveal-status')).toHaveText(/5/)
+})
+
+test('focus reaches the Continue masthead when the only revealed record sorts first', async ({ page }) => {
+  // Under title-ascending sort, the single record hidden by the recency
+  // cap can become the CONTINUE masthead after expansion rather than a
+  // regular row — the focus scan must cover that button too, or the
+  // expander's self-removal drops focus to <body>.
+  const base = Date.parse('2026-06-01T00:00:00.000Z')
+  const hiddenOldest = {
+    id: 'draft-hidden',
+    markdown: '# AAA hidden\n\npayload-hidden\n',
+    createdAt: new Date(base).toISOString(),
+    updatedAt: new Date(base).toISOString(),
+    lastSavedAt: new Date(base).toISOString(),
+  }
+  const newerDrafts = Array.from({ length: 100 }, (_, i) => ({
+    id: `draft-${String(i + 1).padStart(3, '0')}`,
+    markdown: `# ZZZ Probe ${i + 1}\n\npayload-${i + 1}\n`,
+    createdAt: new Date(base).toISOString(),
+    updatedAt: new Date(base + (i + 1) * 60_000).toISOString(),
+    lastSavedAt: new Date(base + (i + 1) * 60_000).toISOString(),
+  }))
+
+  await page.goto('/')
+  await page.evaluate(
+    ({ draftsStorageKey, settingsStorageKey, drafts }) => {
+      localStorage.clear()
+      localStorage.setItem(draftsStorageKey, JSON.stringify(drafts))
+      localStorage.setItem(
+        settingsStorageKey,
+        JSON.stringify({ fileSortBy: 'title', fileSortOrder: 'asc' }),
+      )
+    },
+    {
+      draftsStorageKey: DRAFTS_STORAGE_KEY,
+      settingsStorageKey: SETTINGS_STORAGE_KEY,
+      drafts: [hiddenOldest, ...newerDrafts],
+    },
+  )
+  await page.reload()
+
+  await page.getByTestId('home-show-all-button').focus()
+  await page.keyboard.press('Enter')
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => document.activeElement?.getAttribute('data-doc-id') ?? ''),
+    )
+    .toBe('draft-hidden')
+  await expect(page.getByTestId('home-reveal-status')).toHaveText(/1/)
 })
 
 test('pinning a beyond-cap draft keeps it visible in the resting view', async ({ page }) => {

--- a/tests/e2e/mobile-home-show-all.spec.ts
+++ b/tests/e2e/mobile-home-show-all.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test, type Page } from '@playwright/test'
+import { DRAFTS_STORAGE_KEY } from './helpers/drafts'
+
+test.describe.configure({ timeout: 60000 })
+
+// #151 — drafts beyond the home's recency cap existed with no UI path to
+// them. The quiet resting view keeps the cap (100); a "show more" text
+// action at the end of Earlier expands the list to the COMPLETE draft
+// collection. Expansion is ephemeral state: it never writes storage.
+
+const TOTAL = 105
+
+function seededDrafts() {
+  const base = Date.parse('2026-06-01T00:00:00.000Z')
+  return Array.from({ length: TOTAL }, (_, i) => ({
+    id: `draft-${String(i + 1).padStart(3, '0')}`,
+    markdown: `# Probe ${i + 1}\n\npayload-${i + 1}\n`,
+    createdAt: new Date(base).toISOString(),
+    updatedAt: new Date(base + (i + 1) * 60_000).toISOString(),
+    lastSavedAt: new Date(base + (i + 1) * 60_000).toISOString(),
+  }))
+}
+
+async function openSeededHome(page: Page) {
+  await page.goto('/')
+  await page.evaluate(
+    ({ draftsStorageKey, drafts }) => {
+      localStorage.clear()
+      localStorage.setItem(draftsStorageKey, JSON.stringify(drafts))
+    },
+    { draftsStorageKey: DRAFTS_STORAGE_KEY, drafts: seededDrafts() },
+  )
+  await page.reload()
+}
+
+function documentRows(page: Page) {
+  return page.getByTestId('documents-screen').getByRole('button', { name: /Probe \d+/ })
+}
+
+test('every draft beyond the cap is reachable through show-more', async ({ page }) => {
+  await openSeededHome(page)
+
+  // Resting view: exactly the capped 100 (Continue masthead + Earlier),
+  // and the quiet expander names what is hidden.
+  await expect(documentRows(page)).toHaveCount(100)
+  const showAll = page.getByTestId('home-show-all-button')
+  await expect(showAll).toHaveText(/5/)
+
+  const storageBefore = await page.evaluate(
+    key => localStorage.getItem(key) ?? '',
+    DRAFTS_STORAGE_KEY,
+  )
+
+  await showAll.click()
+  await expect(documentRows(page)).toHaveCount(TOTAL)
+  await expect(page.getByTestId('home-show-all-button')).toHaveCount(0)
+
+  // The expansion is presentation-only: the durable collection is
+  // byte-identical.
+  const storageAfter = await page.evaluate(
+    key => localStorage.getItem(key) ?? '',
+    DRAFTS_STORAGE_KEY,
+  )
+  expect(storageAfter).toBe(storageBefore)
+
+  // The OLDEST draft — unreachable before this change — opens normally.
+  await page.getByRole('button', { name: /Probe 1(?!\d)/ }).click()
+  await expect(page.getByTestId('editor-host')).toContainText('payload-1')
+})
+
+test('pinning a beyond-cap draft keeps it visible in the resting view', async ({ page }) => {
+  await openSeededHome(page)
+
+  await page.getByTestId('home-show-all-button').click()
+  const oldest = page.getByRole('button', { name: /Probe 1(?!\d)/ })
+  await oldest.click({ delay: 700 })
+
+  await expect(page.getByTestId('home-selection-bar')).toBeVisible()
+  await page.getByTestId('home-selection-pin').click()
+
+  // Fresh visit (selection and expansion are both ephemeral): the list
+  // rests collapsed again, but the pinned beyond-cap draft stays
+  // visible — pinning is explicit intent.
+  await page.reload()
+  await expect(page.getByRole('button', { name: /Probe 1(?!\d)/ })).toBeVisible()
+  await expect(page.getByTestId('home-show-all-button')).toHaveText(/4/)
+})

--- a/tests/e2e/mobile-home-show-all.spec.ts
+++ b/tests/e2e/mobile-home-show-all.spec.ts
@@ -68,6 +68,28 @@ test('every draft beyond the cap is reachable through show-more', async ({ page 
   await expect(page.getByTestId('editor-host')).toContainText('payload-1')
 })
 
+test('expansion hands focus to the first revealed row and announces the growth', async ({ page }) => {
+  await openSeededHome(page)
+
+  // Activate the expander from the keyboard: it removes itself once
+  // nothing is hidden, and dropping focus to <body> would send a
+  // keyboard or switch-access user back through ~100 rows.
+  await page.getByTestId('home-show-all-button').focus()
+  await page.keyboard.press('Enter')
+
+  await expect(documentRows(page)).toHaveCount(TOTAL)
+  // Default sort is newest-first, so the first newly revealed row in DOM
+  // order is the newest previously hidden draft (Probe 5).
+  await expect
+    .poll(async () =>
+      page.evaluate(() => document.activeElement?.getAttribute('data-doc-id') ?? ''),
+    )
+    .toBe('draft-005')
+
+  // The polite live region tells assistive tech how many rows appeared.
+  await expect(page.getByTestId('home-reveal-status')).toHaveText(/5/)
+})
+
 test('pinning a beyond-cap draft keeps it visible in the resting view', async ({ page }) => {
   await openSeededHome(page)
 


### PR DESCRIPTION
Closes #151.

## The problem

Drafts are stored completely — nothing is ever destructively capped — but the home list is a **recency projection with a hard cap**. A draft pushed past the cap kept existing with no UI path to it: to the user, indistinguishable from data loss.

## The design (as discussed)

- The resting home keeps its quiet, capped recent-first view.
- A **'Show N more'** text action closes the Earlier section whenever older documents are hidden. It expands the list **in place** to the complete collection, so every existing row affordance — open, long-press multi-select, pin, delete, rename — works on deep items with zero new machinery.
- Expansion is **ephemeral presentation state**: it never writes storage (pinned in the E2E byte-for-byte).
- **Pinned documents beyond the cap stay visible in the resting view** — pinning is explicit intent and must not silently un-surface when newer items push the pin past the cap.
- The cap rises **50 → 100** (review discussion): double Word's own recent-list ceiling (0–50), with headroom under Android ≤ 10's 128-persisted-grant system limit for Android-document records carrying SAF references. Their fine-grained grant lifecycle remains #153; local drafts are never bounded by this number at all.

## Hardening after review

- **The cap limits computation, not just rendered rows.** The first cut materialized list items (whose statistics scan each draft's full Markdown) for the complete collection even while collapsed, then filtered back — and a selection-retention watcher kept that work hot on every autosave. The projection is now layered with an honest cost model: list-item STATISTICS (full-Markdown scans per draft) are materialized only for the records the current state actually renders; the records level is cheaper but not free (local-draft records derive their title from the draft's Markdown), so the selection-retention watcher short-circuits its source and unsubscribes from the projection entirely while no selection is active — a watcher must evaluate its source on every dependency change, so a callback-side guard could not prevent autosaves from pulling the chain hot off-home (verified with a reactivity probe: guard off, zero projection evaluations on a draft change).
- **The Android recents storage cap is pin-aware.** That store is an Android document's only durable home, and the cap was pin-blind at all three layers (upsert, serialize, parse): with 100+ records, opening one more evicted the oldest record even if pinned, and startup pruning then deleted the orphaned pin permanently. Writes now carry the pinned id set and evict the oldest UNPINNED records; reads are uncapped (the cap is enforced pin-aware on every write, and re-capping on read without pin knowledge would undo it). The limit is a TOTAL: protected records claim slots with priority and the newest unpinned records fill the remainder, so the store never exceeds 100 (pins are separately capped at 50, so protection alone cannot overflow it) and the 128-grant headroom argument stays intact. Rename ordering is part of the contract: a SAF rename can change the record id, so the pin migrates to the new id BEFORE the recents write — persisting first with the stale pin set would evict a cap-exempt pinned record on that very write.
- **Expansion keeps focus and announces itself.** The show-all button removes itself once nothing is hidden, which dropped keyboard/switch-access focus to `<body>`; the home now snapshots visible ids at activation, moves focus to the first newly revealed row in DOM order (revealed records interleave under title/ascending sorts), and reports the revealed count through an always-mounted polite live region.

## Verification

- Unit: resting projection caps at 100 while an explicit limit reads the complete collection; records-level sorted projection is uncapped and stats-free; item materialization preserves pre-sorted order; pin-protected cap crossings at the upsert, serialize/parse, and storage round-trip layers (100 unpinned + pinned-oldest + one more ⇒ oldest unpinned evicted, pinned record survives reload).
- E2E (105 seeded drafts): resting view shows exactly 100 with the expander naming the hidden 5; expansion reaches all 105 with the drafts store **byte-identical** before/after; the previously unreachable oldest draft opens and renders; keyboard activation lands focus on the first newly revealed row with the polite announcement present; under title-ascending sort with a single hidden record, focus lands on the Continue masthead that record becomes; pinning a beyond-cap draft in the expanded view keeps it visible after a fresh visit in the resting view.
- Home regression: document-management, navigation, and documents-settings suites green; 641 unit tests, typecheck and lint clean; ten locales gain the expander and announcement strings. The rename cap-crossing regression was verified in BOTH directions (temporarily reverting the pin-migration order makes it fail; the shipped order passes) and extends through the restart chain (startup pin pruning keeps the migrated pin).

