### PR TITLE
Bound persisted SAF grants with a recents-driven lifecycle (#153)

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidDocumentsPlugin.java
@@ -58,6 +58,10 @@ public class AndroidDocumentsPlugin extends Plugin {
     private static final String MARKDOWN_SETTINGS_PREFS = "markdown_settings";
     private static final String PREF_DEFAULT_ENCODING = "defaultEncoding";
     private static final String PREF_AUTO_DETECT_ENCODING = "autoDetectEncoding";
+    // Ledger of persisted SAF grants this plugin took, by kind — the proof
+    // cleanupDocumentGrants needs before it may release one (#153).
+    private static final String DOCUMENT_GRANTS_PREFS = "document_grants";
+    private static final String PREF_GRANT_LEDGER = "ledger";
     private String lastHandledIncomingIntentId = "";
     private String defaultMarkdownEncoding = "utf8";
     private boolean autoDetectMarkdownEncoding = true;
@@ -482,6 +486,7 @@ public class AndroidDocumentsPlugin extends Plugin {
                         renamedUri,
                         Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                     );
+                recordGrantTaken(renamedUri, DocumentGrantPolicy.Kind.DOCUMENT);
             } catch (SecurityException ignored) {
                 // The migrated grant is not persistable on most providers.
             }
@@ -568,6 +573,81 @@ public class AndroidDocumentsPlugin extends Plugin {
         result.put("removedFileCount", cleanup.removedFileCount);
         result.put("removedBytes", cleanup.removedBytes);
         result.put("failedFileCount", cleanup.failedFileCount);
+        call.resolve(result);
+    }
+
+    @PluginMethod
+    public void cleanupDocumentGrants(PluginCall call) {
+        JSArray referencedValues = call.getArray("referencedUris");
+        if (referencedValues == null) {
+            call.reject("Document grant references are required", "INVALID_GRANT_REFERENCES");
+            return;
+        }
+        Set<String> referencedUris = new java.util.HashSet<>();
+        for (int index = 0; index < referencedValues.length(); index++) {
+            String uri = referencedValues.optString(index, "").trim();
+            if (uri.length() > 0) {
+                referencedUris.add(uri);
+            }
+        }
+
+        int releasedGrantCount = 0;
+        int failedReleaseCount = 0;
+        int remainingGrantCount;
+        synchronized (this) {
+            ContentResolver resolver = getContext().getContentResolver();
+            Map<String, UriPermission> persistedGrants = new LinkedHashMap<>();
+            for (UriPermission permission : resolver.getPersistedUriPermissions()) {
+                persistedGrants.put(permission.getUri().toString(), permission);
+            }
+
+            SharedPreferences prefs = getContext()
+                .getSharedPreferences(DOCUMENT_GRANTS_PREFS, Context.MODE_PRIVATE);
+            Map<String, DocumentGrantPolicy.Entry> ledger =
+                DocumentGrantPolicy.parseLedger(prefs.getString(PREF_GRANT_LEDGER, ""));
+            DocumentGrantPolicy.Decision decision = DocumentGrantPolicy.decide(
+                persistedGrants.keySet(),
+                ledger,
+                referencedUris,
+                System.currentTimeMillis()
+            );
+
+            for (String uri : decision.releaseUris) {
+                UriPermission permission = persistedGrants.get(uri);
+                int grantFlags =
+                    (permission.isReadPermission() ? Intent.FLAG_GRANT_READ_URI_PERMISSION : 0)
+                    | (permission.isWritePermission() ? Intent.FLAG_GRANT_WRITE_URI_PERMISSION : 0);
+                try {
+                    resolver.releasePersistableUriPermission(permission.getUri(), grantFlags);
+                    releasedGrantCount += 1;
+                } catch (SecurityException ex) {
+                    // The grant survived; restore its ledger entry so a later
+                    // cleanup retries instead of orphaning it as unmanaged.
+                    decision.nextLedger.put(uri, ledger.get(uri));
+                    failedReleaseCount += 1;
+                    Log.w(TAG, "Could not release Android document URI permission", ex);
+                }
+            }
+
+            prefs
+                .edit()
+                .putString(PREF_GRANT_LEDGER, DocumentGrantPolicy.serializeLedger(decision.nextLedger))
+                .apply();
+            remainingGrantCount = persistedGrants.size() - releasedGrantCount;
+        }
+
+        if (releasedGrantCount > 0 || failedReleaseCount > 0) {
+            Log.i(
+                TAG,
+                "Document grant cleanup released " + releasedGrantCount
+                    + " grant(s), failed " + failedReleaseCount
+                    + ", remaining " + remainingGrantCount
+            );
+        }
+        JSObject result = new JSObject();
+        result.put("grantCount", remainingGrantCount);
+        result.put("releasedGrantCount", releasedGrantCount);
+        result.put("failedReleaseCount", failedReleaseCount);
         call.resolve(result);
     }
 
@@ -703,7 +783,7 @@ public class AndroidDocumentsPlugin extends Plugin {
         try {
             JSObject document = buildOpenWithDocumentResult(uri, intent);
             if ((intent.getFlags() & Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION) != 0) {
-                persistUriPermission(uri, intent);
+                persistUriPermission(uri, intent, DocumentGrantPolicy.Kind.DOCUMENT);
             }
             document.put("persisted", hasPersistedReadPermission(uri));
             document.put("canWrite", canWrite(uri, intent));
@@ -730,7 +810,7 @@ public class AndroidDocumentsPlugin extends Plugin {
         try {
             JSObject document = buildSharedStreamDocumentResult(uri, intent);
             if ((intent.getFlags() & Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION) != 0) {
-                persistUriPermission(uri, intent);
+                persistUriPermission(uri, intent, DocumentGrantPolicy.Kind.DOCUMENT);
             }
             document.put("persisted", hasPersistedReadPermission(uri));
             document.put("canWrite", canWrite(uri, intent));
@@ -806,7 +886,7 @@ public class AndroidDocumentsPlugin extends Plugin {
 
         try {
             JSObject document = createDocumentResult(uri, data, markdown, getMarkdownWriteOptions(call));
-            persistUriPermission(uri, data);
+            persistUriPermission(uri, data, DocumentGrantPolicy.Kind.DOCUMENT);
             document.put("persisted", hasPersistedReadPermission(uri));
             document.put("canWrite", canWrite(uri, data));
             Log.i(TAG, "Created Android document: " + safeForLog(document.getString("displayName")));
@@ -846,7 +926,7 @@ public class AndroidDocumentsPlugin extends Plugin {
 
         try {
             JSObject document = buildDocumentResult(uri, data);
-            persistUriPermission(uri, data);
+            persistUriPermission(uri, data, DocumentGrantPolicy.Kind.DOCUMENT);
             document.put("persisted", hasPersistedReadPermission(uri));
             document.put("canWrite", canWrite(uri, data));
             Log.i(TAG, "Opened Android document: " + safeForLog(document.getString("displayName")));
@@ -970,7 +1050,7 @@ public class AndroidDocumentsPlugin extends Plugin {
             );
         }
 
-        persistUriPermission(uri, grantIntent);
+        persistUriPermission(uri, grantIntent, DocumentGrantPolicy.Kind.IMAGE);
 
         JSObject result = new JSObject();
         result.put("canceled", false);
@@ -1157,7 +1237,7 @@ public class AndroidDocumentsPlugin extends Plugin {
         }
     }
 
-    private void persistUriPermission(Uri uri, Intent data) {
+    private void persistUriPermission(Uri uri, Intent data, DocumentGrantPolicy.Kind grantKind) {
         if (data == null) {
             return;
         }
@@ -1179,9 +1259,25 @@ public class AndroidDocumentsPlugin extends Plugin {
 
         try {
             getContext().getContentResolver().takePersistableUriPermission(uri, grantFlags);
+            recordGrantTaken(uri, grantKind);
         } catch (SecurityException ex) {
             Log.w(TAG, "Could not persist Android document URI permission", ex);
         }
+    }
+
+    private synchronized void recordGrantTaken(Uri uri, DocumentGrantPolicy.Kind grantKind) {
+        SharedPreferences prefs = getContext()
+            .getSharedPreferences(DOCUMENT_GRANTS_PREFS, Context.MODE_PRIVATE);
+        Map<String, DocumentGrantPolicy.Entry> ledger =
+            DocumentGrantPolicy.parseLedger(prefs.getString(PREF_GRANT_LEDGER, ""));
+        ledger.put(
+            uri.toString(),
+            new DocumentGrantPolicy.Entry(grantKind, System.currentTimeMillis())
+        );
+        prefs
+            .edit()
+            .putString(PREF_GRANT_LEDGER, DocumentGrantPolicy.serializeLedger(ledger))
+            .apply();
     }
 
     // Atomic-intent write: never leave the user's real file truncated on a

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/DocumentGrantPolicy.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/DocumentGrantPolicy.java
@@ -1,0 +1,168 @@
+package io.github.renakoni.marktextandroid;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Android-free policy for the persisted SAF grant lifecycle (#153).
+ *
+ * The web layer's recent-documents store is the LRU: it is capped at 100
+ * records, pin-protected, and recency-ordered, and every Android document
+ * record in it carries the content URI whose grant it depends on. This
+ * policy follows that store instead of keeping a second recency clock: a
+ * grant is released only when ALL of the following hold, so a release is
+ * provably safe rather than heuristically likely:
+ *
+ * 1. The ledger proves this app took the grant for a Markdown document.
+ *    Image grants and grants that predate the ledger have dependents this
+ *    policy cannot enumerate (document bodies reference linked images;
+ *    legacy grants have no recorded kind), so they are never released.
+ * 2. The web layer reports no recent/pinned/current document references
+ *    the URI.
+ * 3. The grant settled: it was taken more than {@link #SETTLE_WINDOW_MILLIS}
+ *    ago. A cleanup call carries a reference snapshot the web computed
+ *    before a concurrent open could add its URI, so fresh grants are
+ *    skipped and picked up by the next cleanup instead.
+ */
+final class DocumentGrantPolicy {
+
+    /** Skip releasing grants younger than this; see class contract point 3. */
+    static final long SETTLE_WINDOW_MILLIS = 5 * 60 * 1000;
+
+    enum Kind {
+        DOCUMENT,
+        IMAGE;
+
+        static Kind fromStorageName(String value) {
+            if ("document".equals(value)) {
+                return DOCUMENT;
+            }
+            if ("image".equals(value)) {
+                return IMAGE;
+            }
+            return null;
+        }
+
+        String toStorageName() {
+            return this == DOCUMENT ? "document" : "image";
+        }
+    }
+
+    static final class Entry {
+
+        final Kind kind;
+        final long takenAtMillis;
+
+        Entry(Kind kind, long takenAtMillis) {
+            this.kind = kind;
+            this.takenAtMillis = takenAtMillis;
+        }
+    }
+
+    static final class Decision {
+
+        /** URIs whose persisted grant should be released, in input order. */
+        final List<String> releaseUris;
+        /** Ledger to persist after the releases succeed. */
+        final Map<String, Entry> nextLedger;
+
+        Decision(List<String> releaseUris, Map<String, Entry> nextLedger) {
+            this.releaseUris = releaseUris;
+            this.nextLedger = nextLedger;
+        }
+    }
+
+    private DocumentGrantPolicy() {}
+
+    static Decision decide(
+        Collection<String> persistedUris,
+        Map<String, Entry> ledger,
+        Set<String> referencedUris,
+        long nowMillis
+    ) {
+        List<String> releaseUris = new ArrayList<>();
+        Map<String, Entry> nextLedger = new HashMap<>();
+
+        for (String uri : persistedUris) {
+            Entry entry = ledger.get(uri);
+            if (entry == null) {
+                // Not ours to manage: predates the ledger or was taken by a
+                // code path that does not record. Leave the grant alone.
+                continue;
+            }
+
+            boolean releasable = entry.kind == Kind.DOCUMENT
+                && !referencedUris.contains(uri)
+                && nowMillis - entry.takenAtMillis > SETTLE_WINDOW_MILLIS;
+            if (releasable) {
+                releaseUris.add(uri);
+            } else {
+                nextLedger.put(uri, entry);
+            }
+        }
+
+        // Entries whose grant is gone (revoked by the provider, the system's
+        // own quota pruning, or the user) are dropped by not copying them, so
+        // the ledger cannot outgrow the persisted grant table.
+        return new Decision(releaseUris, nextLedger);
+    }
+
+    static Map<String, Entry> parseLedger(String serialized) {
+        Map<String, Entry> ledger = new HashMap<>();
+        if (serialized == null || serialized.length() == 0) {
+            return ledger;
+        }
+
+        for (String line : serialized.split("\n", -1)) {
+            int kindEnd = line.indexOf('|');
+            if (kindEnd <= 0) {
+                continue;
+            }
+            int takenAtEnd = line.indexOf('|', kindEnd + 1);
+            if (takenAtEnd <= kindEnd + 1 || takenAtEnd + 1 >= line.length()) {
+                continue;
+            }
+
+            Kind kind = Kind.fromStorageName(line.substring(0, kindEnd));
+            if (kind == null) {
+                continue;
+            }
+            long takenAtMillis;
+            try {
+                takenAtMillis = Long.parseLong(line.substring(kindEnd + 1, takenAtEnd));
+            } catch (NumberFormatException ex) {
+                continue;
+            }
+
+            ledger.put(line.substring(takenAtEnd + 1), new Entry(kind, takenAtMillis));
+        }
+        return ledger;
+    }
+
+    static String serializeLedger(Map<String, Entry> ledger) {
+        StringBuilder serialized = new StringBuilder();
+        for (Map.Entry<String, Entry> mapEntry : ledger.entrySet()) {
+            String uri = mapEntry.getKey();
+            if (uri.indexOf('\n') >= 0 || uri.indexOf('\r') >= 0) {
+                // A URI that could corrupt the line format cannot round-trip;
+                // dropping its entry only makes the grant unmanaged (kept).
+                continue;
+            }
+            if (serialized.length() > 0) {
+                serialized.append('\n');
+            }
+            Entry entry = mapEntry.getValue();
+            serialized
+                .append(entry.kind.toStorageName())
+                .append('|')
+                .append(entry.takenAtMillis)
+                .append('|')
+                .append(uri);
+        }
+        return serialized.toString();
+    }
+}

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/DocumentGrantPolicy.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/DocumentGrantPolicy.java
@@ -2,6 +2,7 @@ package io.github.renakoni.marktextandroid;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,11 +28,30 @@ import java.util.Set;
  *    ago. A cleanup call carries a reference snapshot the web computed
  *    before a concurrent open could add its URI, so fresh grants are
  *    skipped and picked up by the next cleanup instead.
+ *
+ * One bounded exception: condition 3 yields to the hard quota bound. When
+ * the grant table would still exceed {@link #SAFETY_VALVE_GRANT_COUNT}
+ * after the settled releases, unsettled grants meeting conditions 1 and 2
+ * are released too — oldest take first, only down to the valve. Without
+ * this, a burst of opens inside one settle window would sail past the
+ * 128-grant OS cap (Android 10 and below), where the SYSTEM silently drops
+ * the oldest grants, possibly a pinned document's. Conditions 1 and 2 are
+ * never waived.
  */
 final class DocumentGrantPolicy {
 
     /** Skip releasing grants younger than this; see class contract point 3. */
     static final long SETTLE_WINDOW_MILLIS = 5 * 60 * 1000;
+
+    /**
+     * Hard quota guard, deliberately under the 128-grant OS floor. Above it
+     * the settle window's race insurance is the smaller risk: releases go
+     * oldest-first and stop at the valve, so an in-flight open — always the
+     * newest take, and referenced by the very cleanup its recents write
+     * triggers next — is touched only if the referenced set plus concurrent
+     * takes alone exceed the valve.
+     */
+    static final int SAFETY_VALVE_GRANT_COUNT = 120;
 
     enum Kind {
         DOCUMENT,
@@ -86,6 +106,7 @@ final class DocumentGrantPolicy {
     ) {
         List<String> releaseUris = new ArrayList<>();
         Map<String, Entry> nextLedger = new HashMap<>();
+        List<String> unsettledUnreferenced = new ArrayList<>();
 
         for (String uri : persistedUris) {
             Entry entry = ledger.get(uri);
@@ -95,13 +116,33 @@ final class DocumentGrantPolicy {
                 continue;
             }
 
-            boolean releasable = entry.kind == Kind.DOCUMENT
-                && !referencedUris.contains(uri)
-                && nowMillis - entry.takenAtMillis > SETTLE_WINDOW_MILLIS;
-            if (releasable) {
+            boolean provenOrphan = entry.kind == Kind.DOCUMENT
+                && !referencedUris.contains(uri);
+            if (provenOrphan && nowMillis - entry.takenAtMillis > SETTLE_WINDOW_MILLIS) {
                 releaseUris.add(uri);
             } else {
+                if (provenOrphan) {
+                    unsettledUnreferenced.add(uri);
+                }
                 nextLedger.put(uri, entry);
+            }
+        }
+
+        // Safety valve: see the class contract. Oldest takes go first and
+        // the release stops at the valve, so the youngest grants keep their
+        // settle protection whenever the count allows it.
+        int remaining = persistedUris.size() - releaseUris.size();
+        if (remaining > SAFETY_VALVE_GRANT_COUNT) {
+            unsettledUnreferenced.sort(
+                Comparator.comparingLong(uri -> ledger.get(uri).takenAtMillis)
+            );
+            for (String uri : unsettledUnreferenced) {
+                if (remaining <= SAFETY_VALVE_GRANT_COUNT) {
+                    break;
+                }
+                releaseUris.add(uri);
+                nextLedger.remove(uri);
+                remaining -= 1;
             }
         }
 

--- a/android/app/src/test/java/io/github/renakoni/marktextandroid/DocumentGrantPolicyTest.java
+++ b/android/app/src/test/java/io/github/renakoni/marktextandroid/DocumentGrantPolicyTest.java
@@ -1,0 +1,263 @@
+package io.github.renakoni.marktextandroid;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public class DocumentGrantPolicyTest {
+
+    private static final long NOW = 1_700_000_000_000L;
+    private static final long SETTLED = NOW - DocumentGrantPolicy.SETTLE_WINDOW_MILLIS - 1;
+
+    private static Map<String, DocumentGrantPolicy.Entry> ledger(Object... pairs) {
+        Map<String, DocumentGrantPolicy.Entry> ledger = new HashMap<>();
+        for (int index = 0; index < pairs.length; index += 2) {
+            ledger.put((String) pairs[index], (DocumentGrantPolicy.Entry) pairs[index + 1]);
+        }
+        return ledger;
+    }
+
+    private static DocumentGrantPolicy.Entry document(long takenAtMillis) {
+        return new DocumentGrantPolicy.Entry(DocumentGrantPolicy.Kind.DOCUMENT, takenAtMillis);
+    }
+
+    private static DocumentGrantPolicy.Entry image(long takenAtMillis) {
+        return new DocumentGrantPolicy.Entry(DocumentGrantPolicy.Kind.IMAGE, takenAtMillis);
+    }
+
+    @Test
+    public void releasesOnlySettledUnreferencedDocumentGrants() {
+        List<String> persisted = Arrays.asList(
+            "content://docs/referenced",
+            "content://docs/orphan",
+            "content://docs/fresh"
+        );
+        Map<String, DocumentGrantPolicy.Entry> entries = ledger(
+            "content://docs/referenced", document(SETTLED),
+            "content://docs/orphan", document(SETTLED),
+            "content://docs/fresh", document(NOW - 1_000)
+        );
+
+        DocumentGrantPolicy.Decision decision = DocumentGrantPolicy.decide(
+            persisted,
+            entries,
+            Collections.singleton("content://docs/referenced"),
+            NOW
+        );
+
+        assertEquals(Collections.singletonList("content://docs/orphan"), decision.releaseUris);
+        assertEquals(
+            new HashSet<>(Arrays.asList("content://docs/referenced", "content://docs/fresh")),
+            decision.nextLedger.keySet()
+        );
+    }
+
+    @Test
+    public void neverReleasesGrantsWithoutALedgerEntry() {
+        DocumentGrantPolicy.Decision decision = DocumentGrantPolicy.decide(
+            Collections.singletonList("content://docs/legacy"),
+            ledger(),
+            Collections.emptySet(),
+            NOW
+        );
+
+        assertTrue(decision.releaseUris.isEmpty());
+        assertTrue(decision.nextLedger.isEmpty());
+    }
+
+    @Test
+    public void neverReleasesImageGrants() {
+        DocumentGrantPolicy.Decision decision = DocumentGrantPolicy.decide(
+            Collections.singletonList("content://media/linked-image"),
+            ledger("content://media/linked-image", image(SETTLED)),
+            Collections.emptySet(),
+            NOW
+        );
+
+        assertTrue(decision.releaseUris.isEmpty());
+        assertEquals(
+            Collections.singleton("content://media/linked-image"),
+            decision.nextLedger.keySet()
+        );
+    }
+
+    @Test
+    public void settleWindowBoundaryIsExact() {
+        long atWindow = NOW - DocumentGrantPolicy.SETTLE_WINDOW_MILLIS;
+        Map<String, DocumentGrantPolicy.Entry> entries = ledger(
+            "content://docs/at-window", document(atWindow),
+            "content://docs/past-window", document(atWindow - 1)
+        );
+
+        DocumentGrantPolicy.Decision decision = DocumentGrantPolicy.decide(
+            Arrays.asList("content://docs/at-window", "content://docs/past-window"),
+            entries,
+            Collections.emptySet(),
+            NOW
+        );
+
+        assertEquals(Collections.singletonList("content://docs/past-window"), decision.releaseUris);
+        assertEquals(Collections.singleton("content://docs/at-window"), decision.nextLedger.keySet());
+    }
+
+    @Test
+    public void dropsLedgerEntriesWhoseGrantIsGone() {
+        DocumentGrantPolicy.Decision decision = DocumentGrantPolicy.decide(
+            Collections.singletonList("content://docs/alive"),
+            ledger(
+                "content://docs/alive", document(SETTLED),
+                "content://docs/revoked", document(SETTLED)
+            ),
+            Collections.singleton("content://docs/alive"),
+            NOW
+        );
+
+        assertTrue(decision.releaseUris.isEmpty());
+        assertEquals(Collections.singleton("content://docs/alive"), decision.nextLedger.keySet());
+    }
+
+    @Test
+    public void ledgerSerializationRoundTripsIncludingPipesInUris() {
+        Map<String, DocumentGrantPolicy.Entry> entries = ledger(
+            "content://docs/plain", document(123L),
+            "content://docs/with%7Cpipe|raw", image(456L)
+        );
+
+        Map<String, DocumentGrantPolicy.Entry> parsed = DocumentGrantPolicy.parseLedger(
+            DocumentGrantPolicy.serializeLedger(entries)
+        );
+
+        assertEquals(entries.keySet(), parsed.keySet());
+        assertEquals(DocumentGrantPolicy.Kind.DOCUMENT, parsed.get("content://docs/plain").kind);
+        assertEquals(123L, parsed.get("content://docs/plain").takenAtMillis);
+        assertEquals(
+            DocumentGrantPolicy.Kind.IMAGE,
+            parsed.get("content://docs/with%7Cpipe|raw").kind
+        );
+        assertEquals(456L, parsed.get("content://docs/with%7Cpipe|raw").takenAtMillis);
+    }
+
+    @Test
+    public void parsingSkipsMalformedLinesAndEmptyInput() {
+        assertTrue(DocumentGrantPolicy.parseLedger(null).isEmpty());
+        assertTrue(DocumentGrantPolicy.parseLedger("").isEmpty());
+
+        Map<String, DocumentGrantPolicy.Entry> parsed = DocumentGrantPolicy.parseLedger(
+            String.join(
+                "\n",
+                "garbage",
+                "unknown-kind|123|content://docs/a",
+                "document|not-a-number|content://docs/b",
+                "document|123|",
+                "document|123|content://docs/valid"
+            )
+        );
+
+        assertEquals(Collections.singleton("content://docs/valid"), parsed.keySet());
+    }
+
+    @Test
+    public void manyDocumentsStressStaysUnderTheGrantQuota() {
+        // Simulates a long-lived install opening 500 documents one minute
+        // apart, with the web recents store keeping its newest 100 records
+        // and a cleanup after every open — the wiring this PR adds. The OS
+        // quota floor is 128 (Android 10 and below).
+        final int quota = 128;
+        final int recentsCap = 100;
+        long clock = NOW;
+
+        Map<String, DocumentGrantPolicy.Entry> entries = new HashMap<>();
+        Set<String> persisted = new LinkedHashSet<>();
+        Deque<String> recents = new ArrayDeque<>();
+
+        for (int index = 0; index < 500; index++) {
+            clock += 60_000;
+            String uri = "content://docs/stress-" + index;
+            persisted.add(uri);
+            entries.put(uri, document(clock));
+            recents.addFirst(uri);
+            while (recents.size() > recentsCap) {
+                recents.removeLast();
+            }
+
+            DocumentGrantPolicy.Decision decision = DocumentGrantPolicy.decide(
+                new ArrayList<>(persisted),
+                entries,
+                new HashSet<>(recents),
+                clock
+            );
+            decision.releaseUris.forEach(persisted::remove);
+            entries = decision.nextLedger;
+
+            // Live grants: the 100 recents plus at most the not-yet-settled
+            // evictions (settle window / open interval = 5 grants).
+            assertTrue(
+                "grants at open " + index + ": " + persisted.size(),
+                persisted.size() <= recentsCap + (int) (DocumentGrantPolicy.SETTLE_WINDOW_MILLIS / 60_000)
+            );
+            assertTrue(persisted.size() < quota);
+        }
+
+        // Once the last evictions settle, the grant table converges to
+        // exactly the protected set.
+        DocumentGrantPolicy.Decision finalDecision = DocumentGrantPolicy.decide(
+            new ArrayList<>(persisted),
+            entries,
+            new HashSet<>(recents),
+            clock + DocumentGrantPolicy.SETTLE_WINDOW_MILLIS + 1
+        );
+        finalDecision.releaseUris.forEach(persisted::remove);
+        assertEquals(recentsCap, persisted.size());
+        assertEquals(new HashSet<>(recents), persisted);
+    }
+
+    @Test
+    public void pinnedStyleReferencesSurviveIndefinitely() {
+        // A pinned document's URI stays in the referenced set forever even
+        // as hundreds of newer documents come and go; its grant must too.
+        final String pinned = "content://docs/pinned";
+        long clock = NOW;
+
+        Map<String, DocumentGrantPolicy.Entry> entries = new HashMap<>();
+        Set<String> persisted = new LinkedHashSet<>();
+        persisted.add(pinned);
+        entries.put(pinned, document(clock));
+
+        for (int index = 0; index < 300; index++) {
+            clock += 60_000;
+            String uri = "content://docs/churn-" + index;
+            persisted.add(uri);
+            entries.put(uri, document(clock));
+
+            Set<String> referenced = new HashSet<>();
+            referenced.add(pinned);
+            referenced.add(uri);
+
+            DocumentGrantPolicy.Decision decision = DocumentGrantPolicy.decide(
+                new ArrayList<>(persisted),
+                entries,
+                referenced,
+                clock
+            );
+            decision.releaseUris.forEach(persisted::remove);
+            entries = decision.nextLedger;
+        }
+
+        assertTrue(persisted.contains(pinned));
+        assertFalse(persisted.contains("content://docs/churn-0"));
+        assertTrue(persisted.size() <= 1 + 1 + (int) (DocumentGrantPolicy.SETTLE_WINDOW_MILLIS / 60_000));
+    }
+}

--- a/android/app/src/test/java/io/github/renakoni/marktextandroid/DocumentGrantPolicyTest.java
+++ b/android/app/src/test/java/io/github/renakoni/marktextandroid/DocumentGrantPolicyTest.java
@@ -225,6 +225,134 @@ public class DocumentGrantPolicyTest {
     }
 
     @Test
+    public void aBurstOfOpensStaysUnderTheOsQuotaViaTheSafetyValve() {
+        // Codex round-1 finding: opening 129+ documents inside one settle
+        // window used to pile up unsettled evictions past the 128-grant OS
+        // cap with nothing releasable. Model the burst: 200 documents two
+        // seconds apart, recents keeping the newest 100, cleanup after every
+        // open — the wiring's cadence.
+        final int quota = 128;
+        final int recentsCap = 100;
+        long clock = NOW;
+
+        Map<String, DocumentGrantPolicy.Entry> entries = new HashMap<>();
+        Set<String> persisted = new LinkedHashSet<>();
+        Deque<String> recents = new ArrayDeque<>();
+
+        for (int index = 0; index < 200; index++) {
+            clock += 2_000;
+            String uri = "content://docs/burst-" + index;
+            persisted.add(uri);
+            entries.put(uri, document(clock));
+            recents.addFirst(uri);
+            while (recents.size() > recentsCap) {
+                recents.removeLast();
+            }
+
+            // Peak between cleanups is one un-cleaned take past the valve.
+            assertTrue(
+                "pre-cleanup grants at open " + index + ": " + persisted.size(),
+                persisted.size() <= DocumentGrantPolicy.SAFETY_VALVE_GRANT_COUNT + 1
+            );
+            assertTrue(persisted.size() < quota);
+
+            DocumentGrantPolicy.Decision decision = DocumentGrantPolicy.decide(
+                new ArrayList<>(persisted),
+                entries,
+                new HashSet<>(recents),
+                clock
+            );
+            decision.releaseUris.forEach(persisted::remove);
+            entries = decision.nextLedger;
+
+            assertTrue(
+                "post-cleanup grants at open " + index + ": " + persisted.size(),
+                persisted.size() <= DocumentGrantPolicy.SAFETY_VALVE_GRANT_COUNT
+            );
+        }
+
+        // Every referenced document kept its grant through the burst.
+        assertTrue(persisted.containsAll(recents));
+    }
+
+    @Test
+    public void safetyValveReleasesOldestFirstAndOnlyDownToTheValve() {
+        // 1 referenced + 124 unsettled unreferenced documents: five over the
+        // valve. Exactly the five oldest takes go; the rest keep their
+        // settle protection and their ledger entries.
+        Map<String, DocumentGrantPolicy.Entry> entries = new HashMap<>();
+        List<String> persisted = new ArrayList<>();
+        persisted.add("content://docs/referenced");
+        entries.put("content://docs/referenced", document(NOW - 10_000));
+        for (int index = 0; index < 124; index++) {
+            String uri = "content://docs/orphan-" + index;
+            persisted.add(uri);
+            entries.put(uri, document(NOW - 100_000 + index * 100L));
+        }
+
+        DocumentGrantPolicy.Decision decision = DocumentGrantPolicy.decide(
+            persisted,
+            entries,
+            Collections.singleton("content://docs/referenced"),
+            NOW
+        );
+
+        assertEquals(
+            persisted.size() - DocumentGrantPolicy.SAFETY_VALVE_GRANT_COUNT,
+            decision.releaseUris.size()
+        );
+        for (int index = 0; index < decision.releaseUris.size(); index++) {
+            assertEquals("content://docs/orphan-" + index, decision.releaseUris.get(index));
+        }
+        assertTrue(decision.nextLedger.containsKey("content://docs/referenced"));
+        assertTrue(decision.nextLedger.containsKey("content://docs/orphan-123"));
+        assertFalse(decision.nextLedger.containsKey("content://docs/orphan-0"));
+    }
+
+    @Test
+    public void safetyValveNeverWaivesTheKindOrReferenceConditions() {
+        // Over the valve with almost nothing releasable: 60 legacy grants
+        // (no ledger entry), 40 image grants, 25 referenced documents, and 5
+        // unsettled unreferenced documents. Only those 5 may go, even though
+        // the table stays over the valve afterwards.
+        Map<String, DocumentGrantPolicy.Entry> entries = new HashMap<>();
+        List<String> persisted = new ArrayList<>();
+        Set<String> referenced = new HashSet<>();
+        for (int index = 0; index < 60; index++) {
+            persisted.add("content://docs/legacy-" + index);
+        }
+        for (int index = 0; index < 40; index++) {
+            String uri = "content://media/image-" + index;
+            persisted.add(uri);
+            entries.put(uri, image(NOW - 1_000_000));
+        }
+        for (int index = 0; index < 25; index++) {
+            String uri = "content://docs/referenced-" + index;
+            persisted.add(uri);
+            entries.put(uri, document(NOW - 1_000_000));
+            referenced.add(uri);
+        }
+        for (int index = 0; index < 5; index++) {
+            String uri = "content://docs/orphan-" + index;
+            persisted.add(uri);
+            entries.put(uri, document(NOW - 1_000));
+        }
+
+        DocumentGrantPolicy.Decision decision = DocumentGrantPolicy.decide(
+            persisted,
+            entries,
+            referenced,
+            NOW
+        );
+
+        assertEquals(5, decision.releaseUris.size());
+        for (String uri : decision.releaseUris) {
+            assertTrue(uri.startsWith("content://docs/orphan-"));
+        }
+        assertEquals(40 + 25, decision.nextLedger.size());
+    }
+
+    @Test
     public void pinnedStyleReferencesSurviveIndefinitely() {
         // A pinned document's URI stays in the referenced set forever even
         // as hundreds of newer documents come and go; its grant must too.

--- a/src/App.vue
+++ b/src/App.vue
@@ -76,6 +76,7 @@ import {
   ImportedImageCleanupBlockedError,
   cleanupUnusedImportedImages,
 } from './features/android-documents/importedImageMaintenance'
+import { createDocumentGrantSync } from './features/android-documents/documentGrantMaintenance'
 import {
   protectImportedImagesInAndroidDocument,
   registerImportedImageCopy,
@@ -1353,6 +1354,26 @@ function persistAndroidRecentDocuments(nextDocuments: RecentDocumentRecord[]) {
     pinnedDocumentIds.value,
   )
   androidRecentDocuments.value = filteredDocuments
+  requestAndroidDocumentGrantCleanup()
+}
+
+const syncAndroidDocumentGrants = createDocumentGrantSync()
+
+// Fire-and-forget: grant cleanup is background maintenance and must never
+// block or fail the recents mutation that triggered it.
+function requestAndroidDocumentGrantCleanup() {
+  syncAndroidDocumentGrants({
+    currentDocument: { sourceUri: documentState.value.sourceUri },
+    recentDocuments: androidRecentDocuments.value,
+  })
+    .then(result => {
+      if (result && (result.releasedGrantCount > 0 || result.failedReleaseCount > 0)) {
+        androidDocumentLog.info('document grant cleanup', result)
+      }
+    })
+    .catch(error => {
+      androidDocumentLog.warn('document grant cleanup failed', { error })
+    })
 }
 
 function persistPinnedDocuments(nextPins: PinnedDocumentRecord[]) {
@@ -2142,6 +2163,10 @@ onMounted(() => {
     restoredAndroidDocuments: androidRecentDocuments.value.length,
     characters: characterCount.value,
   })
+
+  // Releases grants left pending by a previous session (for example the app
+  // was killed between a recents mutation and its cleanup call).
+  requestAndroidDocumentGrantCleanup()
 
   incomingDocuments.installListeners()
   startupActionTimer = window.setTimeout(() => {

--- a/src/features/android-documents/documentGrantMaintenance.test.ts
+++ b/src/features/android-documents/documentGrantMaintenance.test.ts
@@ -105,4 +105,25 @@ describe('createDocumentGrantSync', () => {
     await expect(sync(options)).resolves.toEqual(CLEAN_RESULT)
     expect(cleanup).toHaveBeenCalledTimes(2)
   })
+
+  it('retries a resolved cleanup that reported failed releases', async () => {
+    // The native side resolves (not rejects) when a provider refuses a
+    // release, restoring the ledger entry and reporting the count — the
+    // memo must not swallow the retry.
+    const failedResult = { grantCount: 3, releasedGrantCount: 0, failedReleaseCount: 1 }
+    const cleanup = vi
+      .fn()
+      .mockResolvedValueOnce(failedResult)
+      .mockResolvedValue(CLEAN_RESULT)
+    const sync = createDocumentGrantSync({ cleanup, isAvailable: () => true })
+    const options = {
+      currentDocument: { sourceUri: null },
+      recentDocuments: [{ sourceUri: 'content://docs/a' }],
+    }
+
+    await expect(sync(options)).resolves.toEqual(failedResult)
+    await expect(sync(options)).resolves.toEqual(CLEAN_RESULT)
+    await expect(sync(options)).resolves.toBeNull()
+    expect(cleanup).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/features/android-documents/documentGrantMaintenance.test.ts
+++ b/src/features/android-documents/documentGrantMaintenance.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  collectReferencedDocumentUris,
+  createDocumentGrantSync,
+} from './documentGrantMaintenance'
+
+const CLEAN_RESULT = { grantCount: 3, releasedGrantCount: 0, failedReleaseCount: 0 }
+
+describe('collectReferencedDocumentUris', () => {
+  it('unions the current document with recents, dropping nulls and duplicates', () => {
+    const referenced = collectReferencedDocumentUris({
+      currentDocument: { sourceUri: 'content://docs/current' },
+      recentDocuments: [
+        { sourceUri: 'content://docs/b' },
+        { sourceUri: null },
+        { sourceUri: 'content://docs/a' },
+        { sourceUri: 'content://docs/current' },
+      ],
+    })
+
+    expect(referenced).toEqual([
+      'content://docs/a',
+      'content://docs/b',
+      'content://docs/current',
+    ])
+  })
+
+  it('handles a local-draft current document', () => {
+    expect(
+      collectReferencedDocumentUris({
+        currentDocument: { sourceUri: null },
+        recentDocuments: [],
+      }),
+    ).toEqual([])
+  })
+})
+
+describe('createDocumentGrantSync', () => {
+  it('does nothing off Android', async () => {
+    const cleanup = vi.fn()
+    const sync = createDocumentGrantSync({ cleanup, isAvailable: () => false })
+
+    await expect(
+      sync({ currentDocument: { sourceUri: 'content://docs/a' }, recentDocuments: [] }),
+    ).resolves.toBeNull()
+    expect(cleanup).not.toHaveBeenCalled()
+  })
+
+  it('pushes the sorted unique referenced set to the cleanup', async () => {
+    const cleanup = vi.fn().mockResolvedValue(CLEAN_RESULT)
+    const sync = createDocumentGrantSync({ cleanup, isAvailable: () => true })
+
+    const result = await sync({
+      currentDocument: { sourceUri: 'content://docs/current' },
+      recentDocuments: [{ sourceUri: 'content://docs/a' }],
+    })
+
+    expect(result).toEqual(CLEAN_RESULT)
+    expect(cleanup).toHaveBeenCalledWith(['content://docs/a', 'content://docs/current'])
+  })
+
+  it('suppresses repeat calls for an unchanged referenced set', async () => {
+    const cleanup = vi.fn().mockResolvedValue(CLEAN_RESULT)
+    const sync = createDocumentGrantSync({ cleanup, isAvailable: () => true })
+    const options = {
+      currentDocument: { sourceUri: null },
+      recentDocuments: [{ sourceUri: 'content://docs/a' }],
+    }
+
+    await sync(options)
+    await expect(sync(options)).resolves.toBeNull()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires again when the referenced set changes', async () => {
+    const cleanup = vi.fn().mockResolvedValue(CLEAN_RESULT)
+    const sync = createDocumentGrantSync({ cleanup, isAvailable: () => true })
+
+    await sync({
+      currentDocument: { sourceUri: null },
+      recentDocuments: [{ sourceUri: 'content://docs/a' }],
+    })
+    await sync({
+      currentDocument: { sourceUri: null },
+      recentDocuments: [{ sourceUri: 'content://docs/a' }, { sourceUri: 'content://docs/b' }],
+    })
+
+    expect(cleanup).toHaveBeenCalledTimes(2)
+    expect(cleanup).toHaveBeenLastCalledWith(['content://docs/a', 'content://docs/b'])
+  })
+
+  it('retries after a failed cleanup instead of memoizing it', async () => {
+    const cleanup = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('bridge down'))
+      .mockResolvedValue(CLEAN_RESULT)
+    const sync = createDocumentGrantSync({ cleanup, isAvailable: () => true })
+    const options = {
+      currentDocument: { sourceUri: null },
+      recentDocuments: [{ sourceUri: 'content://docs/a' }],
+    }
+
+    await expect(sync(options)).rejects.toThrow('bridge down')
+    await expect(sync(options)).resolves.toEqual(CLEAN_RESULT)
+    expect(cleanup).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/features/android-documents/documentGrantMaintenance.ts
+++ b/src/features/android-documents/documentGrantMaintenance.ts
@@ -44,8 +44,10 @@ interface DocumentGrantSyncDependencies {
  * conservative (it releases only settled, unreferenced document grants it
  * itself recorded), so the memo here is purely traffic suppression: recents
  * persist on every autosave tick, but the URI set only changes when a
- * document is opened, saved-as, or removed. A failed cleanup keeps the memo
- * unset so the next recents mutation retries it.
+ * document is opened, saved-as, or removed. A cleanup that failed — the
+ * call rejected, OR it resolved with failedReleaseCount > 0 (the native
+ * side restores those ledger entries and resolves) — must leave the memo
+ * unset so the next invocation retries even with an unchanged set.
  */
 export function createDocumentGrantSync(dependencies: DocumentGrantSyncDependencies = {}) {
   const cleanup = dependencies.cleanup ?? cleanupAndroidDocumentGrants
@@ -66,7 +68,7 @@ export function createDocumentGrantSync(dependencies: DocumentGrantSyncDependenc
     }
 
     const result = await cleanup(referencedUris)
-    lastSyncedKey = key
+    lastSyncedKey = result.failedReleaseCount === 0 ? key : null
     return result
   }
 }

--- a/src/features/android-documents/documentGrantMaintenance.ts
+++ b/src/features/android-documents/documentGrantMaintenance.ts
@@ -1,0 +1,72 @@
+import {
+  cleanupAndroidDocumentGrants,
+  isAndroidDocumentAccessAvailable,
+  type AndroidDocumentGrantCleanupResult,
+} from '../../lib/androidDocuments'
+
+interface ReferencedDocumentSource {
+  sourceUri: string | null
+}
+
+export interface DocumentGrantSyncOptions {
+  currentDocument: ReferencedDocumentSource
+  recentDocuments: readonly ReferencedDocumentSource[]
+}
+
+/**
+ * The set of content URIs whose persisted SAF grant a protected document
+ * still depends on: every Android document in the recents store (pinned
+ * records included — the store is the grant LRU, #153) plus the currently
+ * open document, which may have just been removed from recents while its
+ * editor session still writes through the grant.
+ */
+export function collectReferencedDocumentUris(options: DocumentGrantSyncOptions): string[] {
+  const referenced = new Set<string>()
+  if (options.currentDocument.sourceUri) {
+    referenced.add(options.currentDocument.sourceUri)
+  }
+  for (const document of options.recentDocuments) {
+    if (document.sourceUri) {
+      referenced.add(document.sourceUri)
+    }
+  }
+  return [...referenced].sort()
+}
+
+interface DocumentGrantSyncDependencies {
+  cleanup?: (referencedUris: readonly string[]) => Promise<AndroidDocumentGrantCleanupResult>
+  isAvailable?: () => boolean
+}
+
+/**
+ * Returns a sync function that pushes the referenced-URI set to the native
+ * grant cleanup whenever it changes. The native side is idempotent and
+ * conservative (it releases only settled, unreferenced document grants it
+ * itself recorded), so the memo here is purely traffic suppression: recents
+ * persist on every autosave tick, but the URI set only changes when a
+ * document is opened, saved-as, or removed. A failed cleanup keeps the memo
+ * unset so the next recents mutation retries it.
+ */
+export function createDocumentGrantSync(dependencies: DocumentGrantSyncDependencies = {}) {
+  const cleanup = dependencies.cleanup ?? cleanupAndroidDocumentGrants
+  const isAvailable = dependencies.isAvailable ?? isAndroidDocumentAccessAvailable
+  let lastSyncedKey: string | null = null
+
+  return async function syncDocumentGrants(
+    options: DocumentGrantSyncOptions,
+  ): Promise<AndroidDocumentGrantCleanupResult | null> {
+    if (!isAvailable()) {
+      return null
+    }
+
+    const referencedUris = collectReferencedDocumentUris(options)
+    const key = referencedUris.join('\n')
+    if (key === lastSyncedKey) {
+      return null
+    }
+
+    const result = await cleanup(referencedUris)
+    lastSyncedKey = key
+    return result
+  }
+}

--- a/src/lib/androidDocuments.ts
+++ b/src/lib/androidDocuments.ts
@@ -177,6 +177,13 @@ interface AndroidDocumentsPlugin {
     removedBytes: number
     failedFileCount: number
   }>
+  cleanupDocumentGrants(options: {
+    referencedUris: string[]
+  }): Promise<{
+    grantCount: number
+    releasedGrantCount: number
+    failedReleaseCount: number
+  }>
   pickImageDocument(options?: { copyImage?: boolean }): Promise<{
     canceled?: false
     sourceUri: string
@@ -303,6 +310,26 @@ export async function renameAndroidMarkdownDocument(sourceUri: string, newName: 
   return normalizeRenamedDocument(
     await AndroidDocuments.renameMarkdownDocument({ sourceUri, newName }),
   )
+}
+
+export interface AndroidDocumentGrantCleanupResult {
+  grantCount: number
+  releasedGrantCount: number
+  failedReleaseCount: number
+}
+
+export async function cleanupAndroidDocumentGrants(
+  referencedUris: readonly string[],
+): Promise<AndroidDocumentGrantCleanupResult> {
+  ensureAndroidDocumentsAvailable()
+  const result = await AndroidDocuments.cleanupDocumentGrants({
+    referencedUris: [...new Set(referencedUris)],
+  })
+  return {
+    grantCount: result.grantCount,
+    releasedGrantCount: result.releasedGrantCount,
+    failedReleaseCount: result.failedReleaseCount,
+  }
 }
 
 export async function addAndroidOpenWithDocumentListener(


### PR DESCRIPTION
Closes #153.

## What

The plugin took `takePersistableUriPermission` grants on every document open/create/share/rename and never released one, so long-lived use crept toward the OS quota (128 persisted grants per app on Android 10 and below — the minSdk 24 floor; 512 on 11+), where the system silently drops the oldest grants, potentially the ones a pinned document depends on.

This PR bounds the grant table with a conservative, recents-driven lifecycle:

- **The web recents store is the LRU.** It is already capped at 100 records (pinned records, capped at 50, are eviction-proof) and every Android-document record carries its content URI. The native side follows that store instead of keeping a second recency clock.
- **New plugin method `cleanupDocumentGrants({ referencedUris })`** (same contract shape as `cleanupImportedImages`): the web passes the set of URIs a protected document still depends on — every recents record plus the currently open document — and the native side releases what is provably safe to release.
- **A release requires proof, on three conditions.** The grant is released only when (1) the plugin's own ledger (SharedPreferences `document_grants`) records that it was taken as a *Markdown document* grant, (2) the web reports no protected document references it, and (3) it has settled — taken more than 5 minutes ago, so a cleanup racing a concurrent open (whose reference snapshot predates the new URI) can never release the just-opened document; the next cleanup picks it up.
- **Quota safety valve (Codex round 1).** Condition 3 alone made quota safety rate-dependent: 129+ opens inside one settle window would pile up unsettled evictions past the 128-grant cap with nothing releasable. When the table would stay above **120** grants after the settled releases, unsettled grants meeting conditions 1 and 2 are released too — oldest take first, only down to the valve, so the youngest (possibly in-flight) takes keep their settle protection whenever the count allows. Conditions 1 and 2 are never waived.
- **Never released:** linked-image grants (documents reference them from body text the cleanup cannot enumerate) and grants that predate the ledger (unknown kind — legacy installs keep whatever they had; new activity is managed from now on).
- **Wiring:** the web fires the cleanup after every recents persistence (memoized on the referenced-URI set, so autosave ticks do not spam the bridge) and once at startup, which also sweeps releases a killed session left pending. The memo records only clean results (Codex round 1): a rejected call *or* a resolved one with `failedReleaseCount > 0` clears it, so a provider-refused release is retried on the next invocation even with an unchanged set (the native side restores the failed URI's ledger entry for exactly that retry).

Decision logic lives in the Android-free `DocumentGrantPolicy` (mirroring `ImportedImageStorage` / `MarkdownCodec`), so unit tests exercise the real policy.

## Verification

- **Native (JVM, 12 tests in `DocumentGrantPolicyTest`):** release requires all three conditions; image/legacy grants never released; settle boundary exact at the window edge; ledger housekeeping drops revoked entries; serialization round-trips URIs containing `|`; malformed ledger lines skipped. **Stress (the issue's done-when):** 500 documents at one-minute cadence through a 100-cap recents simulation stay ≤ 105 live grants after every cleanup (100 referenced + at most the evictions still inside the settle window) and converge to exactly the 100 referenced grants; a **200-document burst at two-second cadence** — the scenario from Codex round 1 that used to blow past 128 — never exceeds the 120-grant valve plus one in-flight take, and every referenced document keeps its grant; valve ordering (oldest first, stops at the valve) and valve conservatism (kind/reference conditions never waived, even staying over the valve) are pinned separately; a pinned-style URI survives 300 evictions of newer documents. Full native suite green.
- **Web (8 tests):** referenced-set union/dedupe/sort; sync gated off Android; memoized on unchanged sets; re-fires on change; a rejected cleanup is retried, not memoized; a *resolved* cleanup reporting `failedReleaseCount > 0` is also retried on an unchanged set (Codex round 1). Full app vitest suite green, typecheck and lint clean.
- **Device smoke (API 35 emulator, real DocumentsUI grants):** took grant A via a bare plugin call (deliberately bypassing the app, so no recents record references it) and grant B through the real home &gt; Open flow (lands in recents). The automatic cleanup that fired on B's open left young unreferenced A alone (settle window observed on device, `grantCount: 3` including a legacy pre-ledger grant from an earlier install). After the window elapsed, a cold start's automatic startup cleanup — fired by the real `App.vue` wiring with the recents-derived reference set — released exactly the orphan: logcat `Document grant cleanup released 1 grant(s), failed 0, remaining 2`. Afterwards the referenced document still reads with `persisted: true`, the released URI fails with `DOCUMENT_PERMISSION_LOST` (OS-level revocation confirmed), and the legacy pre-ledger grant survived untouched throughout.

Known limits, stated deliberately: image grants and pre-ledger grants are never auto-released (bounded: the legacy set is frozen at upgrade time and linked images are an opt-in path). Because those two classes are exempt even from the valve, an install whose frozen legacy + image + referenced set alone exceeds the quota is beyond what any conservative policy can fix — the OS then prunes as it does today. Below the valve, a grant skipped inside its settle window is revisited on the next referenced-set change or startup.
