### PR TITLE
Add minimal native instrumentation smoke tests (#157)

### DIFF
--- a/.github/workflows/android-connected.yml
+++ b/.github/workflows/android-connected.yml
@@ -1,0 +1,82 @@
+name: Android Connected Tests
+
+# Instrumentation (androidTest) smoke that needs a real device: SAF read/write
+# through a live ContentResolver, incoming-intent content URIs, and PDF export
+# through the platform print pipeline. The emulator job is slow (~8-10 min) and
+# occasionally flaky, so it runs on demand and only when native code changes —
+# not on every PR. See issue #157.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "android/**"
+      - ".github/workflows/android-connected.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "android/**"
+      - ".github/workflows/android-connected.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  connected-tests:
+    name: Instrumentation smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup
+
+      - name: Install JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "22"
+          cache: gradle
+
+      # The debug APK bundles the built web assets, so produce and sync them
+      # before assembling the app under test.
+      - name: Build web shell
+        run: pnpm build
+
+      - name: Sync Capacitor Android assets
+        run: pnpm exec cap sync android
+
+      # Hardware acceleration for the emulator on the Linux runner.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run instrumentation smoke
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          # google_apis carries a System WebView, which the PDF export test
+          # needs; the bare "default" target does not ship one.
+          target: google_apis
+          arch: x86_64
+          # Trim boot time and disable animations for stable UI-free tests.
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            chmod +x android/gradlew
+            ./android/gradlew -p android connectedDebugAndroidTest --no-daemon
+
+      - name: Upload test report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumentation-test-report
+          path: android/app/build/reports/androidTests/connected/
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/android-connected.yml
+++ b/.github/workflows/android-connected.yml
@@ -70,7 +70,11 @@ jobs:
           disable-animations: true
           script: |
             chmod +x android/gradlew
-            ./android/gradlew -p android connectedDebugAndroidTest --no-daemon
+            # Scope to the app module: a bare connectedDebugAndroidTest also
+            # builds the androidTest variant of capacitor-cordova-android-plugins,
+            # whose kotlin-stdlib graph has a duplicate-classes conflict we do
+            # not need to touch — only app carries our instrumentation tests.
+            ./android/gradlew -p android :app:connectedDebugAndroidTest --no-daemon
 
       - name: Upload test report
         if: ${{ always() }}

--- a/android/app/src/androidTest/AndroidManifest.xml
+++ b/android/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!--
+      Registers the in-test content provider (see TestDocumentProvider) into the
+      instrumentation APK only — it never ships in the app. exported="true" is
+      required because the test APK and the .debug app run under different UIDs,
+      so the app process must be allowed to reach the provider through the real
+      ContentResolver. This is test-only surface with no production exposure.
+    -->
+    <application>
+        <provider
+            android:name="io.github.renakoni.marktextandroid.TestDocumentProvider"
+            android:authorities="io.github.renakoni.marktextandroid.test.documents"
+            android:exported="true"
+            android:grantUriPermissions="true" />
+    </application>
+</manifest>

--- a/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/IncomingIntentContentUriInstrumentationTest.java
+++ b/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/IncomingIntentContentUriInstrumentationTest.java
@@ -1,0 +1,76 @@
+package io.github.renakoni.marktextandroid;
+
+import static org.junit.Assert.assertEquals;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Instrumentation smoke that ties a real incoming intent to a real document
+ * read: the JVM IncomingIntentParserTest proves classification against synthetic
+ * intents, but only here does a content URI carried by an ACTION_VIEW /
+ * ACTION_SEND intent get read back through the actual ContentResolver.
+ */
+@RunWith(AndroidJUnit4.class)
+public final class IncomingIntentContentUriInstrumentationTest {
+
+    private ContentResolver resolver;
+
+    @Before
+    public void setUp() {
+        // The app (target) context owns the resolver the production code uses.
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        resolver = context.getContentResolver();
+    }
+
+    private Uri seedDocument(String fileName, String contents) throws Exception {
+        // Seed through the resolver so the test never touches the (different-UID)
+        // provider's files directly.
+        Uri uri = TestDocumentProvider.uriFor(fileName);
+        try (OutputStream output = resolver.openOutputStream(uri, "wt")) {
+            output.write(contents.getBytes(StandardCharsets.UTF_8));
+        }
+        return uri;
+    }
+
+    private String readThrough(Uri uri) throws Exception {
+        byte[] bytes = new ContentResolverDocumentIo(resolver, uri, MarkdownCodec.MAX_MARKDOWN_BYTES)
+            .readBytes();
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void openWithIntentUriIsClassifiedAndReadable() throws Exception {
+        Uri uri = seedDocument("open-with.md", "# Open with\n\nFrom ACTION_VIEW.");
+        Intent intent = new Intent(Intent.ACTION_VIEW).setData(uri);
+
+        IncomingIntentParser.Result result = IncomingIntentParser.parse(intent);
+
+        assertEquals(IncomingIntentParser.Kind.OPEN_WITH_DOCUMENT, result.kind);
+        assertEquals(uri, result.uri);
+        assertEquals("# Open with\n\nFrom ACTION_VIEW.", readThrough(result.uri));
+    }
+
+    @Test
+    public void shareStreamIntentUriIsClassifiedAndReadable() throws Exception {
+        Uri uri = seedDocument("share-stream.md", "# Shared stream\n\nFrom ACTION_SEND.");
+        Intent intent = new Intent(Intent.ACTION_SEND)
+            .setType("text/markdown")
+            .putExtra(Intent.EXTRA_STREAM, uri);
+
+        IncomingIntentParser.Result result = IncomingIntentParser.parse(intent);
+
+        assertEquals(IncomingIntentParser.Kind.SHARE_STREAM, result.kind);
+        assertEquals(uri, result.uri);
+        assertEquals("# Shared stream\n\nFrom ACTION_SEND.", readThrough(result.uri));
+    }
+}

--- a/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/IntentUriResolverReadInstrumentationTest.java
+++ b/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/IntentUriResolverReadInstrumentationTest.java
@@ -15,13 +15,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Instrumentation smoke that ties a real incoming intent to a real document
- * read: the JVM IncomingIntentParserTest proves classification against synthetic
- * intents, but only here does a content URI carried by an ACTION_VIEW /
- * ACTION_SEND intent get read back through the actual ContentResolver.
+ * Instrumentation smoke for the seam between intent parsing and real document
+ * I/O — deliberately NOT an end-to-end incoming-intent test. It constructs an
+ * {@code ACTION_VIEW} / {@code ACTION_SEND} {@link Intent} directly, classifies
+ * it with {@link IncomingIntentParser}, and reads the resulting content URI back
+ * through the actual ContentResolver.
+ *
+ * <p>It does NOT launch {@code MainActivity}, pass through the manifest intent
+ * filters, or exercise {@code AndroidDocumentsPlugin.handleIncomingIntent} / the
+ * plugin's JS event path — so a broken filter, missing {@code onNewIntent}, or a
+ * dropped URI grant would NOT be caught here. That dispatch chain is covered by
+ * the on-device share-intent verification recorded on #158. What this adds over
+ * the JVM {@code IncomingIntentParserTest} is that the parsed URI points at
+ * content the real resolver can actually read.
  */
 @RunWith(AndroidJUnit4.class)
-public final class IncomingIntentContentUriInstrumentationTest {
+public final class IntentUriResolverReadInstrumentationTest {
 
     private ContentResolver resolver;
 

--- a/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/PdfExportInstrumentationTest.java
+++ b/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/PdfExportInstrumentationTest.java
@@ -1,0 +1,74 @@
+package io.github.renakoni.marktextandroid;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Instrumentation smoke that the PDF export completes end to end through the
+ * real platform print pipeline (WebView render -> PrintDocumentAdapter ->
+ * PdfDocument), producing a valid file. None of this is reachable from a JVM
+ * test: it needs a live WebView and android.print.
+ */
+@RunWith(AndroidJUnit4.class)
+public final class PdfExportInstrumentationTest {
+
+    private static final String EXPORT_HTML =
+        "<!DOCTYPE html><html><head><meta charset=\"utf-8\"></head>"
+            + "<body><h1>PDF smoke</h1><p>Instrumentation export.</p></body></html>";
+
+    @Test
+    public void exportsAValidPdfFile() throws Exception {
+        // The app context owns the WebView/print stack the exporter drives.
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        File output = new File(context.getCacheDir(), "instrumentation-export.pdf");
+        if (output.exists() && !output.delete()) {
+            throw new IllegalStateException("could not clear stale export output");
+        }
+
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<String> failure = new AtomicReference<>();
+
+        // export() must run on the main thread (it creates a WebView).
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(() ->
+            PdfExporter.export(context, EXPORT_HTML, "instrumentation-export", output,
+                new PdfExporter.Callback() {
+                    @Override
+                    public void onSuccess() {
+                        done.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(String code, String message) {
+                        failure.set(code + ": " + message);
+                        done.countDown();
+                    }
+                }));
+
+        // The exporter's own timeout is 30s; wait a little longer so a timeout
+        // surfaces as its failure callback rather than as a latch expiry.
+        assertTrue("PDF export did not complete within 40s", done.await(40, TimeUnit.SECONDS));
+        assertNull("PDF export reported a failure", failure.get());
+
+        assertTrue("export output file is missing", output.exists());
+        assertTrue("export output file is empty", output.length() > 0);
+
+        byte[] header = new byte[5];
+        try (FileInputStream input = new FileInputStream(output)) {
+            assertEquals("could not read the PDF header", 5, input.read(header));
+        }
+        assertEquals("%PDF-", new String(header, StandardCharsets.US_ASCII));
+    }
+}

--- a/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/SafDocumentIoInstrumentationTest.java
+++ b/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/SafDocumentIoInstrumentationTest.java
@@ -1,0 +1,84 @@
+package io.github.renakoni.marktextandroid;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.net.Uri;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Instrumentation smoke for the real SAF read/write paths — the
+ * ContentResolver-coupled behavior that the JVM SafeDocumentWriterTest and
+ * ContentResolverDocumentIoTest cannot cover because they run against a fake.
+ * Backed by {@link TestDocumentProvider} so no system picker UI is involved;
+ * every document is seeded and verified through the real ContentResolver, which
+ * also keeps the test and the (different-UID) provider from touching each
+ * other's files directly.
+ */
+@RunWith(AndroidJUnit4.class)
+public final class SafDocumentIoInstrumentationTest {
+
+    private ContentResolver resolver;
+
+    @Before
+    public void setUp() {
+        // The app (target) context owns the resolver the production code uses.
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        resolver = context.getContentResolver();
+    }
+
+    private Uri seedDocument(String fileName, String contents) throws Exception {
+        Uri uri = TestDocumentProvider.uriFor(fileName);
+        try (OutputStream output = resolver.openOutputStream(uri, "wt")) {
+            output.write(contents.getBytes(StandardCharsets.UTF_8));
+        }
+        return uri;
+    }
+
+    @Test
+    public void readsExistingDocumentThroughRealResolver() throws Exception {
+        Uri uri = seedDocument("read.md", "# Existing\n\nReal resolver read.");
+
+        byte[] bytes = new ContentResolverDocumentIo(resolver, uri, MarkdownCodec.MAX_MARKDOWN_BYTES)
+            .readBytes();
+
+        assertEquals("# Existing\n\nReal resolver read.", new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void overwritesExistingDocumentAtomicallyAndReadsItBack() throws Exception {
+        Uri uri = seedDocument("write.md", "# Old body");
+        byte[] next = "# New body\n\nRewritten through the real truncating descriptor."
+            .getBytes(StandardCharsets.UTF_8);
+
+        ContentResolverDocumentIo io =
+            new ContentResolverDocumentIo(resolver, uri, MarkdownCodec.MAX_MARKDOWN_BYTES);
+        // protectExisting=true drives the full read-backup -> truncate -> write
+        // -> fsync -> length-verify path against a real content descriptor.
+        SafeDocumentWriter.write(io, next, true);
+
+        assertArrayEquals(next, io.readBytes());
+    }
+
+    @Test
+    public void writesFreshlyCreatedDocument() throws Exception {
+        // No seed: the write path itself creates the document, as it does for a
+        // freshly created SAF file (protectExisting=false, no backup).
+        Uri uri = TestDocumentProvider.uriFor("fresh.md");
+        byte[] body = "# Fresh\n\nNo backup path.".getBytes(StandardCharsets.UTF_8);
+
+        ContentResolverDocumentIo io =
+            new ContentResolverDocumentIo(resolver, uri, MarkdownCodec.MAX_MARKDOWN_BYTES);
+        SafeDocumentWriter.write(io, body, false);
+
+        assertArrayEquals(body, io.readBytes());
+    }
+}

--- a/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/SafDocumentIoInstrumentationTest.java
+++ b/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/SafDocumentIoInstrumentationTest.java
@@ -2,12 +2,16 @@ package io.github.renakoni.marktextandroid;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import android.content.ContentResolver;
 import android.content.Context;
 import android.net.Uri;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.Before;
@@ -43,6 +47,16 @@ public final class SafDocumentIoInstrumentationTest {
         return uri;
     }
 
+    private void assertDoesNotExist(Uri uri) {
+        try (InputStream ignored = resolver.openInputStream(uri)) {
+            fail("expected " + uri + " to not exist before the fresh-create write");
+        } catch (FileNotFoundException expected) {
+            // good — the document is absent
+        } catch (IOException other) {
+            throw new AssertionError("unexpected error probing " + uri, other);
+        }
+    }
+
     @Test
     public void readsExistingDocumentThroughRealResolver() throws Exception {
         Uri uri = seedDocument("read.md", "# Existing\n\nReal resolver read.");
@@ -70,11 +84,15 @@ public final class SafDocumentIoInstrumentationTest {
 
     @Test
     public void writesFreshlyCreatedDocument() throws Exception {
-        // No seed: the write path itself creates the document, as it does for a
-        // freshly created SAF file (protectExisting=false, no backup).
-        Uri uri = TestDocumentProvider.uriFor("fresh.md");
-        byte[] body = "# Fresh\n\nNo backup path.".getBytes(StandardCharsets.UTF_8);
+        // A unique name plus an explicit delete guarantees the document is absent
+        // before the write, so this genuinely exercises the create path
+        // (protectExisting=false, no backup) rather than an overwrite — even when
+        // the same emulator runs the suite more than once.
+        Uri uri = TestDocumentProvider.uriFor("fresh-" + System.nanoTime() + ".md");
+        resolver.delete(uri, null, null);
+        assertDoesNotExist(uri);
 
+        byte[] body = "# Fresh\n\nNo backup path.".getBytes(StandardCharsets.UTF_8);
         ContentResolverDocumentIo io =
             new ContentResolverDocumentIo(resolver, uri, MarkdownCodec.MAX_MARKDOWN_BYTES);
         SafeDocumentWriter.write(io, body, false);

--- a/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/TestDocumentProvider.java
+++ b/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/TestDocumentProvider.java
@@ -1,0 +1,76 @@
+package io.github.renakoni.marktextandroid;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.provider.OpenableColumns;
+import java.io.File;
+import java.io.FileNotFoundException;
+
+/**
+ * A minimal in-test {@link ContentProvider} that maps a {@code content://} URI
+ * to a real file under the app cache dir. It lets the instrumentation smoke
+ * tests exercise the genuine {@link android.content.ContentResolver} I/O paths
+ * ({@code openInputStream} / {@code openFileDescriptor}) — the parts a JVM unit
+ * test cannot reach — without driving the system DocumentsUI picker, which is a
+ * separate process and varies by API level.
+ *
+ * <p>Registered only in the androidTest manifest, so it never ships in the app.
+ */
+public final class TestDocumentProvider extends ContentProvider {
+
+    static final String AUTHORITY = "io.github.renakoni.marktextandroid.test.documents";
+
+    /** A content URI whose last path segment is the backing file name. */
+    static Uri uriFor(String fileName) {
+        return new Uri.Builder().scheme("content").authority(AUTHORITY).appendPath(fileName).build();
+    }
+
+    private File fileFor(Uri uri) {
+        File dir = new File(getContext().getCacheDir(), "test-docs");
+        dir.mkdirs();
+        return new File(dir, uri.getLastPathSegment());
+    }
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+        // Honor the exact mode the caller asked for ("r", "rwt", "wt", ...) so
+        // ContentResolverDocumentIo's real truncate/read-write handling runs.
+        return ParcelFileDescriptor.open(fileFor(uri), ParcelFileDescriptor.parseMode(mode));
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        MatrixCursor cursor = new MatrixCursor(new String[] {OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE});
+        cursor.addRow(new Object[] {uri.getLastPathSegment(), fileFor(uri).length()});
+        return cursor;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        return "text/markdown";
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        return 0;
+    }
+}

--- a/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/TestDocumentProvider.java
+++ b/android/app/src/androidTest/java/io/github/renakoni/marktextandroid/TestDocumentProvider.java
@@ -66,7 +66,7 @@ public final class TestDocumentProvider extends ContentProvider {
 
     @Override
     public int delete(Uri uri, String selection, String[] selectionArgs) {
-        return 0;
+        return fileFor(uri).delete() ? 1 : 0;
     }
 
     @Override


### PR DESCRIPTION
Part of #157.

Native coverage was JVM-only, which runs against fakes and cannot reach the ContentResolver-, intent-, and print-coupled paths. This adds a **minimal androidTest smoke** for those — no duplication of the existing JVM tests.

## What it covers (6 tests)

- **`SafDocumentIoInstrumentationTest`** — real SAF I/O through a live `ContentResolver`: read an existing document, atomically overwrite one (the full read-backup → truncate → write → fsync → length-verify path against a real content descriptor), and write a freshly created one (unique name + delete + absent-assertion, so it is a genuine create rather than an accidental overwrite on a reused emulator).
- **`IntentUriResolverReadInstrumentationTest`** — the seam between intent parsing and real I/O: an `ACTION_VIEW` / `ACTION_SEND` `Intent` is classified by `IncomingIntentParser` and the resulting content URI is **read back through the actual resolver**. It is deliberately **not** end-to-end dispatch — it does not launch `MainActivity`, pass the manifest filters, or exercise the plugin/JS path, so a broken filter or dropped grant would not be caught here (that is #158's on-device coverage). What it adds over the JVM `IncomingIntentParserTest` is that the parsed URI points at readable content.
- **`PdfExportInstrumentationTest`** — `PdfExporter.export()` completes through the platform print pipeline (WebView → `PrintDocumentAdapter` → `PdfDocument`) and writes a valid `%PDF-` file. Unreachable from JVM.

## Why this is `Part of`, not `Closes` #157

#157 lists **SAF read / write / persist**. This PR does **not** cover *persist*, and — correcting an earlier version of this description — #158 does **not** cover it either: #158 verified `ACTION_CREATE_DOCUMENT` save + read-back, which proves create/save but **not** `takePersistableUriPermission` surviving a process/emulator restart. A faithful persist test needs a real grant from the system SAF flow (DocumentsUI) plus a restart — the flaky system-UI path this design avoids — and the test provider is an unprotected `exported=true` provider, so it cannot stand in for a real grant.

Persist is therefore **out of automation scope** here and left as a decision on #157 (narrow the issue's scope with persist as a recorded manual check, or keep it open as a persist follow-up). Because of that this PR is **Part of #157** and does not auto-close it. See the comment on #157.

## How the SAF cases stay stable

The picker is the system DocumentsUI (a separate process, layout varies by API level), so `TestDocumentProvider` (a tiny in-test `ContentProvider` mapping a content URI to a real cache file) backs the URIs and everything is seeded/verified through the resolver. Test and provider run under different UIDs (app is `.debug`, test APK `.debug.test`); the provider is registered only in the androidTest manifest (`exported=true` so the app process can reach it) and never ships.

## CI

A separate **`android-connected.yml`** workflow runs these (`workflow_dispatch` + `android/**`), scoped to `:app:connectedDebugAndroidTest` so it does not build the unrelated `capacitor-cordova-android-plugins` androidTest variant. All 7 checks pass on a real API 35 emulator.