### PR TITLE
Make the update check immune to GitHub rate limiting, refresh the About icons

### DIFF
--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidAppInfoPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AndroidAppInfoPlugin.java
@@ -8,9 +8,34 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @CapacitorPlugin(name = "AndroidAppInfo")
 public class AndroidAppInfoPlugin extends Plugin {
+
+    private final ExecutorService updateExecutor = Executors.newSingleThreadExecutor();
+    private final AppUpdateChecker updateChecker = new AppUpdateChecker(new UrlConnectionTransport());
+
+    /**
+     * Latest published release via the github.com redirect — see
+     * {@link AppUpdateChecker}. The web layer falls back to the GitHub
+     * API when this rejects, so failures stay coarse-grained.
+     */
+    @PluginMethod
+    public void getLatestRelease(PluginCall call) {
+        updateExecutor.execute(() -> {
+            try {
+                AppUpdateChecker.LatestRelease latest = updateChecker.fetchLatestRelease();
+                JSObject result = new JSObject();
+                result.put("tagName", latest.tagName);
+                result.put("releaseUrl", latest.releaseUrl);
+                call.resolve(result);
+            } catch (Exception ex) {
+                call.reject("Could not resolve the latest release", "UPDATE_CHECK_FAILED");
+            }
+        });
+    }
 
     @PluginMethod
     public void getDiagnostics(PluginCall call) {

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/AppUpdateChecker.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/AppUpdateChecker.java
@@ -1,0 +1,86 @@
+package io.github.renakoni.marktextandroid;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Resolves the latest published release from the {@code releases/latest}
+ * HTTP redirect on github.com: the Location header carries the tag. The
+ * web endpoint is not behind the GitHub API's 60-requests/hour-per-IP
+ * quota, so this keeps working on shared-egress networks (VPN, CGNAT)
+ * where the unauthenticated API answers 403. Pure JVM over the
+ * {@link HttpTransport} seam.
+ */
+final class AppUpdateChecker {
+
+    static final String RELEASES_BASE =
+        "https://github.com/Renakoni/marktext-android/releases";
+    static final String LATEST_RELEASE_URL = RELEASES_BASE + "/latest";
+    private static final String TAG_PREFIX = RELEASES_BASE + "/tag/";
+
+    static final class LatestRelease {
+
+        final String tagName;
+        final String releaseUrl;
+
+        LatestRelease(String tagName, String releaseUrl) {
+            this.tagName = tagName;
+            this.releaseUrl = releaseUrl;
+        }
+    }
+
+    private final HttpTransport transport;
+
+    AppUpdateChecker(HttpTransport transport) {
+        this.transport = transport;
+    }
+
+    LatestRelease fetchLatestRelease() throws IOException {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Accept", "text/html");
+        HttpTransport.Response response = transport.execute(new HttpTransport.Request(
+            "GET",
+            LATEST_RELEASE_URL,
+            headers,
+            null,
+            64 * 1024
+        ));
+
+        if (response.status < 300 || response.status >= 400) {
+            throw new IOException("releases/latest did not redirect (HTTP " + response.status + ")");
+        }
+
+        String location = response.header("Location");
+        if (location == null || location.isEmpty()) {
+            throw new IOException("releases/latest redirect carried no Location");
+        }
+        if (location.startsWith("/")) {
+            location = "https://github.com" + location;
+        }
+        int cut = location.indexOf('?');
+        if (cut >= 0) {
+            location = location.substring(0, cut);
+        }
+        cut = location.indexOf('#');
+        if (cut >= 0) {
+            location = location.substring(0, cut);
+        }
+
+        // Anything but this repository's tag page is refused — a repo with
+        // no releases redirects to the plain /releases listing, and the
+        // returned URL is later opened in a browser, so it must never be
+        // attacker-shaped.
+        if (!location.startsWith(TAG_PREFIX)) {
+            throw new IOException("releases/latest did not point at a release tag");
+        }
+
+        String tagName = URLDecoder.decode(location.substring(TAG_PREFIX.length()), "UTF-8");
+        if (tagName.isEmpty()) {
+            throw new IOException("releases/latest pointed at an empty tag");
+        }
+
+        return new LatestRelease(tagName, location);
+    }
+}

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/CloudDocumentsPlugin.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/CloudDocumentsPlugin.java
@@ -13,16 +13,9 @@ import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.json.JSONException;
@@ -851,59 +844,4 @@ public class CloudDocumentsPlugin extends Plugin {
         return value.replace('\r', ' ').replace('\n', ' ').trim();
     }
 
-    /** Real transport: redirects are handled by the caller, never followed. */
-    private static final class UrlConnectionTransport implements HttpTransport {
-
-        @Override
-        public Response execute(Request request) throws IOException {
-            HttpURLConnection connection = (HttpURLConnection) new URL(request.url).openConnection();
-            try {
-                connection.setInstanceFollowRedirects(false);
-                connection.setConnectTimeout(20_000);
-                connection.setReadTimeout(30_000);
-                connection.setRequestMethod(request.method);
-                for (Map.Entry<String, String> header : request.headers.entrySet()) {
-                    connection.setRequestProperty(header.getKey(), header.getValue());
-                }
-                if (request.body != null) {
-                    connection.setDoOutput(true);
-                    connection.setFixedLengthStreamingMode(request.body.length);
-                    try (OutputStream output = connection.getOutputStream()) {
-                        output.write(request.body);
-                    }
-                }
-
-                int status = connection.getResponseCode();
-                Map<String, String> headers = new LinkedHashMap<>();
-                for (Map.Entry<String, List<String>> header : connection.getHeaderFields().entrySet()) {
-                    if (header.getKey() != null && !header.getValue().isEmpty()) {
-                        headers.put(header.getKey(), header.getValue().get(0));
-                    }
-                }
-
-                InputStream stream = status >= 400
-                    ? connection.getErrorStream()
-                    : connection.getInputStream();
-                ByteArrayOutputStream body = new ByteArrayOutputStream();
-                if (stream != null) {
-                    // Bounded read: deliver at most maxResponseBytes + 1 so
-                    // the caller sees the overflow without this transport
-                    // ever buffering an arbitrarily large response.
-                    int limit = request.maxResponseBytes > 0
-                        ? request.maxResponseBytes + 1
-                        : Integer.MAX_VALUE;
-                    byte[] buffer = new byte[8192];
-                    int read;
-                    while (body.size() < limit && (read = stream.read(buffer)) != -1) {
-                        int keep = Math.min(read, limit - body.size());
-                        body.write(buffer, 0, keep);
-                    }
-                    stream.close();
-                }
-                return new Response(status, headers, body.toByteArray());
-            } finally {
-                connection.disconnect();
-            }
-        }
-    }
 }

--- a/android/app/src/main/java/io/github/renakoni/marktextandroid/UrlConnectionTransport.java
+++ b/android/app/src/main/java/io/github/renakoni/marktextandroid/UrlConnectionTransport.java
@@ -1,0 +1,71 @@
+package io.github.renakoni.marktextandroid;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Real transport behind the {@link HttpTransport} seam: redirects are
+ * handled by the caller, never followed. Shared by the cloud clients and
+ * the update checker.
+ */
+final class UrlConnectionTransport implements HttpTransport {
+
+    @Override
+    public Response execute(Request request) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(request.url).openConnection();
+        try {
+            connection.setInstanceFollowRedirects(false);
+            connection.setConnectTimeout(20_000);
+            connection.setReadTimeout(30_000);
+            connection.setRequestMethod(request.method);
+            for (Map.Entry<String, String> header : request.headers.entrySet()) {
+                connection.setRequestProperty(header.getKey(), header.getValue());
+            }
+            if (request.body != null) {
+                connection.setDoOutput(true);
+                connection.setFixedLengthStreamingMode(request.body.length);
+                try (OutputStream output = connection.getOutputStream()) {
+                    output.write(request.body);
+                }
+            }
+
+            int status = connection.getResponseCode();
+            Map<String, String> headers = new LinkedHashMap<>();
+            for (Map.Entry<String, List<String>> header : connection.getHeaderFields().entrySet()) {
+                if (header.getKey() != null && !header.getValue().isEmpty()) {
+                    headers.put(header.getKey(), header.getValue().get(0));
+                }
+            }
+
+            InputStream stream = status >= 400
+                ? connection.getErrorStream()
+                : connection.getInputStream();
+            ByteArrayOutputStream body = new ByteArrayOutputStream();
+            if (stream != null) {
+                // Bounded read: deliver at most maxResponseBytes + 1 so
+                // the caller sees the overflow without this transport
+                // ever buffering an arbitrarily large response.
+                int limit = request.maxResponseBytes > 0
+                    ? request.maxResponseBytes + 1
+                    : Integer.MAX_VALUE;
+                byte[] buffer = new byte[8192];
+                int read;
+                while (body.size() < limit && (read = stream.read(buffer)) != -1) {
+                    int keep = Math.min(read, limit - body.size());
+                    body.write(buffer, 0, keep);
+                }
+                stream.close();
+            }
+            return new Response(status, headers, body.toByteArray());
+        } finally {
+            connection.disconnect();
+        }
+    }
+}

--- a/android/app/src/test/java/io/github/renakoni/marktextandroid/AppUpdateCheckerTest.java
+++ b/android/app/src/test/java/io/github/renakoni/marktextandroid/AppUpdateCheckerTest.java
@@ -1,0 +1,114 @@
+package io.github.renakoni.marktextandroid;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class AppUpdateCheckerTest {
+
+    /** Canned transport recording requests and replaying queued responses. */
+    private static final class FakeTransport implements HttpTransport {
+
+        final List<Request> requests = new ArrayList<>();
+        final Deque<Response> responses = new ArrayDeque<>();
+
+        void enqueue(int status, Map<String, String> headers) {
+            responses.add(new Response(status, headers, new byte[0]));
+        }
+
+        @Override
+        public Response execute(Request request) {
+            requests.add(request);
+            return responses.remove();
+        }
+    }
+
+    private static Map<String, String> locationHeader(String location) {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Location", location);
+        return headers;
+    }
+
+    @Test
+    public void resolvesTheTagFromTheLatestReleaseRedirect() throws Exception {
+        FakeTransport transport = new FakeTransport();
+        transport.enqueue(302, locationHeader(
+            "https://github.com/Renakoni/marktext-android/releases/tag/v0.2.0"));
+
+        AppUpdateChecker.LatestRelease latest =
+            new AppUpdateChecker(transport).fetchLatestRelease();
+
+        assertEquals("v0.2.0", latest.tagName);
+        assertEquals(
+            "https://github.com/Renakoni/marktext-android/releases/tag/v0.2.0",
+            latest.releaseUrl);
+        HttpTransport.Request request = transport.requests.get(0);
+        assertEquals("GET", request.method);
+        assertEquals(AppUpdateChecker.LATEST_RELEASE_URL, request.url);
+        assertNull(request.body);
+    }
+
+    @Test
+    public void resolvesARelativeRedirectAndStripsQueryAndFragment() throws Exception {
+        FakeTransport transport = new FakeTransport();
+        transport.enqueue(302, locationHeader(
+            "/Renakoni/marktext-android/releases/tag/v0.2.0%2Bhotfix?utm=x#assets"));
+
+        AppUpdateChecker.LatestRelease latest =
+            new AppUpdateChecker(transport).fetchLatestRelease();
+
+        assertEquals("v0.2.0+hotfix", latest.tagName);
+        assertEquals(
+            "https://github.com/Renakoni/marktext-android/releases/tag/v0.2.0%2Bhotfix",
+            latest.releaseUrl);
+    }
+
+    @Test
+    public void refusesARedirectOutsideTheRepositoryTagPage() {
+        // No releases published: GitHub redirects to the plain listing.
+        FakeTransport listing = new FakeTransport();
+        listing.enqueue(302, locationHeader(
+            "https://github.com/Renakoni/marktext-android/releases"));
+        assertThrows(IOException.class, () -> new AppUpdateChecker(listing).fetchLatestRelease());
+
+        // The opened URL must never be attacker-shaped.
+        FakeTransport foreign = new FakeTransport();
+        foreign.enqueue(302, locationHeader(
+            "https://example.com/Renakoni/marktext-android/releases/tag/v9.9.9"));
+        assertThrows(IOException.class, () -> new AppUpdateChecker(foreign).fetchLatestRelease());
+    }
+
+    @Test
+    public void refusesNonRedirectAndLocationlessResponses() {
+        FakeTransport ok = new FakeTransport();
+        ok.enqueue(200, new LinkedHashMap<>());
+        assertThrows(IOException.class, () -> new AppUpdateChecker(ok).fetchLatestRelease());
+
+        FakeTransport bare = new FakeTransport();
+        bare.enqueue(302, new LinkedHashMap<>());
+        assertThrows(IOException.class, () -> new AppUpdateChecker(bare).fetchLatestRelease());
+    }
+
+    @Test
+    public void keepsTheBoundedBodyReadOnTheRedirectProbe() throws Exception {
+        FakeTransport transport = new FakeTransport();
+        transport.enqueue(301, locationHeader(
+            "https://github.com/Renakoni/marktext-android/releases/tag/v1.0.0"));
+
+        new AppUpdateChecker(transport).fetchLatestRelease();
+
+        // A redirect probe never needs an unbounded body; the cap keeps a
+        // misbehaving proxy from feeding the app an arbitrarily large page.
+        assertEquals(64 * 1024, transport.requests.get(0).maxResponseBytes);
+        assertEquals("text/html", transport.requests.get(0).headers.get("Accept"));
+    }
+}

--- a/src/features/settings/advancedDiagnostics.ts
+++ b/src/features/settings/advancedDiagnostics.ts
@@ -1,16 +1,9 @@
-import { Capacitor, registerPlugin } from '@capacitor/core'
-
-interface NativeAdvancedDiagnostics {
-  deviceInfo: string
-  webViewInfo: string
-  manufacturer?: string
-}
-
-interface AndroidAppInfoPlugin {
-  getDiagnostics(): Promise<NativeAdvancedDiagnostics>
-}
-
-const AndroidAppInfo = registerPlugin<AndroidAppInfoPlugin>('AndroidAppInfo')
+import { Capacitor } from '@capacitor/core'
+import {
+  AndroidAppInfo,
+  isAndroidAppInfoAvailable,
+  type NativeAdvancedDiagnostics,
+} from '../../lib/androidAppInfo'
 
 function getBrowserDiagnostics(): NativeAdvancedDiagnostics {
   return {
@@ -20,7 +13,7 @@ function getBrowserDiagnostics(): NativeAdvancedDiagnostics {
 }
 
 export async function getAdvancedDiagnostics(): Promise<NativeAdvancedDiagnostics> {
-  if (Capacitor.getPlatform() !== 'android' || !Capacitor.isNativePlatform()) {
+  if (!isAndroidAppInfoAvailable()) {
     return getBrowserDiagnostics()
   }
 

--- a/src/features/settings/components/AboutSettings.vue
+++ b/src/features/settings/components/AboutSettings.vue
@@ -152,10 +152,13 @@ async function checkUpdates() {
         data-testid="settings-about-github"
       >
         <span class="about-row-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" focusable="false">
-            <path d="M8 9l-4 3 4 3" />
-            <path d="M16 9l4 3-4 3" />
-            <path d="M14 5l-4 14" />
+          <!-- Octicons mark-github (MIT); GitHub permits the mark as a
+               link to a GitHub repository. Filled glyph, so it opts out
+               of the shared stroke styling below. -->
+          <svg viewBox="0 0 16 16" focusable="false" class="about-github-mark">
+            <path
+              d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"
+            />
           </svg>
         </span>
         <span class="about-row-main">
@@ -290,6 +293,15 @@ async function checkUpdates() {
   stroke-width: 2.2;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
+
+/* The GitHub mark is a filled glyph; solid shapes carry more visual
+   weight than 2.2 strokes, so it sits slightly smaller. */
+.about-row-icon svg.about-github-mark {
+  width: 24px;
+  height: 24px;
+  fill: currentColor;
+  stroke: none;
 }
 
 .about-row-trailing svg {

--- a/src/features/settings/components/AboutSettings.vue
+++ b/src/features/settings/components/AboutSettings.vue
@@ -16,12 +16,21 @@ const updateStatus = computed(() => {
   return updateResult.value ? getUpdateStatus(updateResult.value) : undefined
 })
 
-const availableReleaseUrl = computed(() => {
-  if (checkingUpdates.value || updateResult.value?.status !== 'available') {
+// The release link doubles as the manual fallback: it shows when an
+// update is available AND when the check itself failed (rate limit,
+// network) — the releases page usually loads fine even while the API
+// is rate-limiting this IP. Only "no releases exist" leaves it hidden.
+const releaseLinkUrl = computed(() => {
+  if (checkingUpdates.value || !updateResult.value) {
     return null
   }
 
-  return updateResult.value.releaseUrl ?? APP_INFO.releasesUrl
+  const result = updateResult.value
+  if (result.status === 'current' || result.message === 'No published releases yet') {
+    return null
+  }
+
+  return result.releaseUrl ?? APP_INFO.releasesUrl
 })
 
 function getUpdateStatus(result: AppUpdateCheckResult) {
@@ -35,6 +44,10 @@ function getUpdateStatus(result: AppUpdateCheckResult) {
 
   if (result.message === 'No published releases yet') {
     return t('about.update.noReleases')
+  }
+
+  if (result.message === 'GitHub rate limited the update check') {
+    return t('about.update.rateLimited')
   }
 
   if (result.message === 'Latest release did not include a version') {
@@ -105,9 +118,9 @@ async function checkUpdates() {
       </button>
 
       <a
-        v-if="availableReleaseUrl"
+        v-if="releaseLinkUrl"
         class="about-row is-link"
-        :href="availableReleaseUrl"
+        :href="releaseLinkUrl"
         target="_blank"
         rel="noreferrer"
         data-testid="settings-open-release"
@@ -124,9 +137,9 @@ async function checkUpdates() {
         </span>
         <span class="about-row-trailing" aria-hidden="true">
           <svg viewBox="0 0 24 24" focusable="false">
-            <path d="M8 8h8v8" />
-            <path d="M16 8l-9 9" />
-            <path d="M7 7h-1a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2v-1" />
+            <path d="M15 3h6v6" />
+            <path d="M10 14L21 3" />
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
           </svg>
         </span>
       </a>
@@ -150,9 +163,9 @@ async function checkUpdates() {
         </span>
         <span class="about-row-trailing" aria-hidden="true">
           <svg viewBox="0 0 24 24" focusable="false">
-            <path d="M8 8h8v8" />
-            <path d="M16 8l-9 9" />
-            <path d="M7 7h-1a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2v-1" />
+            <path d="M15 3h6v6" />
+            <path d="M10 14L21 3" />
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
           </svg>
         </span>
       </a>

--- a/src/lib/androidAppInfo.ts
+++ b/src/lib/androidAppInfo.ts
@@ -1,0 +1,24 @@
+import { Capacitor, registerPlugin } from '@capacitor/core'
+
+export interface NativeAdvancedDiagnostics {
+  deviceInfo: string
+  webViewInfo: string
+  manufacturer?: string
+}
+
+export interface NativeLatestRelease {
+  tagName: string
+  releaseUrl: string
+}
+
+interface AndroidAppInfoPlugin {
+  getDiagnostics(): Promise<NativeAdvancedDiagnostics>
+  getLatestRelease(): Promise<NativeLatestRelease>
+}
+
+/** Single registration point — Capacitor rejects duplicate plugin names. */
+export const AndroidAppInfo = registerPlugin<AndroidAppInfoPlugin>('AndroidAppInfo')
+
+export function isAndroidAppInfoAvailable() {
+  return Capacitor.getPlatform() === 'android' && Capacitor.isNativePlatform()
+}

--- a/src/lib/appUpdates.test.ts
+++ b/src/lib/appUpdates.test.ts
@@ -41,4 +41,19 @@ describe('checkForAppUpdates', () => {
       releaseUrl: APP_INFO.releasesUrl,
     })
   })
+
+  test('names the IP rate limit behind 403/429 and keeps the releases page reachable', async () => {
+    for (const status of [403, 429]) {
+      const result = await checkForAppUpdates(() =>
+        Promise.resolve(new Response('', { status })),
+      )
+
+      expect(result).toEqual({
+        status: 'unavailable',
+        message: 'GitHub rate limited the update check',
+        latestVersion: null,
+        releaseUrl: APP_INFO.releasesUrl,
+      })
+    }
+  })
 })

--- a/src/lib/appUpdates.ts
+++ b/src/lib/appUpdates.ts
@@ -82,6 +82,19 @@ export async function checkForAppUpdates(fetchRelease: ReleaseFetch = fetch) {
       } satisfies AppUpdateCheckResult
     }
 
+    // GitHub's unauthenticated API allows 60 requests/hour PER IP; on a
+    // shared egress (VPN, CGNAT) the pool is routinely exhausted by other
+    // clients, and GitHub answers 403 (or 429). Not a client bug — name
+    // it, and leave the releases page as the manual path.
+    if (response.status === 403 || response.status === 429) {
+      return {
+        status: 'unavailable',
+        message: 'GitHub rate limited the update check',
+        latestVersion: null,
+        releaseUrl: APP_INFO.releasesUrl,
+      } satisfies AppUpdateCheckResult
+    }
+
     if (!response.ok) {
       return {
         status: 'unavailable',

--- a/src/lib/appUpdates.ts
+++ b/src/lib/appUpdates.ts
@@ -1,4 +1,5 @@
 import { APP_INFO } from './appInfo'
+import { AndroidAppInfo, isAndroidAppInfoAvailable } from './androidAppInfo'
 
 interface GitHubReleaseResponse {
   tag_name?: unknown
@@ -64,7 +65,62 @@ export function compareVersionTags(left: string, right: string) {
   return 0
 }
 
+function resolveAgainstCurrentVersion(
+  latestVersion: string,
+  releaseUrl: string,
+): AppUpdateCheckResult {
+  if (compareVersionTags(latestVersion, APP_INFO.version) > 0) {
+    return {
+      status: 'available',
+      message: `Update available: v${latestVersion}`,
+      latestVersion,
+      releaseUrl,
+    }
+  }
+
+  return {
+    status: 'current',
+    message: 'You are on the latest version',
+    latestVersion,
+    releaseUrl,
+  }
+}
+
+/**
+ * Native-first check: the releases/latest redirect on github.com carries
+ * the tag and sits outside the GitHub API's 60-requests/hour-per-IP
+ * quota, so it keeps working on shared-egress networks (VPN, CGNAT)
+ * where the unauthenticated API answers 403. Browser shells — and any
+ * native failure — fall through to the API fetch.
+ */
+async function checkViaNativeRedirect(): Promise<AppUpdateCheckResult | null> {
+  if (!isAndroidAppInfoAvailable()) {
+    return null
+  }
+
+  try {
+    const latest = await AndroidAppInfo.getLatestRelease()
+    const latestVersion = normalizeVersionTag(latest.tagName)
+    if (!latestVersion) {
+      return null
+    }
+
+    const releaseUrl =
+      typeof latest.releaseUrl === 'string' && latest.releaseUrl.length > 0
+        ? latest.releaseUrl
+        : APP_INFO.releasesUrl
+    return resolveAgainstCurrentVersion(latestVersion, releaseUrl)
+  } catch {
+    return null
+  }
+}
+
 export async function checkForAppUpdates(fetchRelease: ReleaseFetch = fetch) {
+  const nativeResult = await checkViaNativeRedirect()
+  if (nativeResult) {
+    return nativeResult
+  }
+
   try {
     const response = await fetchRelease(APP_INFO.latestReleaseApiUrl, {
       headers: {
@@ -117,21 +173,7 @@ export async function checkForAppUpdates(fetchRelease: ReleaseFetch = fetch) {
       } satisfies AppUpdateCheckResult
     }
 
-    if (compareVersionTags(latestVersion, APP_INFO.version) > 0) {
-      return {
-        status: 'available',
-        message: `Update available: v${latestVersion}`,
-        latestVersion,
-        releaseUrl,
-      } satisfies AppUpdateCheckResult
-    }
-
-    return {
-      status: 'current',
-      message: 'You are on the latest version',
-      latestVersion,
-      releaseUrl,
-    } satisfies AppUpdateCheckResult
+    return resolveAgainstCurrentVersion(latestVersion, releaseUrl)
   } catch {
     return {
       status: 'unavailable',

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -626,6 +626,7 @@ export const de = {
   'about.update.noReleases': 'Noch keine veröffentlichten Releases',
   'about.update.badRelease': 'Das neueste Release enthält keine Versionsangabe',
   'about.update.unavailable': 'GitHub-Releases konnten nicht erreicht werden',
+  'about.update.rateLimited': 'GitHub begrenzt Anfragen aus diesem Netzwerk gerade – später erneut versuchen oder die Release-Seite öffnen',
   'about.update.openRelease': 'GitHub-Release öffnen',
   'openLocations.title': 'Öffnen',
   'openLocations.back': 'Zurück',

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -619,6 +619,7 @@ export const en = {
   'about.update.noReleases': 'No published releases yet',
   'about.update.badRelease': 'Latest release did not include a version number',
   'about.update.unavailable': 'Could not reach GitHub releases',
+  'about.update.rateLimited': 'GitHub is rate limiting this network right now — try again later or open the releases page',
   'about.update.openRelease': 'Open GitHub release',
   'openLocations.title': 'Open',
   'openLocations.back': 'Back',

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -625,6 +625,7 @@ export const es = {
   'about.update.noReleases': 'Aún no hay versiones publicadas',
   'about.update.badRelease': 'La última publicación no incluye un número de versión',
   'about.update.unavailable': 'No se pudo acceder a las versiones de GitHub',
+  'about.update.rateLimited': 'GitHub está limitando las solicitudes de esta red — inténtalo más tarde o abre la página de versiones',
   'about.update.openRelease': 'Abrir la versión en GitHub',
   'openLocations.title': 'Abrir',
   'openLocations.back': 'Atrás',

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -625,6 +625,7 @@ export const fr = {
   'about.update.noReleases': 'Aucune version publiée pour l’instant',
   'about.update.badRelease': 'La dernière version ne comportait pas de numéro de version',
   'about.update.unavailable': 'Impossible d’accéder aux versions GitHub',
+  'about.update.rateLimited': 'GitHub limite actuellement les requêtes de ce réseau — réessayez plus tard ou ouvrez la page des versions',
   'about.update.openRelease': 'Ouvrir la version sur GitHub',
   'openLocations.title': 'Ouvrir',
   'openLocations.back': 'Retour',

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -625,6 +625,7 @@ export const ja = {
   'about.update.noReleases': 'まだ公開されたリリースはありません',
   'about.update.badRelease': '最新リリースにバージョン情報が含まれていません',
   'about.update.unavailable': 'GitHub のリリース情報を取得できませんでした',
+  'about.update.rateLimited': '現在このネットワークは GitHub のレート制限を受けています。しばらくしてから再試行するか、リリースページを開いてください',
   'about.update.openRelease': 'GitHub のリリースを開く',
   'openLocations.title': '開く',
   'openLocations.back': '戻る',

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -625,6 +625,7 @@ export const ko = {
   'about.update.noReleases': '아직 게시된 릴리스가 없습니다',
   'about.update.badRelease': '최신 릴리스에 버전 정보가 없습니다',
   'about.update.unavailable': 'GitHub 릴리스에 연결할 수 없습니다',
+  'about.update.rateLimited': '현재 네트워크가 GitHub 요청 제한을 받고 있습니다. 잠시 후 다시 시도하거나 릴리스 페이지를 여세요',
   'about.update.openRelease': 'GitHub 릴리스 열기',
   'openLocations.title': '열기',
   'openLocations.back': '뒤로',

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -625,6 +625,7 @@ export const pt = {
   'about.update.noReleases': 'Ainda não há lançamentos publicados',
   'about.update.badRelease': 'O lançamento mais recente não informou a versão',
   'about.update.unavailable': 'Não foi possível acessar os lançamentos no GitHub',
+  'about.update.rateLimited': 'O GitHub está limitando as solicitações desta rede — tente mais tarde ou abra a página de lançamentos',
   'about.update.openRelease': 'Abrir lançamento no GitHub',
   'openLocations.title': 'Abrir',
   'openLocations.back': 'Voltar',

--- a/src/lib/locales/tr.ts
+++ b/src/lib/locales/tr.ts
@@ -625,6 +625,7 @@ export const tr = {
   'about.update.noReleases': 'Henüz yayımlanmış sürüm yok',
   'about.update.badRelease': 'En son sürümde sürüm numarası belirtilmemiş',
   'about.update.unavailable': 'GitHub sürümlerine ulaşılamadı',
+  'about.update.rateLimited': 'GitHub şu anda bu ağdan gelen istekleri sınırlıyor — daha sonra yeniden deneyin veya sürüm sayfasını açın',
   'about.update.openRelease': 'GitHub sürümünü aç',
   'openLocations.title': 'Aç',
   'openLocations.back': 'Geri',

--- a/src/lib/locales/zh-CN.ts
+++ b/src/lib/locales/zh-CN.ts
@@ -616,6 +616,7 @@ export const zhCN = {
   'about.update.noReleases': '暂无发布版本',
   'about.update.badRelease': '最新发布未包含版本号',
   'about.update.unavailable': '无法连接 GitHub Releases',
+  'about.update.rateLimited': '当前网络暂被 GitHub 限流，请稍后再试，或直接打开发布页',
   'about.update.openRelease': '打开 GitHub 发布页',
   'openLocations.title': '打开',
   'openLocations.back': '返回',

--- a/src/lib/locales/zh-TW.ts
+++ b/src/lib/locales/zh-TW.ts
@@ -625,6 +625,7 @@ export const zhTW = {
   'about.update.noReleases': '尚無發行版本',
   'about.update.badRelease': '最新發行版本未包含版本號',
   'about.update.unavailable': '無法取得 GitHub 發行資訊',
+  'about.update.rateLimited': '目前網路暫被 GitHub 限流，請稍後再試，或直接開啟發行頁',
   'about.update.openRelease': '開啟 GitHub 發行頁',
   'openLocations.title': '打開',
   'openLocations.back': '返回',


### PR DESCRIPTION
Findings from the owner's post-release phone test of v0.2.0, on the About page.

## 1. "Could not check updates (403)" — diagnosed, then solved outright

**Diagnosis — environmental, not a client bug.** The checker called GitHub's `releases/latest` API unauthenticated, which is limited to **60 requests/hour per source IP**. The phone was on a VPN: the shared exit IP's pool was exhausted by other clients on that node, and GitHub answers 403. Evidence: the identical request from this machine returns 200 with `X-RateLimit-Limit: 60`, and the same build returned "latest version" on the emulator over a different egress. A public client cannot ship a token, so the API quota itself cannot be raised.

**The complete fix — stop depending on the API at all.** On Android the check now asks the native layer first: `AppUpdateChecker` (pure JVM over the existing `HttpTransport` seam, which already surfaces redirects unfollowed) issues one GET to `github.com/…/releases/latest` and reads the release tag from the `Location` header of the redirect. The web endpoint is **not behind the API quota**, so the check works on shared-egress networks where the API refuses. Hardening: refuses non-redirects, locationless responses, and any target outside this repository's tag page (the URL is later opened in a browser and must never be attacker-shaped); strips query/fragment, URL-decodes the tag, bounds the probe body at 64 KB.

**Defense in depth kept.** The API fetch remains the browser-shell path and the fallback for any native failure; there, 403/429 now maps to a localized rate-limit explanation (×10 locales) instead of a bare status code, and the releases-page link row appears after any failed check as the manual path.

**Plumbing:** `UrlConnectionTransport` moves out of `CloudDocumentsPlugin` into a shared package-private class; `AndroidAppInfo` gains `getLatestRelease` on a single-thread executor; the web wrapper (`src/lib/androidAppInfo.ts`) becomes the plugin's single registration point (Capacitor rejects duplicate names), and `advancedDiagnostics` reuses it.

## 2. About icons

- **External-link glyph:** the old geometry ran the arrow strokes within ~1 SVG unit of the box outline; at 24 px with a 2.1 stroke the sub-stroke gaps fused into the smudge visible in the report. Redrawn with the conventional layout (box bottom-left, arrow exiting the open corner) — no stroke pair closer than 3 units.
- **GitHub row:** the code-brackets glyph read as "source code", not GitHub; the row now carries the Octicons `mark-github` Octocat (MIT-licensed glyph; GitHub permits the mark as a link to a repository). Filled shape, so it opts out of the shared stroke styling at a balanced 24 px.

## Verification

- **JVM: 121 green** (+5 `AppUpdateCheckerTest`: redirect parse, relative-Location + query/fragment/URL-decode handling, refusal of the no-releases redirect and foreign hosts, refusal of non-redirect/locationless responses, bounded probe + Accept header).
- **Web: 684 tests green** (+1 rate-limit mapping), `vue-tsc -b` + Vite build green, focused lint clean, locale contract satisfied.
- **e2e** `mobile-home-navigation` 2/2 (browser shell keeps the fetch path: link hidden before a check, shown with the right href after a mocked available result).
- **Emulator (API 35, debug build):** About → Check updates → "You are on the latest version" with logcat showing the `AndroidAppInfo.getLatestRelease` native call and **zero `api.github.com` traffic** — the tag came from the redirect. Screenshot-verified the Octocat row and the redrawn external-link glyph.

## Notes

- Current installs (v0.1.0/v0.2.0) still use the API path; their 403 clears when the VPN exit rotates or the hour window resets. From the next release on, the check no longer touches the API on devices.
