### PR TITLE
Fix API 24 launch: splash crash and old-WebView error page

### DIFF
--- a/android/app/src/main/res/drawable-v26/ic_splash_logo.xml
+++ b/android/app/src/main/res/drawable-v26/ic_splash_logo.xml
@@ -2,15 +2,10 @@
 <!--
   Splash icon: the launcher mark flattened to a single muted grey (its alpha
   silhouette, tinted), so the launch reads as a quiet monochrome mark rather than
-  the full-colour app icon.
-
-  API 24/25 fallback: fractional insets ("15%") are an API 26 InsetDrawable
-  feature and CRASH resource resolution on older releases (the app never
-  reached onCreate past the splash on Android 7). The v26 variant keeps the
-  fraction; this base variant approximates it with a fixed dp inset.
+  the full-colour app icon. Inset to sit inside the splash icon's safe zone.
 -->
 <inset xmlns:android="http://schemas.android.com/apk/res/android"
-    android:inset="18dp">
+    android:inset="15%">
     <bitmap
         android:src="@mipmap/ic_launcher_foreground"
         android:tint="@color/splash_icon_tint"

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -8,6 +8,10 @@ const config: CapacitorConfig = {
     // The bundle targets Vite's baseline-widely-available (Chrome 111);
     // older System WebViews fail at JS parse time, so gate them to the
     // static error page below instead of a blank screen (#158).
+    // This gate only understands standard WebView version schemes; Huawei
+    // WebView is versioned independently, so index.html additionally checks
+    // the real Chromium core version from the user agent and redirects to
+    // the same error page.
     minWebViewVersion: 111
   },
   server: {

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,16 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'io.github.renakoni.marktextandroid',
   appName: 'MarkText',
-  webDir: 'dist'
+  webDir: 'dist',
+  android: {
+    // The bundle targets Vite's baseline-widely-available (Chrome 111);
+    // older System WebViews fail at JS parse time, so gate them to the
+    // static error page below instead of a blank screen (#158).
+    minWebViewVersion: 111
+  },
+  server: {
+    errorPath: 'webview-error.html'
+  }
 };
 
 export default config;

--- a/index.html
+++ b/index.html
@@ -5,6 +5,23 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MarkText</title>
+    <!--
+      Engine floor check. Capacitor's minWebViewVersion gate covers standard
+      Android WebViews, but Huawei WebView is judged against a separate,
+      unrelated version scheme, so an old Chromium core can be waved through
+      and then die parsing the modern bundle. The user agent carries the real
+      core version ("Chrome/NNN") for every Chromium-based WebView, so check
+      that directly. Must stay ES5: it has to run on the WebViews it rejects.
+      Keep the version in sync with Vite's build target (Chrome 111).
+    -->
+    <script>
+      ;(function () {
+        var match = navigator.userAgent.match(/Chrome\/(\d+)/)
+        if (match && parseInt(match[1], 10) < 111) {
+          location.replace('webview-error.html')
+        }
+      })()
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/public/webview-error.html
+++ b/public/webview-error.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MarkText</title>
+<!--
+  Shown by Capacitor (server.errorPath) when the System WebView is older
+  than android.minWebViewVersion. It must render on WebView 53, so keep
+  this page plain HTML/CSS only: no JavaScript, no modern CSS features.
+-->
+<style>
+  html, body {
+    margin: 0;
+    height: 100%;
+  }
+  body {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f4f4f5;
+    color: #27272a;
+    font-family: Roboto, "Helvetica Neue", sans-serif;
+    text-align: center;
+  }
+  .panel {
+    max-width: 320px;
+    padding: 24px;
+  }
+  h1 {
+    margin: 0 0 12px;
+    font-size: 22px;
+    font-weight: 500;
+  }
+  p {
+    margin: 0 0 10px;
+    font-size: 15px;
+    line-height: 1.5;
+    color: #52525b;
+  }
+  .hint {
+    font-size: 13px;
+    color: #a1a1aa;
+  }
+</style>
+</head>
+<body>
+  <div class="panel">
+    <h1>MarkText</h1>
+    <p>This device&#8217;s Android System WebView is too old to run MarkText.</p>
+    <p>Update &#8220;Android System WebView&#8221; from Google Play, then reopen the app.</p>
+    <p class="hint">Requires WebView 111 or newer.</p>
+  </div>
+</body>
+</html>

--- a/public/webview-error.html
+++ b/public/webview-error.html
@@ -47,9 +47,9 @@
 <body>
   <div class="panel">
     <h1>MarkText</h1>
-    <p>This device&#8217;s Android System WebView is too old to run MarkText.</p>
-    <p>Update &#8220;Android System WebView&#8221; from Google Play, then reopen the app.</p>
-    <p class="hint">Requires WebView 111 or newer.</p>
+    <p>MarkText could not start with this device&#8217;s current WebView. Most often the WebView component is too old.</p>
+    <p>Update your device&#8217;s WebView or browser component from your app store or system updates, then reopen the app.</p>
+    <p class="hint">Requires a WebView based on Chrome 111 or newer.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Part of #158 — the first runtime verification on API 24 (emulator, image `android-24;google_apis;x86_64`) found two launch blockers; this PR fixes both, and review round 1 hardened the WebView gate against a third gap.

## 1. Native crash before splash (API 24-25)

`drawable/ic_splash_logo.xml` used `android:inset="15%"` — fractional insets are an API 26+ feature, so resource resolution throws `Resources$NotFoundException` in `MainActivity.onCreate` and the app crashes instantly on Android 7.0/7.1, despite `minSdkVersion 24`.

**Fix:** the original fractional version moves to `drawable-v26/`; the base variant uses a fixed `18dp` inset. API 26+ keeps the exact same drawable as before, so no visual change on any currently working device.

## 2. Permanent blank screen on old System WebViews

After the splash fix the app reached the WebView and died at JS parse time (`Uncaught SyntaxError`): the bundle targets Vite's `baseline-widely-available` (**Chrome 111**), while the emulator's factory WebView is Chrome 69. Capacitor's default without `server.errorPath` is to log one line and load the broken bundle anyway — the user sees a blank screen forever.

**Fix:** `android.minWebViewVersion: 111` (matching the build target) plus `public/webview-error.html`, a plain HTML/CSS page (no JS, renders fine on WebView 53+).

## 3. Huawei WebView bypass (review round 1)

Capacitor judges `com.huawei.webview` against a separate config (`minHuaweiWebViewVersion`, default floor 10) using Huawei's own version scheme, so on Android 8+ Huawei devices an old Chromium core could pass the gate and still die parsing the bundle. Rather than guessing a Huawei-version-to-Chromium mapping (unreliable, rots), `index.html` now carries an ES5 inline check that reads the **real Chromium core version from the user agent** (`Chrome/NNN`, reported by every Chromium-based WebView including Huawei and Amazon) and redirects to the same error page below 111. The error page copy is provider-neutral accordingly.

Support floor after this PR: **minSdk 24 + any WebView with a Chromium 111+ core**. Note the ceiling fact: the last Chrome that installs on Android 7 is **119**, so the current target keeps an 8-version margin — raising the Vite target past 119 would kill API 24-25 support entirely.

## Verification (API 24 emulator)

- Factory WebView (Chrome 69): splash fix verified (no crash), Capacitor gate loads the error page (`Handling local request: .../webview-error.html`), renders cleanly.
- Gate-bypass simulation: with Chrome 119 installed and the UA threshold temporarily raised to 200, Capacitor's gate passes (119 ≥ 111) and the **UA check alone** redirects to the error page — exactly the Huawei failure mode, proven working.
- Real support path: official Google-signed Chrome 119 (last Android 7 release) installed via `adb install`; the app then runs fully — editor rendering (headings/bold/italic/lists), autosave, SAF `ACTION_CREATE_DOCUMENT` save (file verified on disk), PDF export (valid `%PDF-1.4` + share sheet), and share-intent import all pass on Android 7.0.
- API 35 emulator: gate does not misfire; app loads normally.
- `pnpm typecheck`, `eslint capacitor.config.ts`, `pnpm build`, `cap sync`, `assembleDebug` all clean.