### PR TITLE
Count only content lines and show the selection word count (#199)

### DIFF
--- a/src/features/editor/components/MobileEditorToolbar.vue
+++ b/src/features/editor/components/MobileEditorToolbar.vue
@@ -14,6 +14,7 @@ import type { TableCommandId } from '../tableCommands'
 import { useI18n, type I18nKey } from '../../../lib/i18n'
 import { captureNonCollapsedSelectionRange } from '../selectionToolbar'
 import { countWords } from '../../../lib/documentState'
+import { getSelectionTextForStats } from '../selectionStats'
 import ToolbarCommandGlyph from '../../../components/ToolbarCommandGlyph.vue'
 
 const props = defineProps<{
@@ -90,40 +91,10 @@ const statsText = computed(() => {
     : `${stats} · ${t('toolbar.statsSelection', { words: selectionWordCount.value })}`
 })
 
-function readEditorSelectionText() {
+function updateSelectionWordCount() {
   const selection = document.getSelection()
   const host = props.host
-  if (!selection || selection.isCollapsed || selection.rangeCount === 0 || !host) {
-    return ''
-  }
-
-  const { anchorNode, focusNode } = selection
-  if (!anchorNode || !focusNode || !host.contains(anchorNode) || !host.contains(focusNode)) {
-    return ''
-  }
-
-  // Rendered math/ruby previews duplicate their source text in the DOM;
-  // a selection spanning one would count the formula twice. Only ranges
-  // that actually contain a preview pay for fragment cloning — plain
-  // selections keep the toString() fast path and its cleaner block-break
-  // whitespace.
-  let fragmentText = ''
-  let hasRenderedPreviews = false
-  for (let index = 0; index < selection.rangeCount; index += 1) {
-    const fragment = selection.getRangeAt(index).cloneContents()
-    const rendered = fragment.querySelectorAll('.mu-math-render, .mu-ruby-render')
-    if (rendered.length > 0) {
-      hasRenderedPreviews = true
-      rendered.forEach(node => node.remove())
-    }
-    fragmentText += fragment.textContent ?? ''
-  }
-
-  return hasRenderedPreviews ? fragmentText : selection.toString()
-}
-
-function updateSelectionWordCount() {
-  const text = readEditorSelectionText()
+  const text = selection && host ? getSelectionTextForStats(selection, host) : ''
   selectionWordCount.value = text.trim().length > 0 ? countWords(text) : null
 }
 

--- a/src/features/editor/components/MobileEditorToolbar.vue
+++ b/src/features/editor/components/MobileEditorToolbar.vue
@@ -13,6 +13,7 @@ import {
 import type { TableCommandId } from '../tableCommands'
 import { useI18n, type I18nKey } from '../../../lib/i18n'
 import { captureNonCollapsedSelectionRange } from '../selectionToolbar'
+import { countWords } from '../../../lib/documentState'
 import ToolbarCommandGlyph from '../../../components/ToolbarCommandGlyph.vue'
 
 const props = defineProps<{
@@ -68,14 +69,74 @@ const activePanelDef = computed(() =>
 const activePanelCommands = computed(() =>
   props.activePanel === 'table' ? [] : getMobileToolbarPanelCommands(props.activePanel),
 )
-const statsText = computed(
-  () =>
-    t('toolbar.stats', {
-      words: props.wordCount,
-      characters: props.characterCount,
-      lines: props.lineCount,
-    }),
-)
+// --- Selection word count (#199, ports upstream marktext#4457): while a
+// selection lives inside the editor host, the stats line appends its
+// word count. Computed here because this component already owns a
+// document-level selectionchange listener; rAF-coalesced so dragging a
+// selection handle pays at most one count per frame.
+
+const selectionWordCount = ref<number | null>(null)
+let selectionCountFrame: number | null = null
+
+const statsText = computed(() => {
+  const stats = t('toolbar.stats', {
+    words: props.wordCount,
+    characters: props.characterCount,
+    lines: props.lineCount,
+  })
+
+  return selectionWordCount.value === null
+    ? stats
+    : `${stats} · ${t('toolbar.statsSelection', { words: selectionWordCount.value })}`
+})
+
+function readEditorSelectionText() {
+  const selection = document.getSelection()
+  const host = props.host
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0 || !host) {
+    return ''
+  }
+
+  const { anchorNode, focusNode } = selection
+  if (!anchorNode || !focusNode || !host.contains(anchorNode) || !host.contains(focusNode)) {
+    return ''
+  }
+
+  // Rendered math/ruby previews duplicate their source text in the DOM;
+  // a selection spanning one would count the formula twice. Only ranges
+  // that actually contain a preview pay for fragment cloning — plain
+  // selections keep the toString() fast path and its cleaner block-break
+  // whitespace.
+  let fragmentText = ''
+  let hasRenderedPreviews = false
+  for (let index = 0; index < selection.rangeCount; index += 1) {
+    const fragment = selection.getRangeAt(index).cloneContents()
+    const rendered = fragment.querySelectorAll('.mu-math-render, .mu-ruby-render')
+    if (rendered.length > 0) {
+      hasRenderedPreviews = true
+      rendered.forEach(node => node.remove())
+    }
+    fragmentText += fragment.textContent ?? ''
+  }
+
+  return hasRenderedPreviews ? fragmentText : selection.toString()
+}
+
+function updateSelectionWordCount() {
+  const text = readEditorSelectionText()
+  selectionWordCount.value = text.trim().length > 0 ? countWords(text) : null
+}
+
+function scheduleSelectionWordCount() {
+  if (selectionCountFrame !== null) {
+    return
+  }
+
+  selectionCountFrame = requestAnimationFrame(() => {
+    selectionCountFrame = null
+    updateSelectionWordCount()
+  })
+}
 
 watch(
   () => props.expanded,
@@ -135,19 +196,30 @@ function dismissGroupMenuFromOutsidePointer(event: PointerEvent) {
 
 onMounted(() => {
   document.addEventListener('selectionchange', rememberCurrentEditorSelection)
+  document.addEventListener('selectionchange', scheduleSelectionWordCount)
   document.addEventListener('pointerdown', clearEditorSelectionRangeFromEditorPointer, true)
   document.addEventListener('pointerdown', dismissGroupMenuFromOutsidePointer, true)
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('selectionchange', rememberCurrentEditorSelection)
+  document.removeEventListener('selectionchange', scheduleSelectionWordCount)
   document.removeEventListener('pointerdown', clearEditorSelectionRangeFromEditorPointer, true)
   document.removeEventListener('pointerdown', dismissGroupMenuFromOutsidePointer, true)
+  if (selectionCountFrame !== null) {
+    cancelAnimationFrame(selectionCountFrame)
+    selectionCountFrame = null
+  }
 })
 
 watch(
   () => props.host,
-  () => rememberCurrentEditorSelection(),
+  // Host swaps and editor teardown re-derive the count (a null host
+  // clears it), so a stale selection tally never outlives its editor.
+  () => {
+    rememberCurrentEditorSelection()
+    scheduleSelectionWordCount()
+  },
 )
 
 function rememberCurrentEditorSelection() {

--- a/src/features/editor/selectionStats.test.ts
+++ b/src/features/editor/selectionStats.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { getSelectionTextForStats, type SelectionLike } from './selectionStats'
+
+function buildHost(html: string) {
+  const host = document.createElement('div')
+  host.innerHTML = html
+  document.body.appendChild(host)
+  return host
+}
+
+interface FakeRangeOptions {
+  commonAncestorContainer: Node
+  intersects?: (node: Node) => boolean
+  cloneContents?: () => DocumentFragment
+}
+
+function fakeSelection(
+  text: string,
+  anchorNode: Node,
+  focusNode: Node,
+  ranges: FakeRangeOptions[],
+): SelectionLike {
+  return {
+    isCollapsed: false,
+    rangeCount: ranges.length,
+    anchorNode,
+    focusNode,
+    getRangeAt: index => {
+      const options = ranges[index]
+      return {
+        commonAncestorContainer: options.commonAncestorContainer,
+        intersectsNode: node => options.intersects?.(node) ?? false,
+        cloneContents: () => {
+          if (!options.cloneContents) {
+            throw new Error('cloneContents must not run on the fast path')
+          }
+          return options.cloneContents()
+        },
+      }
+    },
+    toString: () => text,
+  }
+}
+
+describe('getSelectionTextForStats', () => {
+  it('keeps plain selections on the toString fast path without cloning', () => {
+    const host = buildHost('<p>alpha beta gamma</p>')
+    const textNode = host.querySelector('p')!.firstChild!
+
+    const selection = fakeSelection('alpha beta', textNode, textNode, [
+      { commonAncestorContainer: textNode },
+    ])
+
+    // The fake range throws on cloneContents, so this passing IS the
+    // proof that plain selections never pay for a fragment copy.
+    expect(getSelectionTextForStats(selection, host)).toBe('alpha beta')
+  })
+
+  it('stays on the fast path when previews exist elsewhere in the block', () => {
+    const host = buildHost(
+      '<p><span class="plain">alpha</span><span class="mu-math-render">x^2</span></p>',
+    )
+    const plainText = host.querySelector('.plain')!.firstChild!
+
+    const selection = fakeSelection('alpha', plainText, plainText, [
+      // Common ancestor is the paragraph, which contains a preview — but
+      // the range does not intersect it.
+      { commonAncestorContainer: host.querySelector('p')!, intersects: () => false },
+    ])
+
+    expect(getSelectionTextForStats(selection, host)).toBe('alpha')
+  })
+
+  it('clones and strips previews when the range crosses one', () => {
+    const host = buildHost(
+      '<p>sum <span class="mu-math-render">KATEX OUTPUT</span><span class="mu-math">$x^2$</span> tail</p>',
+    )
+    const paragraph = host.querySelector('p')!
+
+    const selection = fakeSelection('UNUSED', paragraph.firstChild!, paragraph.lastChild!, [
+      {
+        commonAncestorContainer: paragraph,
+        intersects: node => (node as Element).classList?.contains('mu-math-render') ?? false,
+        cloneContents: () => {
+          const fragment = document.createDocumentFragment()
+          const clone = paragraph.cloneNode(true) as Element
+          fragment.append(...Array.from(clone.childNodes))
+          return fragment
+        },
+      },
+    ])
+
+    expect(getSelectionTextForStats(selection, host)).toBe('sum $x^2$ tail')
+  })
+
+  it('counts nothing when the whole range sits inside a preview', () => {
+    const host = buildHost(
+      '<p><span class="mu-math-render"><span class="katex">x</span></span></p>',
+    )
+    const katex = host.querySelector('.katex')!
+
+    const selection = fakeSelection('UNUSED', katex, katex, [
+      // No cloneContents provided: render output is not document text,
+      // so the inside-preview verdict must not clone anything either.
+      { commonAncestorContainer: katex },
+    ])
+
+    expect(getSelectionTextForStats(selection, host)).toBe('')
+  })
+
+  it('ignores selections outside the editor host and collapsed selections', () => {
+    const host = buildHost('<p>alpha</p>')
+    const outside = document.createElement('p')
+    outside.textContent = 'outside'
+    document.body.appendChild(outside)
+
+    const outsideSelection = fakeSelection('outside', outside.firstChild!, outside.firstChild!, [
+      { commonAncestorContainer: outside },
+    ])
+    expect(getSelectionTextForStats(outsideSelection, host)).toBe('')
+
+    const collapsed: SelectionLike = {
+      isCollapsed: true,
+      rangeCount: 1,
+      anchorNode: host,
+      focusNode: host,
+      getRangeAt: () => {
+        throw new Error('collapsed selections are never inspected')
+      },
+      toString: () => '',
+    }
+    expect(getSelectionTextForStats(collapsed, host)).toBe('')
+  })
+})

--- a/src/features/editor/selectionStats.test.ts
+++ b/src/features/editor/selectionStats.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getSelectionTextForStats, type SelectionLike } from './selectionStats'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 function buildHost(html: string) {
   const host = document.createElement('div')
@@ -55,6 +59,22 @@ describe('getSelectionTextForStats', () => {
     // The fake range throws on cloneContents, so this passing IS the
     // proof that plain selections never pay for a fragment copy.
     expect(getSelectionTextForStats(selection, host)).toBe('alpha beta')
+  })
+
+  it('never materializes a NodeList on the no-preview path', () => {
+    const host = buildHost('<p>alpha beta gamma</p>')
+    const textNode = host.querySelector('p')!.firstChild!
+    const queryAllSpy = vi.spyOn(Element.prototype, 'querySelectorAll')
+
+    const selection = fakeSelection('alpha beta', textNode, textNode, [
+      { commonAncestorContainer: host.querySelector('p')! },
+    ])
+
+    expect(getSelectionTextForStats(selection, host)).toBe('alpha beta')
+    // The probe may run querySelector (early-exit, no list); the full
+    // querySelectorAll walk is reserved for documents that actually
+    // contain previews under the range's ancestor.
+    expect(queryAllSpy).not.toHaveBeenCalled()
   })
 
   it('stays on the fast path when previews exist elsewhere in the block', () => {

--- a/src/features/editor/selectionStats.ts
+++ b/src/features/editor/selectionStats.ts
@@ -21,9 +21,15 @@ export interface SelectionLike {
  * Rendered math/ruby previews duplicate their source text in the DOM, so
  * a selection crossing one must be re-read from cloned fragments with
  * the previews removed. Cloning is proportional to the selection, so the
- * probe below decides WITHOUT cloning — ancestor and scoped-query checks
- * only — and plain selections (the overwhelming case, every frame of a
- * handle drag) stay on the toString() fast path (#204 review).
+ * probe below decides WITHOUT cloning, keeping plain selections (every
+ * frame of a handle drag) on the toString() fast path.
+ *
+ * Honest cost model (#204 review round 2): the probe is not free — it is
+ * an engine-level selector test over the range's common-ancestor
+ * subtree. On the no-preview path that is one querySelector() scan,
+ * which early-exits on a match and materializes no NodeList; fragment
+ * clones and NodeList allocations only happen once a preview is actually
+ * present under the ancestor.
  */
 export function getSelectionTextForStats(selection: SelectionLike, host: HTMLElement): string {
   if (selection.isCollapsed || selection.rangeCount === 0) {
@@ -71,9 +77,19 @@ function probeRenderedPreviews(selection: SelectionLike): 'none' | 'inside' | 'c
       return 'inside'
     }
 
-    // …or span across previews below its common ancestor. Selector
-    // matching plus intersectsNode never allocates; preview counts are
-    // small in real documents.
+    // …or span across previews below its common ancestor. Existence
+    // first: querySelector early-exits on the first match and allocates
+    // no NodeList, so the common no-preview case pays exactly one native
+    // scan. Only when a preview exists does the full list materialize
+    // for the intersection walk (preview counts are small in practice).
+    const firstPreview = scope.querySelector(RENDERED_PREVIEW_SELECTOR)
+    if (!firstPreview) {
+      continue
+    }
+    if (range.intersectsNode(firstPreview)) {
+      crosses = true
+      continue
+    }
     for (const preview of scope.querySelectorAll(RENDERED_PREVIEW_SELECTOR)) {
       if (range.intersectsNode(preview)) {
         crosses = true

--- a/src/features/editor/selectionStats.ts
+++ b/src/features/editor/selectionStats.ts
@@ -1,0 +1,86 @@
+const RENDERED_PREVIEW_SELECTOR = '.mu-math-render, .mu-ruby-render'
+
+interface RangeLike {
+  commonAncestorContainer: Node
+  intersectsNode(node: Node): boolean
+  cloneContents(): DocumentFragment
+}
+
+export interface SelectionLike {
+  isCollapsed: boolean
+  rangeCount: number
+  anchorNode: Node | null
+  focusNode: Node | null
+  getRangeAt(index: number): RangeLike
+  toString(): string
+}
+
+/**
+ * The selected text as the stats counter should see it (#199).
+ *
+ * Rendered math/ruby previews duplicate their source text in the DOM, so
+ * a selection crossing one must be re-read from cloned fragments with
+ * the previews removed. Cloning is proportional to the selection, so the
+ * probe below decides WITHOUT cloning — ancestor and scoped-query checks
+ * only — and plain selections (the overwhelming case, every frame of a
+ * handle drag) stay on the toString() fast path (#204 review).
+ */
+export function getSelectionTextForStats(selection: SelectionLike, host: HTMLElement): string {
+  if (selection.isCollapsed || selection.rangeCount === 0) {
+    return ''
+  }
+
+  const { anchorNode, focusNode } = selection
+  if (!anchorNode || !focusNode || !host.contains(anchorNode) || !host.contains(focusNode)) {
+    return ''
+  }
+
+  const probe = probeRenderedPreviews(selection)
+  if (probe === 'none') {
+    return selection.toString()
+  }
+  if (probe === 'inside') {
+    // The whole selection sits inside one preview: render output is not
+    // document text, and its clone would lack the preview wrapper that
+    // the strip below keys on. Count nothing.
+    return ''
+  }
+
+  let text = ''
+  for (let index = 0; index < selection.rangeCount; index += 1) {
+    const fragment = selection.getRangeAt(index).cloneContents()
+    fragment.querySelectorAll(RENDERED_PREVIEW_SELECTOR).forEach(node => node.remove())
+    text += fragment.textContent ?? ''
+  }
+  return text
+}
+
+function probeRenderedPreviews(selection: SelectionLike): 'none' | 'inside' | 'crosses' {
+  let crosses = false
+
+  for (let index = 0; index < selection.rangeCount; index += 1) {
+    const range = selection.getRangeAt(index)
+    const container = range.commonAncestorContainer
+    const scope = container instanceof Element ? container : container.parentElement
+    if (!scope) {
+      continue
+    }
+
+    // The whole range may sit inside one preview…
+    if (scope.closest(RENDERED_PREVIEW_SELECTOR)) {
+      return 'inside'
+    }
+
+    // …or span across previews below its common ancestor. Selector
+    // matching plus intersectsNode never allocates; preview counts are
+    // small in real documents.
+    for (const preview of scope.querySelectorAll(RENDERED_PREVIEW_SELECTOR)) {
+      if (range.intersectsNode(preview)) {
+        crosses = true
+        break
+      }
+    }
+  }
+
+  return crosses ? 'crosses' : 'none'
+}

--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -190,6 +190,25 @@ describe('documentState', () => {
     expect(getDocumentStats('# T\n\n```\ncode\n```\n\npara\n').lines).toBe(3)
   })
 
+  it('applies CommonMark delimiter rules to fence detection', () => {
+    // Four columns of indentation make the backticks indented-code
+    // CONTENT, not delimiters: all three lines are visible.
+    expect(getDocumentStats('    ```\n    alpha\n    ```\n').lines).toBe(3)
+    expect(getDocumentStats('\t```\n').lines).toBe(1)
+    // A 4-space-indented marker run cannot close a real fence either.
+    expect(getDocumentStats('```\ncode\n    ```\nstill code\n```\n').lines).toBe(3)
+    // Trailing text keeps a would-be closer inside the block.
+    expect(getDocumentStats('```\nalpha\n```not-a-closing-fence\nbeta\n```\n').lines).toBe(3)
+    // A backtick info string may not contain backticks: this is a
+    // paragraph with inline code, not a fence opener.
+    expect(getDocumentStats('```foo``` bar\n').lines).toBe(1)
+    // Tilde info strings are unrestricted.
+    expect(getDocumentStats('~~~ info `x`\ncode\n~~~\n').lines).toBe(1)
+    // Up to three spaces of indentation still delimit, and a closer may
+    // carry trailing whitespace.
+    expect(getDocumentStats('   ```\ncode\n```  \n').lines).toBe(1)
+  })
+
   it('normalizes CRLF documents to LF internally while preserving save intent', () => {
     const normalized = normalizeMarkdownForEditor('one\r\ntwo\r\n')
 

--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -166,6 +166,16 @@ describe('documentState', () => {
     expect(getDocumentStats('Hello MarkText\n你好').words).toBe(4)
   })
 
+  it('counts only non-blank lines, ignoring block separators and the trailing newline', () => {
+    expect(getDocumentStats('').lines).toBe(0)
+    expect(getDocumentStats('one').lines).toBe(1)
+    // Muya-style serialization: heading, blank separator, two paragraphs,
+    // trailing newline — the user sees three content lines.
+    expect(getDocumentStats('# Title\n\npara one\n\npara two\n').lines).toBe(3)
+    expect(getDocumentStats('a\r\n\r\nb\r\n').lines).toBe(2)
+    expect(getDocumentStats('\n\n  \n').lines).toBe(0)
+  })
+
   it('normalizes CRLF documents to LF internally while preserving save intent', () => {
     const normalized = normalizeMarkdownForEditor('one\r\ntwo\r\n')
 

--- a/src/lib/documentState.test.ts
+++ b/src/lib/documentState.test.ts
@@ -176,6 +176,20 @@ describe('documentState', () => {
     expect(getDocumentStats('\n\n  \n').lines).toBe(0)
   })
 
+  it('counts fenced code interiors verbatim and fence markers as syntax', () => {
+    // The user sees three lines in the block: alpha, a blank, beta. The
+    // interior blank is real content; the fences are not (#204 review).
+    expect(getDocumentStats('```js\nalpha\n\nbeta\n```\n').lines).toBe(3)
+    // A lone blank interior line is still one visible line.
+    expect(getDocumentStats('~~~\n\n~~~\n').lines).toBe(1)
+    // Tildes do not close a backtick fence: they are content inside it.
+    expect(getDocumentStats('```\n~~~\ncode\n```\n').lines).toBe(2)
+    // A longer run of the same marker does close (CommonMark).
+    expect(getDocumentStats('```\ncode\n````\n').lines).toBe(1)
+    // Fenced blocks between paragraphs compose with separator filtering.
+    expect(getDocumentStats('# T\n\n```\ncode\n```\n\npara\n').lines).toBe(3)
+  })
+
   it('normalizes CRLF documents to LF internally while preserving save intent', () => {
     const normalized = normalizeMarkdownForEditor('one\r\ntwo\r\n')
 

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -259,26 +259,88 @@ export function countWords(markdown: string) {
   return latinWords + cjkCharacters
 }
 
+interface FenceDelimiter {
+  marker: '`' | '~'
+  length: number
+}
+
+/**
+ * CommonMark allows fence delimiters at most 3 columns of indentation;
+ * at 4 the line is indented-code content instead. Tabs advance to the
+ * next 4-column stop, so any leading tab already disqualifies.
+ */
+function fenceIndentDisqualifies(line: string): boolean {
+  let width = 0
+  for (const character of line) {
+    if (character === ' ') {
+      width += 1
+    } else if (character === '\t') {
+      width += 4 - (width % 4)
+    } else {
+      break
+    }
+    if (width >= 4) {
+      return true
+    }
+  }
+  return false
+}
+
+function parseFenceOpen(line: string): FenceDelimiter | null {
+  if (fenceIndentDisqualifies(line)) {
+    return null
+  }
+
+  const match = /^(`{3,}|~{3,})(.*)$/.exec(line.trim())
+  if (!match) {
+    return null
+  }
+
+  const marker = match[1][0] as FenceDelimiter['marker']
+  // A backtick fence's info string may not contain backticks (CommonMark):
+  // such a line is a paragraph with inline code, not a delimiter. Tilde
+  // info strings are unrestricted.
+  if (marker === '`' && match[2].includes('`')) {
+    return null
+  }
+
+  return { marker, length: match[1].length }
+}
+
+function isFenceClose(line: string, fence: FenceDelimiter): boolean {
+  if (fenceIndentDisqualifies(line)) {
+    return false
+  }
+
+  // A closing fence is a run of the opener's marker, at least as long,
+  // with nothing but whitespace around it — trailing text keeps the line
+  // inside the block.
+  const content = line.trim()
+  if (content.length < fence.length) {
+    return false
+  }
+  for (const character of content) {
+    if (character !== fence.marker) {
+      return false
+    }
+  }
+  return true
+}
+
 /**
  * Lines the user sees as content. Blank lines between blocks are
  * serialization artifacts (Muya's paragraph separators, the trailing
  * newline) and do not count — but inside a fenced code block every line
- * is visible content, blank ones included, while the fence markers
- * themselves are syntax (#199, #204 review).
+ * is visible content, blank ones included, while the fence delimiters
+ * themselves are syntax (#199, #204 review rounds 1–2).
  */
 function countContentLines(markdown: string): number {
   let count = 0
-  let fence: { marker: string; length: number } | null = null
+  let fence: FenceDelimiter | null = null
 
   for (const line of markdown.split(/\r\n|\r|\n/)) {
-    const trimmed = line.trim()
-
     if (fence) {
-      const marker = fence.marker
-      const closes =
-        trimmed.length >= fence.length
-        && Array.from(trimmed).every(character => character === marker)
-      if (closes) {
+      if (isFenceClose(line, fence)) {
         fence = null
       } else {
         count += 1
@@ -286,13 +348,13 @@ function countContentLines(markdown: string): number {
       continue
     }
 
-    const opened = /^(`{3,}|~{3,})/.exec(trimmed)
+    const opened = parseFenceOpen(line)
     if (opened) {
-      fence = { marker: opened[1][0], length: opened[1].length }
+      fence = opened
       continue
     }
 
-    if (trimmed.length > 0) {
+    if (line.trim().length > 0) {
       count += 1
     }
   }

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -259,17 +259,52 @@ export function countWords(markdown: string) {
   return latinWords + cjkCharacters
 }
 
+/**
+ * Lines the user sees as content. Blank lines between blocks are
+ * serialization artifacts (Muya's paragraph separators, the trailing
+ * newline) and do not count — but inside a fenced code block every line
+ * is visible content, blank ones included, while the fence markers
+ * themselves are syntax (#199, #204 review).
+ */
+function countContentLines(markdown: string): number {
+  let count = 0
+  let fence: { marker: string; length: number } | null = null
+
+  for (const line of markdown.split(/\r\n|\r|\n/)) {
+    const trimmed = line.trim()
+
+    if (fence) {
+      const marker = fence.marker
+      const closes =
+        trimmed.length >= fence.length
+        && Array.from(trimmed).every(character => character === marker)
+      if (closes) {
+        fence = null
+      } else {
+        count += 1
+      }
+      continue
+    }
+
+    const opened = /^(`{3,}|~{3,})/.exec(trimmed)
+    if (opened) {
+      fence = { marker: opened[1][0], length: opened[1].length }
+      continue
+    }
+
+    if (trimmed.length > 0) {
+      count += 1
+    }
+  }
+
+  return count
+}
+
 export function getDocumentStats(markdown: string): DocumentStats {
   return {
     words: countWords(markdown),
     characters: markdown.length,
-    // Non-blank lines only: Muya serializes blank separator lines between
-    // blocks and a trailing newline yields a phantom segment — neither is
-    // a line the user sees, and counting them overstated short documents
-    // ("10 lines" for a handful of visible ones, #199).
-    lines: markdown
-      ? markdown.split(/\r\n|\r|\n/).filter(line => line.trim().length > 0).length
-      : 0,
+    lines: countContentLines(markdown),
   }
 }
 

--- a/src/lib/documentState.ts
+++ b/src/lib/documentState.ts
@@ -263,7 +263,13 @@ export function getDocumentStats(markdown: string): DocumentStats {
   return {
     words: countWords(markdown),
     characters: markdown.length,
-    lines: markdown ? markdown.split(/\r\n|\r|\n/).length : 0,
+    // Non-blank lines only: Muya serializes blank separator lines between
+    // blocks and a trailing newline yields a phantom segment — neither is
+    // a line the user sees, and counting them overstated short documents
+    // ("10 lines" for a handful of visible ones, #199).
+    lines: markdown
+      ? markdown.split(/\r\n|\r|\n/).filter(line => line.trim().length > 0).length
+      : 0,
   }
 }
 

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -164,6 +164,7 @@ export const de = {
   'toolbar.collapse': 'Symbolleiste einklappen',
   'toolbar.groups': 'Symbolleisten-Gruppen',
   'toolbar.stats': '{words} Wörter · {characters} Zeichen · {lines} Zeilen',
+  'toolbar.statsSelection': '{words} ausgewählt',
   'toolbar.panel.format': 'Format',
   'toolbar.panel.formatTitle': 'Hervorhebung und Textmarkierungen',
   'toolbar.panel.paragraph': 'Absatz',

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -158,6 +158,7 @@ export const en = {
   'toolbar.collapse': 'Collapse toolbar',
   'toolbar.groups': 'Toolbar groups',
   'toolbar.stats': '{words} words · {characters} chars · {lines} lines',
+  'toolbar.statsSelection': '{words} selected',
   'toolbar.panel.format': 'Format',
   'toolbar.panel.formatTitle': 'Emphasis and text marks',
   'toolbar.panel.paragraph': 'Paragraph',

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -163,6 +163,7 @@ export const es = {
   'toolbar.collapse': 'Contraer barra de herramientas',
   'toolbar.groups': 'Grupos de la barra de herramientas',
   'toolbar.stats': '{words} palabras · {characters} caracteres · {lines} líneas',
+  'toolbar.statsSelection': '{words} seleccionadas',
   'toolbar.panel.format': 'Formato',
   'toolbar.panel.formatTitle': 'Énfasis y marcas de texto',
   'toolbar.panel.paragraph': 'Párrafo',

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -163,6 +163,7 @@ export const fr = {
   'toolbar.collapse': 'Réduire la barre d’outils',
   'toolbar.groups': 'Groupes de la barre d’outils',
   'toolbar.stats': '{words} mots · {characters} caractères · {lines} lignes',
+  'toolbar.statsSelection': '{words} sélectionnés',
   'toolbar.panel.format': 'Format',
   'toolbar.panel.formatTitle': 'Emphase et marques de texte',
   'toolbar.panel.paragraph': 'Paragraphe',

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -163,6 +163,7 @@ export const ja = {
   'toolbar.collapse': 'ツールバーを折りたたむ',
   'toolbar.groups': 'ツールバーのグループ',
   'toolbar.stats': '{words} 語 · {characters} 文字 · {lines} 行',
+  'toolbar.statsSelection': '選択中 {words} 語',
   'toolbar.panel.format': '書式',
   'toolbar.panel.formatTitle': '強調とテキストマーク',
   'toolbar.panel.paragraph': '段落',

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -163,6 +163,7 @@ export const ko = {
   'toolbar.collapse': '도구 모음 접기',
   'toolbar.groups': '도구 모음 그룹',
   'toolbar.stats': '단어 {words}개 · {characters}자 · {lines}줄',
+  'toolbar.statsSelection': '선택 {words}개',
   'toolbar.panel.format': '서식',
   'toolbar.panel.formatTitle': '강조 및 텍스트 표시',
   'toolbar.panel.paragraph': '단락',

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -163,6 +163,7 @@ export const pt = {
   'toolbar.collapse': 'Recolher barra de ferramentas',
   'toolbar.groups': 'Grupos da barra de ferramentas',
   'toolbar.stats': '{words} palavras · {characters} caracteres · {lines} linhas',
+  'toolbar.statsSelection': '{words} selecionadas',
   'toolbar.panel.format': 'Formato',
   'toolbar.panel.formatTitle': 'Ênfase e marcas de texto',
   'toolbar.panel.paragraph': 'Parágrafo',

--- a/src/lib/locales/tr.ts
+++ b/src/lib/locales/tr.ts
@@ -163,6 +163,7 @@ export const tr = {
   'toolbar.collapse': 'Araç çubuğunu daralt',
   'toolbar.groups': 'Araç çubuğu grupları',
   'toolbar.stats': '{words} sözcük · {characters} karakter · {lines} satır',
+  'toolbar.statsSelection': '{words} seçili',
   'toolbar.panel.format': 'Biçim',
   'toolbar.panel.formatTitle': 'Vurgu ve metin işaretleri',
   'toolbar.panel.paragraph': 'Paragraf',

--- a/src/lib/locales/zh-CN.ts
+++ b/src/lib/locales/zh-CN.ts
@@ -160,6 +160,7 @@ export const zhCN = {
   'toolbar.collapse': '收起工具栏',
   'toolbar.groups': '工具栏分组',
   'toolbar.stats': '{words} 字 · {characters} 字符 · {lines} 行',
+  'toolbar.statsSelection': '选中 {words} 字',
   'toolbar.panel.format': '格式',
   'toolbar.panel.formatTitle': '强调与文本标记',
   'toolbar.panel.paragraph': '段落',

--- a/src/lib/locales/zh-TW.ts
+++ b/src/lib/locales/zh-TW.ts
@@ -163,6 +163,7 @@ export const zhTW = {
   'toolbar.collapse': '收合工具列',
   'toolbar.groups': '工具列群組',
   'toolbar.stats': '{words} 字 · {characters} 字元 · {lines} 行',
+  'toolbar.statsSelection': '選取 {words} 字',
   'toolbar.panel.format': '格式',
   'toolbar.panel.formatTitle': '強調與文字標記',
   'toolbar.panel.paragraph': '段落',

--- a/tests/e2e/mobile-editor-toolbar.spec.ts
+++ b/tests/e2e/mobile-editor-toolbar.spec.ts
@@ -1188,3 +1188,31 @@ test('switches toolbar sections and applies paragraph commands to the current pa
 
   await expect.poll(() => getDraftStorage(page)).toContain('- [ ] next action')
 })
+
+test('counts content lines only and appends the selection word count (#199)', async ({
+  page,
+}) => {
+  await newBlankDocument(page)
+  await page.getByTestId('editor-host').click()
+  await page.keyboard.type('# Stats note')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('alpha beta gamma')
+
+  // Serialized markdown carries a blank separator line and a trailing
+  // newline; only the two content lines may count (#199 line bug).
+  await page.getByTestId('toolbar-expand-button').click()
+  const stats = page.getByTestId('toolbar-document-stats')
+  await expect(stats).toContainText('5 words')
+  await expect(stats).toContainText('2 lines')
+  await expect(stats).not.toContainText('selected')
+
+  await selectTextInFirstParagraph(page, 'alpha beta')
+  await expect(stats).toContainText('2 selected')
+
+  // Collapsing the selection clears the tally from the stats line.
+  await page.evaluate(() => {
+    document.getSelection()?.removeAllRanges()
+    document.dispatchEvent(new Event('selectionchange'))
+  })
+  await expect(stats).not.toContainText('selected')
+})


### PR DESCRIPTION
Closes #199 — both halves: the line-count bug and the selection word count port, surfaced on the toolbar stats line per the owner's decision (not the ⋮ menu).

## Bug: line count

`getDocumentStats` counted every newline-delimited segment of the serialized markdown — Muya's blank separator lines between blocks and the trailing-newline phantom segment included — which is how a handful of visible lines reported as "10 lines" on device. It now counts **non-blank lines only**: `# Title\n\npara one\n\npara two\n` is 3 lines, a single-line document is 1 (previously 2). The same stats feed the draft-log diagnostics, which become meaningful too.

## Port: selection word count (upstream marktext#4457, reshaped)

While a selection lives inside the editor host, the expanded-toolbar stats line appends its word count — `4 words · 23 chars · 1 lines · 2 selected` — and drops it when the selection collapses.

The port deliberately reshapes the upstream implementation rather than copying it:

- **One update source instead of two.** Upstream feeds a store from both Muya's `selection-change` event and a document `selectionchange` listener, reconciled through a subtle `lastSelectedText`/store-consistency dedupe. Here a single document-level `selectionchange` listener feeds **component-local state** in `MobileEditorToolbar` — the component already owns such a listener for command restore-ranges, and the count never leaves the component that displays it. No store, no dedupe, no race.
- **rAF-coalesced** so dragging a selection handle pays at most one count per frame (upstream parity).
- **Math/ruby preview exclusion kept** (upstream parity): rendered previews duplicate their source text in the DOM, and a selection spanning one would count the formula twice. Only ranges that actually contain a preview pay for fragment cloning; plain selections keep the `toString()` fast path. The vendored engine uses the same `mu-math-render`/`mu-ruby-render` class names, so the selector ports verbatim.
- **Containment guard**: anchor and focus must both sit inside the editor host, so selections elsewhere in the app never count.
- **Cleared on collapse, host swap, and editor teardown** (the host watcher re-derives; a null host yields null).
- **Not ported, deliberately**: the table rectangular-selection counting (mouse-drag cell selection has no mobile counterpart; native selections across table cells still count through `toString()`), and the source-mode leg — the toolbar, the stats surface the owner chose, does not render in source mode. If a source-mode surface is wanted later, that is a new issue.

New locale key `toolbar.statsSelection` across all ten languages, phrased to each locale's existing counter style (`选中 {words} 字`, `{words} selected`, …).

## Codex review round 1 (at `d5d7db9`) — both P2s addressed in `6683395`

- **Fence-aware line counting.** The blanket blank-line filter mis-counted fenced code: interior blank lines are real, visible content, and the fence markers are syntax. `countContentLines` now tracks fence state — every interior line counts (blanks included), fences don't, and closing requires the same marker at least as long as the opener (tildes stay content inside a backtick fence, a longer run of the same marker closes, per CommonMark). Codex's example (` ```js / alpha / blank / beta / ``` `) now counts 3. Regression cases cover interior blanks, lone-blank interiors, marker mixing, longer closers, and composition with the separator filtering.
- **Genuinely allocation-free fast path.** The previous code cloned every range before deciding whether previews were present — proportional copying and GC on every frame of a handle drag. The read moved to `selectionStats.ts`: an ancestor `closest()` plus scoped `intersectsNode` probe decides **without cloning**, so plain selections stay on `toString()`. A selection entirely inside a rendered preview now counts as nothing (render output is not document text — and its clone would lack the wrapper the strip keys on, a gap the upstream implementation shares). Contract tests pin the cost model: the fake range **throws on `cloneContents`**, so the fast-path tests passing is the proof no clone happens; strip and containment behavior covered alongside.

## Codex review round 2 (at `6683395`) — addressed in `f2c5218`

- **Indentation rule (real gap, fixed):** fence delimiters now allow at most three columns of indentation — a leading tab already disqualifies — so four-space-indented backticks are indented-code *content* (codex's example counts 3), and an over-indented marker run cannot close a real fence.
- **Delimiter syntax checks (the close-side example was already handled; the open side had the real gap):** the shipped closing check required a pure marker run, so ` ```not-a-closing-fence ` already stayed inside the block — a regression case now pins it. The genuine hole was on the *open* side: a backtick fence's info string may not contain backticks, so a paragraph starting with inline code (` ```foo``` bar `) no longer opens a phantom fence; tilde info strings stay unrestricted. Both delimiters now have explicit, separate syntax checks as suggested.
- **Honest probe cost (wording corrected + probe improved):** the claim is now *clone-free*, not allocation-free. The probe runs a `querySelector` existence test first — engine early-exit, no NodeList — so the common no-preview path pays exactly one native scan of the range-ancestor subtree; `querySelectorAll` only materializes when a preview actually exists there. A new contract test pins that `querySelectorAll` is never called on the no-preview path (alongside the existing throws-on-clone proof). The deeper options codex sketched (preview index via MutationObserver) trade ongoing mutation-tracking cost for probe cost; at realistic preview counts the existence test is the better bargain, and the comment now documents the model honestly.

## Verification

- **Web: 693 tests green** — unit tests pin the line semantics (empty / single line / Muya-style serialization / CRLF / blank-only / five fenced-code cases / seven CommonMark delimiter-rule cases) and the selection-read contract (fast path never clones, never materializes a NodeList without previews, strip, inside-preview, containment, collapsed); `vue-tsc -b` + Vite build green, focused lint clean, locale contract satisfied.
- **e2e `mobile-editor-toolbar` 37/37** — new test types a heading + paragraph, asserts `5 words` and `2 lines` (the old code would say 4), selects two words via a real DOM range and asserts `2 selected`, then collapses and asserts the suffix is gone.
- **Emulator (API 35, debug build):** typed `alpha beta gamma delta`, expanded the toolbar → `4 words · 23 chars · 1 lines` (single content line, previously 2); drove a `beta gamma` selection over CDP → `4 words · 23 chars · 1 lines · 2 selected`; cleared the selection → suffix dropped. Long-press caret placement (no selection) correctly shows no suffix.
