### PR TITLE
Bump mermaid to 11.16.1 for the five Dependabot advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1464,8 +1464,8 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  mermaid@11.15.0:
-    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2404,7 +2404,7 @@ snapshots:
       katex: 0.17.0
       marked: 18.0.5
       marked-highlight: 2.2.4(marked@18.0.5)
-      mermaid: 11.15.0
+      mermaid: 11.16.1
       ot-json1: 1.0.2
       ot-text-unicode: 4.0.0
       plantuml-encoder: 1.4.0
@@ -3581,7 +3581,7 @@ snapshots:
 
   marked@18.0.5: {}
 
-  mermaid@11.15.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.3


### PR DESCRIPTION
Resolves all five open Dependabot alerts (#8–#12), which target the same package: `mermaid@11.15.0`, pulled in through the vendored muya's `^11.15.0` dependency. Four moderate + one low, all fixed in `11.16.1`:

- CVE-2026-71436 — XY charts infinite-loop DoS (moderate)
- CVE-2026-71437 — architecture diagrams prototype pollution (moderate)
- CVE-2026-50159 — CSS injection reaching the diagram's sibling elements (moderate)
- CVE-2026-71439 — radar diagrams DoS (moderate)
- CVE-2026-71438 — configuration-API prototype pollution (low)

## What

Lockfile-only bump: `pnpm update mermaid` moved the single resolved version 11.15.0 → 11.16.1 (the current latest). muya's manifest range `^11.15.0` already admits it, so no manifest or vendored-source change; the diff is the three mermaid entries in `pnpm-lock.yaml` and nothing else.

Exposure assessment, for the record: diagram rendering is a live feature (a ` ```mermaid ` code block lazy-loads the library; the paragraph quick-insert menu offers it), so the vulnerable code did ship. The realistic vector is limited to opening a hostile shared/`open-with` Markdown file — worst case a WebView freeze (drafts autosave), in-editor CSS spoofing, or prototype pollution inside the WebView context; no remote surface.

## Verification

- `git diff pnpm-lock.yaml`: only the mermaid version/snapshot entries change; every transitive dependency stays at its pinned version.
- muya vendor-sync contract test green after the install (`pnpm update` rebuilds the muya copy).
- `pnpm build` green; mermaid chunks emitted.
- Resolution proof: `.pnpm/@muyajs+core@file+third_party+muya…/node_modules/mermaid` links to 11.16.1.
- Device smoke (API 35 emulator, APK from this branch): injected a document with a `mermaid` flowchart via the share-text intent — the editor renders `figure.mu-diagram-block` with a fully materialized inline SVG (74 nodes), no error state.
