### PR TITLE
Give debug builds their own application id and launcher label

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,6 +48,13 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            // Debug installs coexist with the release app instead of
+            // replacing it: separate application id, separate data, and a
+            // distinguishable launcher label. Measurement and smoke installs
+            // on a daily-driver device must never touch the real app.
+            applicationIdSuffix ".debug"
+        }
     }
 }
 

--- a/android/app/src/debug/res/values/strings.xml
+++ b/android/app/src/debug/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Debug installs carry their own launcher label so the coexisting
+         release app stays unmistakable on device. -->
+    <string name="app_name">MarkText Debug</string>
+</resources>


### PR DESCRIPTION
Debug installs now coexist with the release app instead of replacing it: `applicationIdSuffix ".debug"` separates the package and its data, and a debug-source-set `strings.xml` labels the launcher icon **MarkText Debug**. Until now a debug `adb install` on a device carrying the release app would silently REPLACE it (same application id) — on a daily-driver device that is a data-loss hazard. This enabled the on-device half of the #152 measurements: the debug copy installed alongside the maintainer's real app, measured, and uninstalled without touching it. Release builds are byte-identical to before (the debug block only affects the debug variant).