### PR TITLE
Remove the Browse all row from the Open page (#185)

### DIFF
--- a/src/features/open-locations/OpenLocationsScreen.vue
+++ b/src/features/open-locations/OpenLocationsScreen.vue
@@ -174,29 +174,6 @@ const { t } = useI18n()
         </button>
       </div>
 
-      <button
-        v-if="mode !== 'save'"
-        type="button"
-        class="open-location-row"
-        @click="emit('browseAll')"
-      >
-        <span class="open-location-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" width="24" height="24">
-            <path
-              d="M3.5 7.5v-2a1 1 0 0 1 1-1h4l2 2h9a1 1 0 0 1 1 1v11a1 1 0 0 1-1 1h-15a1 1 0 0 1-1-1v-11Z"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.8"
-              stroke-linejoin="round"
-            />
-          </svg>
-        </span>
-        <span class="open-location-text">
-          <span class="open-location-label">{{ t('openLocations.browseAll') }}</span>
-          <span class="open-location-subtitle">{{ t('openLocations.browseAllSubtitle') }}</span>
-        </span>
-      </button>
-
       <p v-if="notice" class="open-locations-notice" role="alert">{{ notice }}</p>
     </div>
   </div>

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -638,8 +638,6 @@ export const de = {
   'openLocations.cloudUnavailable': 'In diesem Build nicht konfiguriert',
   'openLocations.cloudConnecting': 'Warten auf die Browser-Anmeldung …',
   'openLocations.cloudOpening': 'Ausgewähltes Dokument wird geöffnet …',
-  'openLocations.browseAll': 'Alle Speicherorte durchsuchen',
-  'openLocations.browseAllSubtitle': 'Systemdateiauswahl und installierte Anbieter',
   'cloudBrowser.signInHint': 'Melde dich mit deinem Microsoft-Konto an, um Markdown-Dokumente aus OneDrive zu öffnen.',
   'cloudBrowser.connect': 'Bei OneDrive anmelden',
   'cloudBrowser.connecting': 'Warten auf die Browser-Anmeldung …',

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -631,8 +631,6 @@ export const en = {
   'openLocations.cloudUnavailable': 'Not configured in this build',
   'openLocations.cloudConnecting': 'Waiting for the browser sign-in…',
   'openLocations.cloudOpening': 'Opening the picked document…',
-  'openLocations.browseAll': 'Browse all locations',
-  'openLocations.browseAllSubtitle': 'System file picker and installed providers',
   'cloudBrowser.signInHint': 'Sign in with your Microsoft account to open Markdown documents from OneDrive.',
   'cloudBrowser.connect': 'Sign in to OneDrive',
   'cloudBrowser.connecting': 'Waiting for the browser sign-in…',

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -637,8 +637,6 @@ export const es = {
   'openLocations.cloudUnavailable': 'No configurado en esta compilación',
   'openLocations.cloudConnecting': 'Esperando el inicio de sesión en el navegador…',
   'openLocations.cloudOpening': 'Abriendo el documento elegido…',
-  'openLocations.browseAll': 'Explorar todas las ubicaciones',
-  'openLocations.browseAllSubtitle': 'Selector de archivos del sistema y proveedores instalados',
   'cloudBrowser.signInHint': 'Inicia sesión con tu cuenta de Microsoft para abrir documentos Markdown de OneDrive.',
   'cloudBrowser.connect': 'Iniciar sesión en OneDrive',
   'cloudBrowser.connecting': 'Esperando el inicio de sesión en el navegador…',

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -637,8 +637,6 @@ export const fr = {
   'openLocations.cloudUnavailable': 'Non configuré dans cette version',
   'openLocations.cloudConnecting': 'En attente de la connexion dans le navigateur…',
   'openLocations.cloudOpening': 'Ouverture du document choisi…',
-  'openLocations.browseAll': 'Parcourir tous les emplacements',
-  'openLocations.browseAllSubtitle': 'Sélecteur de fichiers du système et fournisseurs installés',
   'cloudBrowser.signInHint': 'Connectez-vous avec votre compte Microsoft pour ouvrir des documents Markdown depuis OneDrive.',
   'cloudBrowser.connect': 'Se connecter à OneDrive',
   'cloudBrowser.connecting': 'En attente de la connexion dans le navigateur…',

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -637,8 +637,6 @@ export const ja = {
   'openLocations.cloudUnavailable': 'このビルドでは未設定',
   'openLocations.cloudConnecting': 'ブラウザーでのサインインを待っています…',
   'openLocations.cloudOpening': '選択したドキュメントを開いています…',
-  'openLocations.browseAll': 'すべての場所を参照',
-  'openLocations.browseAllSubtitle': 'システムのファイルピッカーとインストール済みプロバイダー',
   'cloudBrowser.signInHint': 'Microsoft アカウントでサインインすると、OneDrive の Markdown ドキュメントを開けます。',
   'cloudBrowser.connect': 'OneDrive にサインイン',
   'cloudBrowser.connecting': 'ブラウザーでのサインインを待っています…',

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -637,8 +637,6 @@ export const ko = {
   'openLocations.cloudUnavailable': '이 빌드에는 설정되지 않음',
   'openLocations.cloudConnecting': '브라우저 로그인을 기다리는 중…',
   'openLocations.cloudOpening': '선택한 문서를 여는 중…',
-  'openLocations.browseAll': '모든 위치 찾아보기',
-  'openLocations.browseAllSubtitle': '시스템 파일 선택기 및 설치된 제공자',
   'cloudBrowser.signInHint': 'Microsoft 계정으로 로그인하면 OneDrive의 Markdown 문서를 열 수 있습니다.',
   'cloudBrowser.connect': 'OneDrive에 로그인',
   'cloudBrowser.connecting': '브라우저 로그인을 기다리는 중…',

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -637,8 +637,6 @@ export const pt = {
   'openLocations.cloudUnavailable': 'Não configurado nesta compilação',
   'openLocations.cloudConnecting': 'Aguardando o login no navegador…',
   'openLocations.cloudOpening': 'Abrindo o documento escolhido…',
-  'openLocations.browseAll': 'Procurar todos os locais',
-  'openLocations.browseAllSubtitle': 'Seletor de arquivos do sistema e provedores instalados',
   'cloudBrowser.signInHint': 'Entre com sua conta Microsoft para abrir documentos Markdown do OneDrive.',
   'cloudBrowser.connect': 'Entrar no OneDrive',
   'cloudBrowser.connecting': 'Aguardando o login no navegador…',

--- a/src/lib/locales/tr.ts
+++ b/src/lib/locales/tr.ts
@@ -637,8 +637,6 @@ export const tr = {
   'openLocations.cloudUnavailable': 'Bu derlemede yapılandırılmamış',
   'openLocations.cloudConnecting': 'Tarayıcıda oturum açma bekleniyor…',
   'openLocations.cloudOpening': 'Seçilen belge açılıyor…',
-  'openLocations.browseAll': 'Tüm konumlara göz at',
-  'openLocations.browseAllSubtitle': 'Sistem dosya seçici ve yüklü sağlayıcılar',
   'cloudBrowser.signInHint': 'OneDrive\'daki Markdown belgelerini açmak için Microsoft hesabınızla oturum açın.',
   'cloudBrowser.connect': 'OneDrive\'da oturum aç',
   'cloudBrowser.connecting': 'Tarayıcıda oturum açma bekleniyor…',

--- a/src/lib/locales/zh-CN.ts
+++ b/src/lib/locales/zh-CN.ts
@@ -628,8 +628,6 @@ export const zhCN = {
   'openLocations.cloudUnavailable': '此构建未配置',
   'openLocations.cloudConnecting': '正在等待浏览器登录…',
   'openLocations.cloudOpening': '正在打开所选文档…',
-  'openLocations.browseAll': '浏览全部位置',
-  'openLocations.browseAllSubtitle': '系统文件选择器与已安装的存储',
   'cloudBrowser.signInHint': '使用你的 Microsoft 账户登录,即可打开 OneDrive 中的 Markdown 文档。',
   'cloudBrowser.connect': '登录 OneDrive',
   'cloudBrowser.connecting': '正在等待浏览器登录…',

--- a/src/lib/locales/zh-TW.ts
+++ b/src/lib/locales/zh-TW.ts
@@ -637,8 +637,6 @@ export const zhTW = {
   'openLocations.cloudUnavailable': '此版本未設定',
   'openLocations.cloudConnecting': '正在等待瀏覽器登入…',
   'openLocations.cloudOpening': '正在開啟所選文件…',
-  'openLocations.browseAll': '瀏覽全部位置',
-  'openLocations.browseAllSubtitle': '系統檔案選擇器與已安裝的儲存',
   'cloudBrowser.signInHint': '使用你的 Microsoft 帳戶登入,即可開啟 OneDrive 中的 Markdown 文件。',
   'cloudBrowser.connect': '登入 OneDrive',
   'cloudBrowser.connecting': '正在等待瀏覽器登入…',


### PR DESCRIPTION
The row duplicated 'This phone' — both launched the identical system picker, whose drawer already reaches every installed DocumentsProvider, so nothing becomes unreachable. The `browseAll` emit and the App-side handler stay wired (a future row is a template-block re-add); the two locale strings leave with the row (all ten languages).

Deliberately retired with this change (details in the #185 comment): per-provider picker deep links (querying another provider's roots requires the signature-level `MANAGE_DOCUMENTS` permission — ordinary apps cannot build an `EXTRA_INITIAL_URI` for arbitrary providers) and any Android/data ambition (sealed by the platform since Android 11, and since 13 even against All-files access; only Shizuku/root-class tools bypass it, which does not fit this app).

Verification: web 693 tests green, `vue-tsc -b` + Vite build green, focused lint clean, Open-page e2e spec 7/7 (no test referenced the row).