### PR TITLE
Make theme picker rows full-width targets, rename Custom mode to More

### DIFF
--- a/src/features/settings/components/SettingsSelectRow.vue
+++ b/src/features/settings/components/SettingsSelectRow.vue
@@ -270,6 +270,12 @@ function selectOption(value: string) {
 
 .settings-select-panel {
   display: grid;
+  /* The single implicit column must be explicit: an auto track sizes to its
+     content, which shrank every option row (and its divider) to the width of
+     its swatches + label — the space right of the radio was dead to taps.
+     A 1fr track stretches the rows to the panel, so the WHOLE row is the
+     hit target and the radio marks align on the right edge. */
+  grid-template-columns: minmax(0, 1fr);
   width: min(100%, 520px);
   max-height: min(72vh, 620px);
   overflow: auto;
@@ -295,6 +301,10 @@ function selectOption(value: string) {
   grid-template-columns: minmax(0, 1fr) 22px;
   align-items: center;
   gap: 16px;
+  /* A button's auto width is shrink-to-fit even as a grid container, which
+     silently collapsed every row (and its divider) to its content — the
+     space right of the radio was dead to taps. The row IS the hit target. */
+  width: 100%;
   min-height: 52px;
   padding: 0 12px 0 14px;
   border: 0;

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -490,7 +490,7 @@ export const de = {
   'settings.option.system': 'System',
   'settings.option.light': 'Hell',
   'settings.option.dark': 'Dunkel',
-  'settings.option.custom': 'Benutzerdefiniert',
+  'settings.option.custom': 'Mehr',
   'settings.option.off': 'Aus',
   'settings.option.ltr': 'LTR',
   'settings.option.rtl': 'RTL',

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -485,7 +485,7 @@ export const en = {
   'settings.option.system': 'System',
   'settings.option.light': 'Light',
   'settings.option.dark': 'Dark',
-  'settings.option.custom': 'Custom',
+  'settings.option.custom': 'More',
   'settings.option.off': 'Off',
   'settings.option.ltr': 'LTR',
   'settings.option.rtl': 'RTL',

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -490,7 +490,7 @@ export const es = {
   'settings.option.system': 'Sistema',
   'settings.option.light': 'Claro',
   'settings.option.dark': 'Oscuro',
-  'settings.option.custom': 'Personalizado',
+  'settings.option.custom': 'Más',
   'settings.option.off': 'Desactivado',
   'settings.option.ltr': 'LTR',
   'settings.option.rtl': 'RTL',

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -490,7 +490,7 @@ export const fr = {
   'settings.option.system': 'Système',
   'settings.option.light': 'Clair',
   'settings.option.dark': 'Sombre',
-  'settings.option.custom': 'Personnalisé',
+  'settings.option.custom': 'Plus',
   'settings.option.off': 'Désactivé',
   'settings.option.ltr': 'LTR',
   'settings.option.rtl': 'RTL',

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -490,7 +490,7 @@ export const ja = {
   'settings.option.system': 'システム',
   'settings.option.light': 'ライト',
   'settings.option.dark': 'ダーク',
-  'settings.option.custom': 'カスタム',
+  'settings.option.custom': 'その他',
   'settings.option.off': 'オフ',
   'settings.option.ltr': 'LTR',
   'settings.option.rtl': 'RTL',

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -490,7 +490,7 @@ export const ko = {
   'settings.option.system': '시스템',
   'settings.option.light': '라이트',
   'settings.option.dark': '다크',
-  'settings.option.custom': '사용자 정의',
+  'settings.option.custom': '더보기',
   'settings.option.off': '꺼짐',
   'settings.option.ltr': 'LTR',
   'settings.option.rtl': 'RTL',

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -490,7 +490,7 @@ export const pt = {
   'settings.option.system': 'Sistema',
   'settings.option.light': 'Claro',
   'settings.option.dark': 'Escuro',
-  'settings.option.custom': 'Personalizado',
+  'settings.option.custom': 'Mais',
   'settings.option.off': 'Desativado',
   'settings.option.ltr': 'LTR',
   'settings.option.rtl': 'RTL',

--- a/src/lib/locales/tr.ts
+++ b/src/lib/locales/tr.ts
@@ -490,7 +490,7 @@ export const tr = {
   'settings.option.system': 'Sistem',
   'settings.option.light': 'Açık',
   'settings.option.dark': 'Koyu',
-  'settings.option.custom': 'Özel',
+  'settings.option.custom': 'Daha fazla',
   'settings.option.off': 'Kapalı',
   'settings.option.ltr': 'LTR',
   'settings.option.rtl': 'RTL',

--- a/src/lib/locales/zh-CN.ts
+++ b/src/lib/locales/zh-CN.ts
@@ -483,7 +483,7 @@ export const zhCN = {
   'settings.option.system': '系统',
   'settings.option.light': '浅色',
   'settings.option.dark': '深色',
-  'settings.option.custom': '自定义',
+  'settings.option.custom': '更多',
   'settings.option.off': '关',
   'settings.option.ltr': 'LTR',
   'settings.option.rtl': 'RTL',

--- a/src/lib/locales/zh-TW.ts
+++ b/src/lib/locales/zh-TW.ts
@@ -490,7 +490,7 @@ export const zhTW = {
   'settings.option.system': '系統',
   'settings.option.light': '淺色',
   'settings.option.dark': '深色',
-  'settings.option.custom': '自訂',
+  'settings.option.custom': '更多',
   'settings.option.off': '關',
   'settings.option.ltr': 'LTR',
   'settings.option.rtl': 'RTL',

--- a/tests/e2e/mobile-appearance-settings.spec.ts
+++ b/tests/e2e/mobile-appearance-settings.spec.ts
@@ -45,9 +45,10 @@ test('keeps the theme mode segments on screen with long locale labels', async ({
   await page.goto('/')
   await page.evaluate(() => {
     localStorage.clear()
-    // German has the longest mode label ("Benutzerdefiniert"); it used to push
-    // the segmented control past the right screen edge.
-    localStorage.setItem('marktext-for-android:locale', 'de')
+    // Turkish carries the longest surviving mode label ("Daha fazla") now
+    // that the fourth mode is "More" everywhere (German "Benutzerdefiniert"
+    // went away with the rename); it exercises the same overflow guard.
+    localStorage.setItem('marktext-for-android:locale', 'tr')
   })
   await page.reload()
 
@@ -78,8 +79,13 @@ test('keeps the theme mode segments on screen with long locale labels', async ({
   await expectSegmentsOnScreen()
 
   // On a narrower phone the segments stack into two balanced columns; every
-  // label must still be fully on screen and unclipped.
-  await page.setViewportSize({ width: 360, height: 800 })
+  // label must still be fully on screen and unclipped. The shorter "More"
+  // labels fit a 360px line, so the stacking threshold sits lower now;
+  // 320px is the app's minimum supported layout width and Turkish stacks
+  // there (narrower viewports leave the layout viewport pinned at ~320,
+  // which would fail the on-screen assertions for reasons unrelated to
+  // this control).
+  await page.setViewportSize({ width: 320, height: 800 })
   await expect
     .poll(() =>
       modeControl

--- a/tests/e2e/mobile-theme-gallery.spec.ts
+++ b/tests/e2e/mobile-theme-gallery.spec.ts
@@ -87,3 +87,29 @@ test('lists every catalog theme in the picker with swatches and group headings',
 
   await page.screenshot({ path: 'test-results/theme-gallery/picker.png' })
 })
+
+test('the whole picker row is the hit target, not just its swatches and label', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await page.evaluate(() => localStorage.clear())
+  await page.reload()
+
+  await page.getByTestId('bottom-nav-settings').click()
+  await page.getByTestId('settings-entry-appearance').click()
+  await page.getByTestId('settings-appearance-theme-mode-option-custom').click()
+  await page.getByTestId('settings-appearance-custom-theme-trigger').click()
+
+  // Every option row stretches to the panel width — the auto grid track
+  // used to shrink rows to their content, leaving the space right of the
+  // radio dead to taps.
+  const panelBox = await page.locator('.settings-select-panel').boundingBox()
+  const option = page.getByTestId('settings-appearance-custom-theme-option-nord')
+  const optionBox = await option.boundingBox()
+  expect(optionBox!.width).toBeGreaterThan(panelBox!.width - 24)
+
+  // Selecting by tapping the far RIGHT edge of the row (formerly dead
+  // space) works.
+  await option.click({ position: { x: optionBox!.width - 8, y: optionBox!.height / 2 } })
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'nord')
+})


### PR DESCRIPTION
Two small appearance fixes from device feedback (screenshot in review chat: rows in the theme gallery ignored taps outside the swatches/label/radio).

## Full-row hit targets in the theme picker

The gallery rows were content-width, not panel-width, so the space right of the radio was dead to taps and every divider had a different length. Two stacked root causes, both fixed:

- a `<button>`'s auto width is **shrink-to-fit even as a grid container** — the row's declared `grid-template-columns: 1fr 22px` layout never actually engaged; `width: 100%` turns it on;
- the picker panel is a grid with a single **implicit** column, which sizes to content; an explicit `minmax(0, 1fr)` track stretches the rows.

Net effect: the whole row is the hit target, radio marks right-align, dividers span uniformly — the layout the stylesheet always declared. New E2E pins the row width against the panel and selects a theme by tapping the formerly dead right edge.

## Theme Mode: "Custom" → "More"

The fourth mode segment opens the full theme gallery; "More" says that, "Custom" promised user-defined colors that do not exist. Renamed across all ten locales (de `Mehr`, es `Más`, fr `Plus`, ja `その他`, ko `더보기`, pt `Mais`, tr `Daha fazla`, zh-CN `更多`, zh-TW `更多`).

Test fallout handled with measurements rather than guesses: the long-label overflow E2E was built around German's 17-character "Benutzerdefiniert", which this rename removes. It now uses Turkish (the longest surviving label set), and the stacked-layout assertion moves from 360px to **320px** — probed: the shorter labels fit a 360px line, Turkish stacks at 320px, and 320px is the app's minimum supported layout width (narrower viewports leave the layout viewport pinned at ~320, which fails the on-screen assertions for reasons unrelated to this control).

## Verification

Appearance + theme-gallery E2E 36/36 (including the new full-row hit-target case), app unit 655/655, typecheck and lint clean.