### PR TITLE
Add a soft-break-as-space rendering preference (#142)

### DIFF
--- a/src/features/settings/editingSettings.test.ts
+++ b/src/features/settings/editingSettings.test.ts
@@ -158,6 +158,24 @@ describe('editingSettings', () => {
     ])
   })
 
+  it('sends soft-break-as-space as a no-reparse presentation option (#142)', () => {
+    const next: EditingSettings = {
+      ...DEFAULT_EDITING_SETTINGS,
+      renderSoftBreakAsSpace: true,
+    }
+
+    expect(getMuyaEditingOptions(next)).toMatchObject({ renderSoftBreakAsSpace: true })
+    // A pure CSS re-style: muya toggles a root class, so the live update must
+    // NOT force a re-parse (that would drop the cursor and undo history).
+    expect(getMuyaEditingRuntimeUpdates(next, DEFAULT_EDITING_SETTINGS)).toEqual([
+      {
+        kind: 'setOptions',
+        options: { renderSoftBreakAsSpace: true },
+        forceRender: false,
+      },
+    ])
+  })
+
   it('does not emit runtime work for the stored-only source mode row', () => {
     const next: EditingSettings = {
       ...DEFAULT_EDITING_SETTINGS,

--- a/src/features/settings/editingSettings.ts
+++ b/src/features/settings/editingSettings.ts
@@ -23,6 +23,7 @@ export type EditingSettingKey =
   | 'frontmatterType'
   | 'footnote'
   | 'superSubScript'
+  | 'renderSoftBreakAsSpace'
   | 'isHtmlEnabled'
   | 'isGitlabCompatibilityEnabled'
   | 'sequenceTheme'
@@ -52,6 +53,7 @@ export interface EditingSettings {
   frontmatterType: FrontmatterType
   footnote: boolean
   superSubScript: boolean
+  renderSoftBreakAsSpace: boolean
   isHtmlEnabled: boolean
   isGitlabCompatibilityEnabled: boolean
   sequenceTheme: SequenceTheme
@@ -99,6 +101,7 @@ export const EDITING_SETTING_KEYS = [
   'frontmatterType',
   'footnote',
   'superSubScript',
+  'renderSoftBreakAsSpace',
   'isHtmlEnabled',
   'isGitlabCompatibilityEnabled',
   'sequenceTheme',
@@ -129,6 +132,7 @@ export const DEFAULT_EDITING_SETTINGS = {
   frontmatterType: '-',
   footnote: false,
   superSubScript: false,
+  renderSoftBreakAsSpace: false,
   isHtmlEnabled: true,
   isGitlabCompatibilityEnabled: false,
   sequenceTheme: 'hand',
@@ -252,6 +256,7 @@ export function normalizeEditingSettingValue(key: EditingSettingKey, value: Sett
     case 'preferLooseListItem':
     case 'footnote':
     case 'superSubScript':
+    case 'renderSoftBreakAsSpace':
     case 'isHtmlEnabled':
     case 'isGitlabCompatibilityEnabled':
     case 'codeBlockLineNumbers':
@@ -356,6 +361,10 @@ export function getEditingSettings(
       getValue('superSubScript', DEFAULT_EDITING_SETTINGS.superSubScript),
       DEFAULT_EDITING_SETTINGS.superSubScript,
     ),
+    renderSoftBreakAsSpace: normalizeBoolean(
+      getValue('renderSoftBreakAsSpace', DEFAULT_EDITING_SETTINGS.renderSoftBreakAsSpace),
+      DEFAULT_EDITING_SETTINGS.renderSoftBreakAsSpace,
+    ),
     isHtmlEnabled: normalizeBoolean(
       getValue('isHtmlEnabled', DEFAULT_EDITING_SETTINGS.isHtmlEnabled),
       DEFAULT_EDITING_SETTINGS.isHtmlEnabled,
@@ -431,6 +440,7 @@ export function getMuyaEditingOptions(settings: EditingSettings): MuyaEditingOpt
     frontmatterType: settings.frontmatterType,
     superSubScript: settings.superSubScript,
     footnote: settings.footnote,
+    renderSoftBreakAsSpace: settings.renderSoftBreakAsSpace,
     disableHtml: !settings.isHtmlEnabled,
     isGitlabCompatibilityEnabled: settings.isGitlabCompatibilityEnabled,
     hideQuickInsertHint: !settings.quickInsert,
@@ -532,6 +542,13 @@ export function getMuyaEditingRuntimeUpdates(
     next.spellcheckerUnderline !== previous.spellcheckerUnderline,
     'spellcheckHideMarks',
     !next.spellcheckerUnderline,
+  )
+  // A pure presentation re-style: muya toggles a root class, no re-parse (#142),
+  // so this stays out of the forceRender group below.
+  setOption(
+    next.renderSoftBreakAsSpace !== previous.renderSoftBreakAsSpace,
+    'renderSoftBreakAsSpace',
+    next.renderSoftBreakAsSpace,
   )
 
   setOption(next.footnote !== previous.footnote, 'footnote', next.footnote, true)

--- a/src/features/settings/settingsContent.test.ts
+++ b/src/features/settings/settingsContent.test.ts
@@ -95,6 +95,7 @@ const RUNTIME_SETTING_DEFAULTS = new Map<string, SettingsValue>([
   ['frontmatterType', DEFAULT_EDITING_SETTINGS.frontmatterType],
   ['footnote', DEFAULT_EDITING_SETTINGS.footnote],
   ['superSubScript', DEFAULT_EDITING_SETTINGS.superSubScript],
+  ['renderSoftBreakAsSpace', DEFAULT_EDITING_SETTINGS.renderSoftBreakAsSpace],
   ['isHtmlEnabled', DEFAULT_EDITING_SETTINGS.isHtmlEnabled],
   ['isGitlabCompatibilityEnabled', DEFAULT_EDITING_SETTINGS.isGitlabCompatibilityEnabled],
   ['sequenceTheme', DEFAULT_EDITING_SETTINGS.sequenceTheme],

--- a/src/features/settings/settingsContent.ts
+++ b/src/features/settings/settingsContent.ts
@@ -681,6 +681,14 @@ const SETTINGS_DETAIL_SECTIONS_BASE: Partial<Record<SettingsPage, readonly Setti
           defaultValue: false,
           testId: 'settings-markdown-gitlab',
         },
+        {
+          kind: 'toggle',
+          id: 'renderSoftBreakAsSpace',
+          implementation: 'runtime',
+          labelKey: 'settings.markdown.softBreakAsSpace',
+          defaultValue: false,
+          testId: 'settings-markdown-soft-break-as-space',
+        },
       ],
     },
     {

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -362,6 +362,7 @@ export const de = {
   'settings.markdown.footnotes': 'Fußnoten',
   'settings.markdown.superSub': 'Hoch-/Tiefgestellt',
   'settings.markdown.gitlab': 'GitLab',
+  'settings.markdown.softBreakAsSpace': 'Weiche Umbrüche als Leerzeichen',
   'settings.markdown.sequenceTheme': 'Sequenz-Design',
   'settings.markdown.plantumlServer': 'PlantUML-Server',
 

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -356,6 +356,7 @@ export const en = {
   'settings.markdown.footnotes': 'Footnotes',
   'settings.markdown.superSub': 'Super/subscript',
   'settings.markdown.gitlab': 'GitLab',
+  'settings.markdown.softBreakAsSpace': 'Soft breaks as spaces',
   'settings.markdown.sequenceTheme': 'Sequence theme',
   'settings.markdown.plantumlServer': 'PlantUML server',
 

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -361,6 +361,7 @@ export const es = {
   'settings.markdown.footnotes': 'Notas al pie',
   'settings.markdown.superSub': 'Super/subíndice',
   'settings.markdown.gitlab': 'GitLab',
+  'settings.markdown.softBreakAsSpace': 'Saltos suaves como espacios',
   'settings.markdown.sequenceTheme': 'Tema de secuencia',
   'settings.markdown.plantumlServer': 'Servidor PlantUML',
 

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -361,6 +361,7 @@ export const fr = {
   'settings.markdown.footnotes': 'Notes de bas de page',
   'settings.markdown.superSub': 'Exposant/indice',
   'settings.markdown.gitlab': 'GitLab',
+  'settings.markdown.softBreakAsSpace': 'Sauts de ligne simples en espaces',
   'settings.markdown.sequenceTheme': 'Thème de séquence',
   'settings.markdown.plantumlServer': 'Serveur PlantUML',
 

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -361,7 +361,7 @@ export const fr = {
   'settings.markdown.footnotes': 'Notes de bas de page',
   'settings.markdown.superSub': 'Exposant/indice',
   'settings.markdown.gitlab': 'GitLab',
-  'settings.markdown.softBreakAsSpace': 'Sauts de ligne simples en espaces',
+  'settings.markdown.softBreakAsSpace': 'Sauts de ligne souples en espaces',
   'settings.markdown.sequenceTheme': 'Thème de séquence',
   'settings.markdown.plantumlServer': 'Serveur PlantUML',
 

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -361,6 +361,7 @@ export const ja = {
   'settings.markdown.footnotes': '脚注',
   'settings.markdown.superSub': '上付き/下付き文字',
   'settings.markdown.gitlab': 'GitLab',
+  'settings.markdown.softBreakAsSpace': 'ソフト改行をスペースに',
   'settings.markdown.sequenceTheme': 'シーケンス図テーマ',
   'settings.markdown.plantumlServer': 'PlantUML サーバー',
 

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -361,6 +361,7 @@ export const ko = {
   'settings.markdown.footnotes': '각주',
   'settings.markdown.superSub': '위/아래 첨자',
   'settings.markdown.gitlab': 'GitLab',
+  'settings.markdown.softBreakAsSpace': '소프트 줄바꿈을 공백으로',
   'settings.markdown.sequenceTheme': '시퀀스 테마',
   'settings.markdown.plantumlServer': 'PlantUML 서버',
 

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -361,6 +361,7 @@ export const pt = {
   'settings.markdown.footnotes': 'Notas de rodapé',
   'settings.markdown.superSub': 'Sobrescrito/subscrito',
   'settings.markdown.gitlab': 'GitLab',
+  'settings.markdown.softBreakAsSpace': 'Quebras suaves como espaços',
   'settings.markdown.sequenceTheme': 'Tema de sequência',
   'settings.markdown.plantumlServer': 'Servidor PlantUML',
 

--- a/src/lib/locales/tr.ts
+++ b/src/lib/locales/tr.ts
@@ -361,7 +361,7 @@ export const tr = {
   'settings.markdown.footnotes': 'Dipnotlar',
   'settings.markdown.superSub': 'Üst/alt simge',
   'settings.markdown.gitlab': 'GitLab',
-  'settings.markdown.softBreakAsSpace': 'Yumuşak satır sonları boşluğa',
+  'settings.markdown.softBreakAsSpace': 'Yumuşak satır sonlarını boşluk olarak göster',
   'settings.markdown.sequenceTheme': 'Sekans teması',
   'settings.markdown.plantumlServer': 'PlantUML sunucusu',
 

--- a/src/lib/locales/tr.ts
+++ b/src/lib/locales/tr.ts
@@ -361,6 +361,7 @@ export const tr = {
   'settings.markdown.footnotes': 'Dipnotlar',
   'settings.markdown.superSub': 'Üst/alt simge',
   'settings.markdown.gitlab': 'GitLab',
+  'settings.markdown.softBreakAsSpace': 'Yumuşak satır sonları boşluğa',
   'settings.markdown.sequenceTheme': 'Sekans teması',
   'settings.markdown.plantumlServer': 'PlantUML sunucusu',
 

--- a/src/lib/locales/zh-CN.ts
+++ b/src/lib/locales/zh-CN.ts
@@ -354,6 +354,7 @@ export const zhCN = {
   'settings.markdown.footnotes': '脚注',
   'settings.markdown.superSub': '上标/下标',
   'settings.markdown.gitlab': 'GitLab',
+  'settings.markdown.softBreakAsSpace': '软换行显示为空格',
   'settings.markdown.sequenceTheme': '时序图主题',
   'settings.markdown.plantumlServer': 'PlantUML 服务器',
 

--- a/src/lib/locales/zh-TW.ts
+++ b/src/lib/locales/zh-TW.ts
@@ -361,6 +361,7 @@ export const zhTW = {
   'settings.markdown.footnotes': '註腳',
   'settings.markdown.superSub': '上標/下標',
   'settings.markdown.gitlab': 'GitLab',
+  'settings.markdown.softBreakAsSpace': '軟換行顯示為空格',
   'settings.markdown.sequenceTheme': '循序圖主題',
   'settings.markdown.plantumlServer': 'PlantUML 伺服器',
 

--- a/third_party/muya/src/__tests__/softBreakAsSpaceDom.spec.ts
+++ b/third_party/muya/src/__tests__/softBreakAsSpaceDom.spec.ts
@@ -1,0 +1,202 @@
+// @vitest-environment happy-dom
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CLASS_NAMES } from '../config';
+import hardLineBreak from '../inlineRenderer/renderer/hardLineBreak';
+import softLineBreak from '../inlineRenderer/renderer/softLineBreak';
+import { Muya } from '../muya';
+import { getHighlightHtml } from '../utils/highlightHTML';
+
+// The #142 preference is implemented entirely as CSS scoped under the root
+// `.mu-soft-break-as-space` class, so the regression surface is the CSS/DOM
+// contract: the rules must hit soft-break spans (mid-paragraph and trailing)
+// and must NOT hit the other emitters of `.mu-line-end` — trailing hard
+// breaks (the hardLineBreak renderer) and trailing code-block newlines
+// (getHighlightHtml). An earlier draft's broad
+// `.mu-soft-break-as-space .mu-line-end` rule matched all three.
+
+const SPACE_RULE
+    = `.${CLASS_NAMES.MU_SOFT_BREAK_AS_SPACE} .${CLASS_NAMES.MU_SOFT_LINE_BREAK}`;
+const LINE_END_RULE
+    = `.${CLASS_NAMES.MU_SOFT_BREAK_AS_SPACE} .${CLASS_NAMES.MU_SOFT_LINE_BREAK}.${CLASS_NAMES.MU_LINE_END}`;
+
+// happy-dom's `Element.matches` mis-evaluates descendant combinators against
+// the real (deeply nested) editor tree, so "would this descendant rule apply"
+// is asserted as its equivalent decomposition: the element itself matches the
+// rule's final compound, and some proper ancestor matches the scope part.
+function ruleHits(el: Element, rule: string): boolean {
+    const lastSpace = rule.lastIndexOf(' ');
+    const scope = rule.slice(0, lastSpace);
+    const compound = rule.slice(lastSpace + 1);
+    if (!el.matches(compound))
+        return false;
+    const scopeHit = el.parentElement?.closest(scope) ?? null;
+    return scopeHit !== null;
+}
+
+// Captures the selector strings the inline renderers actually emit, so the
+// elements under test carry exactly the classes production DOM would.
+type EmitH = (selector: string, children?: unknown) => string;
+const emitH: EmitH = selector => selector;
+
+function emittedSelectors(renderer: unknown, token: Record<string, unknown>): string[] {
+    const fn = renderer as (args: { h: EmitH; token: unknown }) => string[];
+    return fn.call(undefined, { h: emitH, token });
+}
+
+function elementFrom(selector: string): HTMLElement {
+    const [tag, ...classes] = selector.split('.');
+    const el = document.createElement(tag);
+    for (const cls of classes)
+        el.classList.add(cls);
+    return el;
+}
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string, options: Record<string, unknown> = {}): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown, ...options } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function raf(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+describe('soft-break-as-space CSS/DOM contract (#142)', () => {
+    it('scopes both stylesheet rules to the soft-break span', () => {
+        const css = readFileSync(
+            resolve(process.cwd(), 'src/assets/styles/inlineSyntax.css'),
+            'utf8',
+        );
+        expect(css).toContain(`${SPACE_RULE} {`);
+        expect(css).toContain(`${LINE_END_RULE} {`);
+        // The broad variant (any `.mu-line-end` under the root class) must
+        // not come back: it also restyles hard-break and code-block nodes.
+        expect(css).not.toMatch(
+            new RegExp(`\\.${CLASS_NAMES.MU_SOFT_BREAK_AS_SPACE}\\s+\\.${CLASS_NAMES.MU_LINE_END}`),
+        );
+    });
+
+    it('hits soft-break emissions and only those, per renderer emission', () => {
+        const host = document.createElement('div');
+        host.classList.add(CLASS_NAMES.MU_SOFT_BREAK_AS_SPACE);
+        document.body.appendChild(host);
+        bootedHosts.push(host);
+
+        const attach = (selector: string) => {
+            const el = elementFrom(selector);
+            host.appendChild(el);
+            return el;
+        };
+
+        // Trailing soft break: one span carrying both classes — both rules hit.
+        const [softAtEnd] = emittedSelectors(softLineBreak, { lineBreak: '\n', isAtEnd: true });
+        expect(softAtEnd).toBe(`span.${CLASS_NAMES.MU_SOFT_LINE_BREAK}.${CLASS_NAMES.MU_LINE_END}`);
+        const softAtEndEl = attach(softAtEnd);
+        expect(ruleHits(softAtEndEl, SPACE_RULE)).toBe(true);
+        expect(ruleHits(softAtEndEl, LINE_END_RULE)).toBe(true);
+
+        // Mid-paragraph soft break: white-space rule only.
+        const [softMid] = emittedSelectors(softLineBreak, { lineBreak: '\n', isAtEnd: false });
+        const softMidEl = attach(softMid);
+        expect(ruleHits(softMidEl, SPACE_RULE)).toBe(true);
+        expect(ruleHits(softMidEl, LINE_END_RULE)).toBe(false);
+
+        // Trailing hard break: its separate `.mu-line-end` span must match
+        // neither rule — the preference is about soft breaks only.
+        const hardEmissions = emittedSelectors(hardLineBreak, {
+            spaces: '  ',
+            lineBreak: '\n',
+            isAtEnd: true,
+        });
+        expect(hardEmissions[1]).toBe(`span.${CLASS_NAMES.MU_LINE_END}`);
+        const hardLineEndEl = attach(hardEmissions[1]);
+        expect(ruleHits(hardLineEndEl, SPACE_RULE)).toBe(false);
+        expect(ruleHits(hardLineEndEl, LINE_END_RULE)).toBe(false);
+    });
+
+    it('does not restyle the trailing code-block newline span', () => {
+        const host = document.createElement('div');
+        host.classList.add(CLASS_NAMES.MU_SOFT_BREAK_AS_SPACE);
+        document.body.appendChild(host);
+        bootedHosts.push(host);
+
+        const container = document.createElement('span');
+        container.innerHTML = getHighlightHtml('const a = 1\n', [], false, true);
+        host.appendChild(container);
+
+        const codeLineEnd = container.querySelector<HTMLElement>(`.${CLASS_NAMES.MU_LINE_END}`);
+        expect(codeLineEnd).not.toBeNull();
+        expect(ruleHits(codeLineEnd!, SPACE_RULE)).toBe(false);
+        expect(ruleHits(codeLineEnd!, LINE_END_RULE)).toBe(false);
+    });
+
+    it('setOptions toggles the root class live on the same soft-break node', async () => {
+        const muya = bootMuya('alpha\nbeta\n');
+        await raf();
+        const soft = muya.domNode.querySelector<HTMLElement>(`.${CLASS_NAMES.MU_SOFT_LINE_BREAK}`);
+        expect(soft).not.toBeNull();
+        expect(ruleHits(soft!, SPACE_RULE)).toBe(false);
+
+        muya.setOptions({ renderSoftBreakAsSpace: true });
+        expect(muya.domNode.classList.contains(CLASS_NAMES.MU_SOFT_BREAK_AS_SPACE)).toBe(true);
+        // The SAME node is now hit by the scoped rule — a pure class flip, no
+        // re-render: the document model and serialized markdown are untouched.
+        expect(soft!.isConnected).toBe(true);
+        expect(ruleHits(soft!, SPACE_RULE)).toBe(true);
+        expect(muya.getMarkdown()).toBe('alpha\nbeta\n');
+
+        muya.setOptions({ renderSoftBreakAsSpace: false });
+        expect(muya.domNode.classList.contains(CLASS_NAMES.MU_SOFT_BREAK_AS_SPACE)).toBe(false);
+        expect(ruleHits(soft!, SPACE_RULE)).toBe(false);
+    });
+
+    it('applies the root class at construction time', async () => {
+        const muya = bootMuya('alpha\nbeta\n', { renderSoftBreakAsSpace: true });
+        await raf();
+        expect(muya.domNode.classList.contains(CLASS_NAMES.MU_SOFT_BREAK_AS_SPACE)).toBe(true);
+        const soft = muya.domNode.querySelector<HTMLElement>(`.${CLASS_NAMES.MU_SOFT_LINE_BREAK}`);
+        expect(soft).not.toBeNull();
+        expect(ruleHits(soft!, SPACE_RULE)).toBe(true);
+    });
+
+    it('leaves a real document hard break out of the soft-break styling', async () => {
+        const muya = bootMuya('alpha  \nbeta\n', { renderSoftBreakAsSpace: true });
+        await raf();
+        const hard = muya.domNode.querySelector<HTMLElement>(`.${CLASS_NAMES.MU_HARD_LINE_BREAK}`);
+        expect(hard).not.toBeNull();
+        // A hard break renders no soft-break span, so nothing in this
+        // document is hit by the preference's rules.
+        expect(
+            muya.domNode.querySelectorAll(`.${CLASS_NAMES.MU_SOFT_LINE_BREAK}`).length,
+        ).toBe(0);
+        expect(ruleHits(hard!, SPACE_RULE)).toBe(false);
+    });
+});

--- a/third_party/muya/src/assets/styles/inlineSyntax.css
+++ b/third_party/muya/src/assets/styles/inlineSyntax.css
@@ -168,12 +168,15 @@ code.mu-inline-rule {
    behavior) instead of MarkText's default visual line break. `.mu-content` is
    pre-wrap, so overriding the soft-break span's own white-space is what makes
    its bare `\n` collapse; the DOM text and cursor offsets are untouched. The
-   trailing variant also drops its forced block so it no longer breaks the line. */
+   trailing variant also drops its forced block so it no longer breaks the line.
+   Both rules must stay scoped to `.mu-soft-line-break`: `.mu-line-end` alone is
+   also emitted for trailing hard breaks (hardLineBreak renderer) and trailing
+   code-block newlines (highlightHTML), which this preference must not touch. */
 .mu-soft-break-as-space .mu-soft-line-break {
     white-space: normal;
 }
 
-.mu-soft-break-as-space .mu-line-end {
+.mu-soft-break-as-space .mu-soft-line-break.mu-line-end {
     display: inline;
 }
 

--- a/third_party/muya/src/assets/styles/inlineSyntax.css
+++ b/third_party/muya/src/assets/styles/inlineSyntax.css
@@ -163,6 +163,20 @@ code.mu-inline-rule {
     display: block;
 }
 
+/* Soft-break-as-space preference (#142): with the root `.mu-soft-break-as-space`
+   class on, an authored soft break collapses to a space (CommonMark/GitHub
+   behavior) instead of MarkText's default visual line break. `.mu-content` is
+   pre-wrap, so overriding the soft-break span's own white-space is what makes
+   its bare `\n` collapse; the DOM text and cursor offsets are untouched. The
+   trailing variant also drops its forced block so it no longer breaks the line. */
+.mu-soft-break-as-space .mu-soft-line-break {
+    white-space: normal;
+}
+
+.mu-soft-break-as-space .mu-line-end {
+    display: inline;
+}
+
 .mu-hard-line-break-space::after {
     font-family: monospace;
 

--- a/third_party/muya/src/config/index.ts
+++ b/third_party/muya/src/config/index.ts
@@ -163,6 +163,7 @@ export const CLASS_NAMES = genUpper2LowerKeyHash([
     'MU_RUBY_RENDER',
     'MU_SELECTED',
     'MU_SOFT_LINE_BREAK',
+    'MU_SOFT_BREAK_AS_SPACE',
     'MU_MATH_ERROR',
     'MU_MATH_MARKER',
     'MU_MATH_RENDER',
@@ -331,6 +332,7 @@ export const MUYA_DEFAULT_OPTIONS = {
     plantumlServer: 'https://www.plantuml.com/plantuml',
     sequenceTheme: 'hand' as 'hand' | 'simple', // hand / simple
     hideQuickInsertHint: false,
+    renderSoftBreakAsSpace: false,
     hideLinkPopup: false,
     autoCheck: false,
     // Whether we should set spellcheck attribute on our container to highlight misspelled words.

--- a/third_party/muya/src/muya.ts
+++ b/third_party/muya/src/muya.ts
@@ -354,6 +354,17 @@ export class Muya {
             );
         }
 
+        // Soft-break-as-space is a pure presentation switch (#142): toggling
+        // this class re-styles the existing soft-break spans without a re-parse
+        // (it is deliberately NOT in PARSE_AFFECTING_OPTIONS), so the document
+        // model, DOM text, and cursor offsets are all untouched.
+        if ('renderSoftBreakAsSpace' in options) {
+            this.domNode.classList.toggle(
+                CLASS_NAMES.MU_SOFT_BREAK_AS_SPACE,
+                !!options.renderSoftBreakAsSpace,
+            );
+        }
+
         applyAppearance(this.domNode, options);
 
         if (!forceRender)
@@ -1742,7 +1753,7 @@ function applyAppearance(domNode: HTMLElement, options: Partial<IMuyaOptions>) {
  * [ensureContainerDiv ensure container element is div]
  */
 function getContainer(originContainer: HTMLElement, options: IMuyaOptions) {
-    const { spellcheckEnabled, spellcheckHideMarks, hideQuickInsertHint, focusMode } = options;
+    const { spellcheckEnabled, spellcheckHideMarks, hideQuickInsertHint, focusMode, renderSoftBreakAsSpace } = options;
     const newContainer = document.createElement('div');
     const attrs = originContainer.attributes;
     // Copy attrs from origin container to new container
@@ -1755,6 +1766,9 @@ function getContainer(originContainer: HTMLElement, options: IMuyaOptions) {
 
     if (spellcheckHideMarks)
         newContainer.classList.add(CLASS_NAMES.MU_HIDE_SPELLING_MARKS);
+
+    if (renderSoftBreakAsSpace)
+        newContainer.classList.add(CLASS_NAMES.MU_SOFT_BREAK_AS_SPACE);
 
     // Apply focus mode at construction when initially enabled; `setFocusMode`
     // toggles it thereafter.

--- a/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
+++ b/third_party/muya/src/state/__tests__/softBreakExportHtml.spec.ts
@@ -333,6 +333,45 @@ describe('the sentinel cannot weaken sanitization or leak', () => {
     });
 });
 
+describe('renderSoftBreakAsSpace preference (#142) collapses instead of <br>', () => {
+    const MUYA_SOFT_BREAK_AS_SPACE = {
+        options: { renderSoftBreakAsSpace: true },
+    } as unknown as ConstructorParameters<typeof MarkdownToHtml>[1];
+
+    async function exportAsSpace(markdown: string) {
+        const html = await new MarkdownToHtml(PAD + markdown, MUYA_SOFT_BREAK_AS_SPACE).renderHtml();
+        expect(html).not.toContain(SENTINEL_PREFIX);
+        return html;
+    }
+
+    it('keeps a paragraph soft break as a bare newline (renders as a space), never <br>', async () => {
+        const html = await exportAsSpace('line one\nline two\n');
+        expect(html).toContain('line one\nline two');
+        expect(html).not.toContain('line one<br>');
+    });
+
+    it('keeps a tight-item soft break as a bare newline, never <br>', async () => {
+        const html = await exportAsSpace('- line A\n  line B\n');
+        expect(html).toContain('line A\nline B');
+        expect(html).not.toContain('line A<br>');
+    });
+
+    it('reaches the final document through generate() without <br>', async () => {
+        const doc = await new MarkdownToHtml(
+            `${PAD}alpha\nbeta\n`,
+            MUYA_SOFT_BREAK_AS_SPACE,
+        ).generate({ title: 't', inlineStyles: false });
+        expect(doc).toContain('alpha\nbeta');
+        expect(doc).not.toContain('alpha<br>');
+    });
+
+    it('still collapses a real hard break to <br> (the preference is soft-only)', async () => {
+        expect(await exportAsSpace('line one  \nline two\n')).toMatch(
+            /line one<br\s*\/?>\s*line two/,
+        );
+    });
+});
+
 describe('conversion cost stays linear', () => {
     it('converts a very long single paragraph without quadratic blowup', async () => {
         // Per-boundary prefix/suffix array copies made this quadratic

--- a/third_party/muya/src/state/markdownToHtml.ts
+++ b/third_party/muya/src/state/markdownToHtml.ts
@@ -115,6 +115,15 @@ export class MarkdownToHtml {
         const parts = text.data.split(sentinel);
         const parent = text.parentElement;
 
+        // Reader opted into CommonMark soft-break spacing (#142): restore the
+        // plain newline everywhere instead of emitting <br>. The export
+        // paragraph's default `white-space: normal` then collapses it to a
+        // space, matching what the editor shows with the same preference on.
+        if (this._muya?.options?.renderSoftBreakAsSpace) {
+            text.data = parts.join('\n');
+            return;
+        }
+
         // Contexts that never convert restore the plain newline: a text
         // token's newline that parsed into a protected or structural
         // position (an inline raw `<pre>` interior, a multiline setext

--- a/third_party/muya/src/types.ts
+++ b/third_party/muya/src/types.ts
@@ -31,6 +31,10 @@ export interface IMuyaOptions {
     spellcheckHideMarks: boolean;
     superSubScript: boolean;
     footnote: boolean;
+    // When true, an authored soft line break (a bare `\n` inside a block)
+    // renders as a space (CommonMark/GitHub behavior) instead of MarkText's
+    // default visual line break, in both the editor and on export (#142).
+    renderSoftBreakAsSpace?: boolean;
     math: boolean;
     isGitlabCompatibilityEnabled: boolean;
     autoMoveCheckedToEnd: boolean;


### PR DESCRIPTION
Part of #142.

## Problem

MarkText renders an authored **soft line break** (a bare `\n` inside a paragraph — a CommonMark *soft break*) as a **visual line break**: the soft-break span carries the raw `\n` and `.mu-content` is `white-space: pre-wrap`. GitHub, pandoc, and CommonMark treat it as a word boundary and render a **space**. On a phone this matters a lot — hard-wrapped files (72–80 columns, SemBr, many READMEs) render as ragged chopped lines.

The **export** half of this was already settled: #178 converts soft breaks to `<br>` on the export DOM stage. This PR adds the reader-facing **opt-in** to choose CommonMark spacing instead, wired through **both** the editor and export so they stay consistent.

## Design — one option, both sides, no re-parse

A single muya option `renderSoftBreakAsSpace` (default **off**) drives everything:

- **Editor** — muya toggles a root class `mu-soft-break-as-space` on `.muya-host` (the exact pattern `hideQuickInsertHint`/`wrapCodeBlocks` already use). Scoped CSS re-styles the existing soft-break span to `white-space: normal` so its `\n` collapses to a space, and drops the forced block on the trailing soft break only (`.mu-soft-line-break.mu-line-end` — deliberately scoped so trailing hard breaks and code-block newline spans, which also carry `.mu-line-end`, are untouched). **Pure presentation switch**: no re-parse, and the document model, DOM text, and cursor offsets are all untouched — the same invariant class as source code mode (#182).
- **Export** — the #178 DOM-stage conversion restores the plain `\n` instead of emitting `<br>` when the preference is on; the export paragraph's default `white-space: normal` then collapses it to a space, matching the editor.

The live toggle is a `forceRender: false` option update (no re-parse) — deliberately **not** in `PARSE_AFFECTING_OPTIONS`, unlike the upstream #4937 attempt which forced a full re-parse. Source code mode (#182) already answers the upstream 'you can't see where the source breaks are' concern; and Android has no Shift+Enter, so the other upstream blocker doesn't apply here either.

## Verification

- **muya unit** — extended `softBreakExportHtml.spec.ts`: with the option on, a paragraph/tight-item soft break stays a bare `\n` (renders as a space) and never `<br>`; a real hard break still becomes `<br>`; through `generate()` too. All 39 soft-break specs + 67 export-related specs pass. Default (option off) behavior is unchanged.
- **muya DOM/CSS regression** — `softBreakAsSpaceDom.spec.ts` (added after Codex review) pins the CSS/DOM contract: both stylesheet rules stay scoped to the soft-break span and the broad `.mu-soft-break-as-space .mu-line-end` variant is asserted absent; renderer emissions for mid-paragraph and trailing soft breaks hit the rules while trailing hard breaks and trailing code-block newlines do not; the root class applies at construction time and `setOptions` toggles it live on the same DOM node (true -> false restore included) with the serialized markdown untouched — no re-parse.
- **muya app-gate** — 221 test files, 1548 tests, all passing (the full run's only 3 failures are the three pre-existing upstream exclusions).
- **app unit** — `editingSettings.test.ts`: the setting maps into muya options and its live update is `forceRender: false` (a re-parse would drop the cursor/undo). `settingsContent.test.ts` runtime-defaults contract updated.
- **on device (API 35, CDP)** — opened a fixture with a genuine soft break: `.mu-soft-line-break` exists, computed `white-space` is `pre-wrap` by default and flips to `normal` when `mu-soft-break-as-space` is on `.muya-host` (the same root that carries `mu-show-quick-insert-hint`, confirming the option→class path runs on device). Toggling the Settings switch persisted `renderSoftBreakAsSpace: true`. CDP computed-style measurement was used instead of screenshots — it measures the actual style rather than pixels.
- `pnpm typecheck` + `eslint` clean.

## Scope

- Settings › Editing (rendering section) toggle **'Soft breaks as spaces'**, labels in all ten locales (intent-based, not template-translated).
- Default off — MarkText's existing line-break identity is unchanged unless the reader opts in.
- The paste-splitting side (#3741/#2257) and any Shift+Enter authoring semantics remain out of scope; this is the presentation preference only.
